### PR TITLE
Caching responses from EC2

### DIFF
--- a/aws/ec2meta_test.go
+++ b/aws/ec2meta_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +58,18 @@ func TestRegion_KnownRegion(t *testing.T) {
 	defer server.Close()
 
 	assert.Equal(t, "us-east-1", ec2meta.Region())
+}
+
+func TestUnreachable(t *testing.T) {
+	assert.False(t, unreachable(errors.New("foo")))
+	assert.True(t, unreachable(errors.New("host is down")))
+	assert.True(t, unreachable(errors.New("request canceled")))
+	assert.True(t, unreachable(errors.New("no route to host")))
+}
+
+func TestRetrieveMetadata_NonEC2(t *testing.T) {
+	ec2meta := NewEc2Meta()
+	ec2meta.nonAWS = true
+
+	assert.Equal(t, "foo", ec2meta.retrieveMetadata("", "foo"))
 }

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -21,6 +21,6 @@ func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
 	}
 	httpClient := &http.Client{Transport: tr}
 
-	client := &Ec2Meta{server.URL + "/", httpClient, false}
+	client := &Ec2Meta{server.URL + "/", httpClient, false, make(map[string]string)}
 	return server, client
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func (g *Gomplate) RunTemplate(in io.Reader, out io.Writer) {
 func NewGomplate(data *Data) *Gomplate {
 	env := &Env{}
 	typeconv := &TypeConv{}
-	ec2meta := &aws.Ec2Meta{}
+	ec2meta := aws.NewEc2Meta()
 	ec2info := aws.NewEc2Info()
 	return &Gomplate{
 		funcMap: template.FuncMap{


### PR DESCRIPTION
This is the second half of the fix for #59. Now, repeated calls to `ec2*` functions will not incur multiple network requests. This probably won't have a big impact on most templates, but it's probably 
nice to not bombard the EC2 API with tons of calls...

Fixes #59 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>