### PR TITLE
Building a slim macOS binary too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ compress-all:
 	$(call compress,linux,amd64)
 	$(call compress,linux,386)
 	$(call compress,linux,arm)
+	$(call compress,darwin,amd64)
 	$(call compress,windows,amd64)
 	$(call compress,windows,386)
 


### PR DESCRIPTION
UPX 3.92 was recently released - it now supports slimmed-down macOS binaries too 🎉 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>