### PR TITLE
New functions join, title, toLower, and toUpper

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hairyhenderson/gomplate/aws"
 	"github.com/hairyhenderson/gomplate/version"
-
+	"strings"
 	"text/template"
 )
 
@@ -63,10 +63,14 @@ func NewGomplate() *Gomplate {
 			"json":       typeconv.JSON,
 			"jsonArray":  typeconv.JSONArray,
 			"slice":      typeconv.Slice,
+			"join":       typeconv.Join,
 			"ec2meta":    ec2meta.Meta,
 			"ec2dynamic": ec2meta.Dynamic,
 			"ec2tag":     ec2info.Tag,
 			"ec2region":  ec2meta.Region,
+			"title":      strings.Title,
+			"toUpper":    strings.ToUpper,
+			"toLower":    strings.ToLower,
 		},
 	}
 }

--- a/typeconv.go
+++ b/typeconv.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"strconv"
+	"strings"
 )
 
 // TypeConv - type conversion function
@@ -43,4 +45,42 @@ func (t *TypeConv) JSONArray(in string) []interface{} {
 // Slice creates a slice from a bunch of arguments
 func (t *TypeConv) Slice(args ...interface{}) []interface{} {
 	return args
+}
+
+// Join concatenates the elements of a to create a single string.
+// The separator string sep is placed between elements in the resulting string.
+//
+// This is functionally identical to strings.Join, except that each element is
+// coerced to a string first
+func (t *TypeConv) Join(a []interface{}, sep string) string {
+	b := make([]string, len(a))
+	for i := range a {
+		b[i] = toString(a[i])
+	}
+	return strings.Join(b, sep)
+}
+
+func toString(in interface{}) string {
+	if s, ok := in.(string); ok {
+		return s
+	}
+	if s, ok := in.(fmt.Stringer); ok {
+		return s.String()
+	}
+	if i, ok := in.(int); ok {
+		return strconv.Itoa(i)
+	}
+	if u, ok := in.(uint64); ok {
+		return strconv.FormatUint(u, 10)
+	}
+	if f, ok := in.(float64); ok {
+		return strconv.FormatFloat(f, 'f', -1, 64)
+	}
+	if b, ok := in.(bool); ok {
+		return strconv.FormatBool(b)
+	}
+	if in == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%s", in)
 }

--- a/typeconv_test.go
+++ b/typeconv_test.go
@@ -52,3 +52,15 @@ func TestSlice(t *testing.T) {
 	assert.Equal(t, expected[0], actual[0])
 	assert.Equal(t, expected[1], actual[1])
 }
+
+func TestJoin(t *testing.T) {
+	ty := new(TypeConv)
+
+	assert.Equal(t, "foo,bar", ty.Join([]interface{}{"foo", "bar"}, ","))
+	assert.Equal(t, "foo,\nbar", ty.Join([]interface{}{"foo", "bar"}, ",\n"))
+	// Join handles all kinds of scalar types too...
+	assert.Equal(t, "42-18446744073709551615", ty.Join([]interface{}{42, uint64(18446744073709551615)}, "-"))
+	assert.Equal(t, "1,,true,3.14,foo,nil", ty.Join([]interface{}{1, "", true, 3.14, "foo", nil}, ","))
+	// and best-effort with weird types
+	assert.Equal(t, "[foo],bar", ty.Join([]interface{}{[]string{"foo"}, "bar"}, ","))
+}


### PR DESCRIPTION
New functions:

- `join` - identical to [`strings.Join`](https://golang.org/pkg/strings#Join), except that each element is converted to a string first (i.e. `[]interface{}` is supported, not just `[]string`)
- `title` - exposed [`strings.Title`](https://golang.org/pkg/strings/#Title)
- `toLower` - exposed [`strings.ToLower`](https://golang.org/pkg/strings/#ToLower)
- `toUpper` - exposed [`strings.ToUpper`](https://golang.org/pkg/strings/#ToUpper)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>