### PR TITLE
Updating codegangsta/cli reference to urfave/cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/codegangsta/cli"
 	"github.com/hairyhenderson/gomplate/aws"
 	"github.com/hairyhenderson/gomplate/version"
+	"github.com/urfave/cli"
 )
 
 func (g *Gomplate) createTemplate() *template.Template {


### PR DESCRIPTION
`github.com/codegangsta/cli` now redirects to `github.com/urfave/cli` - updating for clarity

Signed-off-by: Dave Henderson <dhenderson@gmail.com>