### PR TITLE
Fixing bug where vault data is incorrectly cached

### DIFF
--- a/data.go
+++ b/data.go
@@ -176,7 +176,11 @@ func (d *Data) ReadSource(fs vfs.Filesystem, source *Source, args ...string) ([]
 	if d.cache == nil {
 		d.cache = make(map[string][]byte)
 	}
-	cached, ok := d.cache[source.Alias]
+	cacheKey := source.Alias
+	for _, v := range args {
+		cacheKey += v
+	}
+	cached, ok := d.cache[cacheKey]
 	if ok {
 		return cached, nil
 	}
@@ -185,7 +189,7 @@ func (d *Data) ReadSource(fs vfs.Filesystem, source *Source, args ...string) ([]
 		if err != nil {
 			return nil, err
 		}
-		d.cache[source.Alias] = data
+		d.cache[cacheKey] = data
 		return data, nil
 	}
 


### PR DESCRIPTION
This use case was broken:

_where:_
_secret/foo.value == hi_
_secret/bar.value == hello_
```console
$  echo -ne '{{(datasource "vault" "foo").value}}\n{{(datasource "vault" "bar").value}}\n' | bin/gomplate -d vault=vault:///secret
hi
hi
```

😞 

This fixes it!

```console
$ echo -ne '{{(datasource "vault" "foo").value}}\n{{(datasource "vault" "bar").value}}\n' | bin/gomplate -d vault=vault:///secret
hi
hello
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>