### PR TITLE
No envs; don't panic

### DIFF
--- a/vault/app-id_strategy.go
+++ b/vault/app-id_strategy.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 )
 
@@ -19,13 +18,13 @@ type AppIDAuthStrategy struct {
 
 // NewAppIDAuthStrategy - create an AuthStrategy that uses Vault's app-id auth
 // backend.
-func NewAppIDAuthStrategy() *AppIDAuthStrategy {
-	appID := os.Getenv("VAULT_APP_ID")
-	userID := os.Getenv("VAULT_USER_ID")
+func NewAppIDAuthStrategy(getenv GetenvFunc) (*AppIDAuthStrategy, error) {
+	appID := getenv("VAULT_APP_ID")
+	userID := getenv("VAULT_USER_ID")
 	if appID != "" && userID != "" {
-		return &AppIDAuthStrategy{appID, userID, nil}
+		return &AppIDAuthStrategy{appID, userID, nil}, nil
 	}
-	return nil
+	return nil, fmt.Errorf("VAULT_APP_ID/VAULT_USER_ID unset")
 }
 
 // GetHTTPClient configures the HTTP client with a timeout

--- a/vault/client_test.go
+++ b/vault/client_test.go
@@ -17,6 +17,13 @@ func TestLogin_SavesToken(t *testing.T) {
 	assert.Equal(t, "foo", client.token)
 }
 
+func TestNewClient_FailsWithNoEnvVars(t *testing.T) {
+	_, err := NewClientUseGetenv(func(e string) string {
+		return ""
+	})
+	assert.Error(t, err)
+}
+
 func TestRead_ErrorsGivenNetworkError(t *testing.T) {
 	server, hc := setupErrorHTTP()
 	defer server.Close()


### PR DESCRIPTION
Fix for #83 

When gomplate is used correctly everything works fine. However, if gomplate vault datasource is misconfigured for some reason, it tends to panic rather than exit gracefully.

This PR improves the error handling to be more graceful if `VAULT_ADDR` is unset or if other auth strategy related errors occur.

**BEFORE**:
```
└> echo -n '{{(datasource "vault" "secret/foo").value}}' | /usr/local/Cellar/gomplate/1.2.2/bin/gomplate -d vault="vault://"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

**AFTER**:
```
└> echo -n '{{(datasource "vault" "secret/foo").value}}' | gomplate -d vault="vault://"
2016/11/20 14:06:42 VAULT_ADDR is not a valid URL:  <nil>
```