### PR TITLE
Fixing a panic in Ec2Info.go

### DIFF
--- a/aws/ec2info.go
+++ b/aws/ec2info.go
@@ -20,7 +20,7 @@ type InstanceDescriber interface {
 
 // NewEc2Info -
 func NewEc2Info() *Ec2Info {
-	metaClient := &Ec2Meta{}
+	metaClient := NewEc2Meta()
 	return &Ec2Info{
 		describer: func() InstanceDescriber {
 			region := metaClient.Region()

--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -98,3 +98,28 @@ func TestTag_NonEC2(t *testing.T) {
 	assert.Equal(t, "", e.Tag("foo"))
 	assert.Equal(t, "default", e.Tag("foo", "default"))
 }
+
+func TestNewEc2Info(t *testing.T) {
+	server, ec2meta := MockServer(200, `"i-1234"`)
+	defer server.Close()
+	client := DummyInstanceDescriber{
+		tags: []*ec2.Tag{
+			&ec2.Tag{
+				Key:   aws.String("foo"),
+				Value: aws.String("bar"),
+			},
+			&ec2.Tag{
+				Key:   aws.String("baz"),
+				Value: aws.String("qux"),
+			},
+		},
+	}
+	e := NewEc2Info()
+	e.describer = func() InstanceDescriber {
+		return client
+	}
+	e.metaClient = ec2meta
+
+	assert.Equal(t, "bar", e.Tag("foo"))
+	assert.Equal(t, "bar", e.Tag("foo", "default"))
+}


### PR DESCRIPTION
Initializing the metaClient field with NewEc2Meta() instead of with a struct literal, so that the cache field in the embedded Ec2Meta instance is properly initialized.

I looked at why the tests didn't catch this and it appears that this would be a difficult case to catch in a non-EC2 environment.  Specifically, https://github.com/hairyhenderson/gomplate/blob/master/aws/ec2info.go#L62 short circuits the code path that would have caused the test to fail.