### PR TITLE
Removing vestigial newline addition

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ func (g *Gomplate) RunTemplate(in io.Reader, out io.Writer) {
 	if err := tmpl.Execute(out, context); err != nil {
 		panic(err)
 	}
-	out.Write([]byte("\n"))
 }
 
 // NewGomplate -

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,7 @@ func testTemplate(g *Gomplate, template string) string {
 	in := strings.NewReader(template)
 	var out bytes.Buffer
 	g.RunTemplate(in, &out)
-	return strings.TrimSpace(out.String())
+	return out.String()
 }
 
 func TestGetenvTemplates(t *testing.T) {


### PR DESCRIPTION
The original `gomplate` didn't support multi-line template strings, but in #10 I added proper support for multi-line templates. I didn't remove the `\n` that was added, though, so an extra newline was always printed at the end of the output! _Oops._

Signed-off-by: Dave Henderson <dhenderson@gmail.com>