### PR TITLE
Handle redirects from vault server versions earlier than v0.6.2

### DIFF
--- a/vault/http.go
+++ b/vault/http.go
@@ -1,0 +1,47 @@
+package vault
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+)
+
+// httpClient
+type httpClient interface {
+	GetHTTPClient() *http.Client
+	SetToken(req *http.Request)
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func requestAndFollow(hc httpClient, method string, u *url.URL, body []byte) (*http.Response, error) {
+	var res *http.Response
+	var err error
+	for attempts := 0; attempts < 2; attempts++ {
+		reader := bytes.NewReader(body)
+		req, err := http.NewRequest(method, u.String(), reader)
+
+		if err != nil {
+			return nil, err
+		}
+		hc.SetToken(req)
+		if method == "POST" {
+			req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		}
+
+		res, err = hc.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if res.StatusCode == http.StatusTemporaryRedirect {
+			res.Body.Close()
+			location, errLocation := res.Location()
+			if errLocation != nil {
+				return nil, errLocation
+			}
+			u.Host = location.Host
+		} else {
+			break
+		}
+	}
+	return res, err
+}

--- a/vault/http_test.go
+++ b/vault/http_test.go
@@ -1,0 +1,68 @@
+package vault
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testClient struct{}
+
+func (tc *testClient) GetHTTPClient() *http.Client {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqStr := fmt.Sprintf("%s %s", r.Method, r.URL)
+		switch reqStr {
+		case "POST http://vaultA:8500/v1/foo":
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Location", "http://vaultB:8500/v1/foo")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+			fmt.Fprintln(w, "{}")
+		case "POST http://vaultB:8500/v1/foo":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, "{}")
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "{ 'message': 'Unexpected request: %s'}", reqStr)
+		}
+	}))
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(req *http.Request) (*url.URL, error) {
+				return url.Parse(server.URL)
+			},
+		},
+	}
+}
+
+func (tc *testClient) SetToken(req *http.Request) {
+	req.Header.Set("X-Vault-Token", "dead-beef-cafe-babe")
+}
+
+func (tc *testClient) Do(req *http.Request) (*http.Response, error) {
+	hc := tc.GetHTTPClient()
+	return hc.Do(req)
+}
+
+func TestRequestAndFollow_GetWithRedirect(t *testing.T) {
+	tc := &testClient{}
+	u, _ := url.Parse("http://vaultA:8500/v1/foo")
+
+	res, err := requestAndFollow(tc, "POST", u, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+}
+
+func TestRequestAndFollow_GetNoRedirect(t *testing.T) {
+	tc := &testClient{}
+	u, _ := url.Parse("http://vaultB:8500/v1/foo")
+
+	res, err := requestAndFollow(tc, "POST", u, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}


### PR DESCRIPTION
Fix issue #75.

There are two golang HTTP related issues that are involved here, due to the way golang 1.7 http package reacts to HTTP redirects:
- https://github.com/golang/go/issues/4800
- https://github.com/golang/go/issues/7912 or https://github.com/golang/go/issues/9348

The first issue causes the `X-Vault-Token` header to be dropped when following redirects of HTTP GET requests. The second issue causes redirects on POST requests not to be followed _at all_.

It does look like golang 1.8 will address both these issues once it is released... so these fixes are just needed in the meantime.

TODO:
- [x] manual testing with vault HA-server configuration w/redirects
- [x] updated tests

**PTAL**: @hairyhenderson 