### PR TITLE
Avoiding CGO landmine

### DIFF
--- a/vault/token_strategy.go
+++ b/vault/token_strategy.go
@@ -2,13 +2,13 @@ package vault
 
 import (
 	"fmt"
-	"github.com/blang/vfs"
 	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
-	"os/user"
 	"path"
+
+	"github.com/blang/vfs"
 )
 
 // TokenAuthStrategy - a pass-through strategy for situations where we already
@@ -50,12 +50,20 @@ func (a *TokenAuthStrategy) Revokable() bool {
 	return false
 }
 
-func getTokenFromFile(fs vfs.Filesystem) string {
-	u, err := user.Current()
-	if err != nil {
-		log.Fatal(err)
+func homeDir() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
 	}
-	f, err := fs.OpenFile(path.Join(u.HomeDir, ".vault-token"), os.O_RDONLY, 0)
+	if home := os.Getenv("USERPROFILE"); home != "" {
+		return home
+	}
+	log.Fatal(`Neither HOME nor USERPROFILE environment variables are set!
+		I can't figure out where the current user's home directory is!`)
+	return ""
+}
+
+func getTokenFromFile(fs vfs.Filesystem) string {
+	f, err := fs.OpenFile(path.Join(homeDir(), ".vault-token"), os.O_RDONLY, 0)
 	if err != nil {
 		return ""
 	}

--- a/vault/token_strategy_test.go
+++ b/vault/token_strategy_test.go
@@ -2,7 +2,6 @@ package vault
 
 import (
 	"os"
-	"os/user"
 	"path"
 	"testing"
 
@@ -23,13 +22,11 @@ func TestNewTokenAuthStrategy_FromEnvVar(t *testing.T) {
 
 func TestNewTokenAuthStrategy_FromFileGivenNoEnvVar(t *testing.T) {
 	token := "deadbeef"
-	u, err := user.Current()
-	assert.NoError(t, err)
 
 	fs := memfs.Create()
-	err = vfs.MkdirAll(fs, u.HomeDir, 0777)
+	err := vfs.MkdirAll(fs, homeDir(), 0777)
 	assert.NoError(t, err)
-	f, err := vfs.Create(fs, path.Join(u.HomeDir, ".vault-token"))
+	f, err := vfs.Create(fs, path.Join(homeDir(), ".vault-token"))
 	assert.NoError(t, err)
 	f.Write([]byte(token))
 


### PR DESCRIPTION
Fixes #79 

This implements a `homeDir()` function as a stand-in for my usage of `user.Current()`, which blows up when cross-compiling without `cgo`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>