### PR TITLE
Fixing broken versions in build-x target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ VERSION_FLAG := -X `go list ./version`.Version=`git describe --abbrev=0 --tags $
 define gocross
 	GOOS=$(1) GOARCH=$(2) \
 		$(GO) build \
+			-ldflags "$(COMMIT_FLAG) $(VERSION_FLAG)" \
 			-o $(PREFIX)/bin/$(PKG_NAME)_$(1)-$(2)$(call extension,$(1));
 endef
 


### PR DESCRIPTION
This affected the 0.3.0 release, but not 0.4.0 (cuz I compiled the 0.4.0 binaries after making this fix).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>