### PR TITLE
Short-circuit ec2 function defaults when not in AWS

### DIFF
--- a/aws/ec2info.go
+++ b/aws/ec2info.go
@@ -38,6 +38,10 @@ func ec2Client(region string) (client InstanceDescriber) {
 
 // Tag -
 func (e *Ec2Info) Tag(tag string, def ...string) string {
+	if e.metaClient.nonAWS {
+		returnDefault(def)
+	}
+
 	instanceID := e.metaClient.Meta("instance-id")
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: aws.StringSlice([]string{instanceID}),

--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -60,6 +60,21 @@ func TestTag_ValidKey(t *testing.T) {
 	assert.Equal(t, "bar", e.Tag("foo", "default"))
 }
 
+func TestTag_NonEC2(t *testing.T) {
+	server, ec2meta := MockServer(404, "")
+	defer server.Close()
+	client := DummyInstanceDescriber{}
+	e := &Ec2Info{
+		describer: func() InstanceDescriber {
+			return client
+		},
+		metaClient: ec2meta,
+	}
+
+	assert.Equal(t, "", e.Tag("foo"))
+	assert.Equal(t, "default", e.Tag("foo", "default"))
+}
+
 // test doubles
 type DummyInstanceDescriber struct {
 	tags []*ec2.Tag

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -21,6 +21,6 @@ func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
 	}
 	httpClient := &http.Client{Transport: tr}
 
-	client := &Ec2Meta{server.URL + "/", httpClient}
+	client := &Ec2Meta{server.URL + "/", httpClient, false}
 	return server, client
 }


### PR DESCRIPTION
This fixes part of #59 by not even trying to connect to the EC2 instance metadata API or the EC2 API if gomplate can't connect to the EC2 instance metadata API.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>