### PR TITLE
Adding toJSON and toYAML functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Gomplate is an alternative that will let you process templates which also includ
 				- [Example](#example)
 			- [`yamlArray`](#yamlarray)
 				- [Example](#example)
+			- [`toJSON`](#tojson)
+				- [Example](#example)
+			- [`toYAML`](#toyaml)
+				- [Example](#example)
 			- [`datasource`](#datasource)
 				- [Examples](#examples)
 					- [Basic usage](#basic-usage)
@@ -111,7 +115,7 @@ $ apk add gomplate
 ...
 ```
 
-_Note: the Alpine version of gomplate may lag behind the latest release of gomplate._ 
+_Note: the Alpine version of gomplate may lag behind the latest release of gomplate._
 
 ### use with Docker
 
@@ -451,6 +455,43 @@ Hello {{ index (getenv "FOO" | yamlArray) 1 }}
 $ export FOO='[ "you", "world" ]'
 $ gomplate < input.tmpl
 Hello world
+```
+
+#### `toJSON`
+
+Converts an object to a JSON document. Input objects may be the result of `json`, `yaml`, `jsonArray`, or `yamlArray` functions, or they could be provided by a `datasource`.
+
+##### Example
+
+_This is obviously contrived - `json` is used to create an object._
+
+_`input.tmpl`:_
+```
+{{ (`{"foo":{"hello":"world"}}` | json).foo | toJSON }}
+```
+
+```console
+$ gomplate < input.tmpl
+{"hello":"world"}
+```
+
+#### `toYAML`
+
+Converts an object to a YAML document. Input objects may be the result of `json`, `yaml`, `jsonArray`, or `yamlArray` functions, or they could be provided by a `datasource`.
+
+##### Example
+
+_This is obviously contrived - `json` is used to create an object._
+
+_`input.tmpl`:_
+```
+{{ (`{"foo":{"hello":"world"}}` | json).foo | toYAML }}
+```
+
+```console
+$ gomplate < input.tmpl
+hello: world
+
 ```
 
 #### `datasource`

--- a/main.go
+++ b/main.go
@@ -56,6 +56,8 @@ func NewGomplate(data *Data) *Gomplate {
 			"yamlArray":        typeconv.YAMLArray,
 			"slice":            typeconv.Slice,
 			"join":             typeconv.Join,
+			"toJSON":           typeconv.ToJSON,
+			"toYAML":           typeconv.ToYAML,
 			"ec2meta":          ec2meta.Meta,
 			"ec2dynamic":       ec2meta.Dynamic,
 			"ec2tag":           ec2info.Tag,

--- a/typeconv.go
+++ b/typeconv.go
@@ -64,6 +64,25 @@ func (t *TypeConv) YAMLArray(in string) []interface{} {
 	return unmarshalArray(obj, in, yaml.Unmarshal)
 }
 
+func marshalObj(obj interface{}, f func(interface{}) ([]byte, error)) string {
+	b, err := f(obj)
+	if err != nil {
+		log.Fatalf("Unable to marshal object %s: %v", obj, err)
+	}
+
+	return string(b)
+}
+
+// ToJSON - Stringify a struct as JSON
+func (t *TypeConv) ToJSON(in interface{}) string {
+	return marshalObj(in, json.Marshal)
+}
+
+// ToYAML - Stringify a struct as YAML
+func (t *TypeConv) ToYAML(in interface{}) string {
+	return marshalObj(in, yaml.Marshal)
+}
+
 // Slice creates a slice from a bunch of arguments
 func (t *TypeConv) Slice(args ...interface{}) []interface{} {
 	return args

--- a/typeconv_test.go
+++ b/typeconv_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -57,6 +58,51 @@ func TestUnmarshalArray(t *testing.T) {
 - foo
 - bar
 `))
+}
+
+func TestToJSON(t *testing.T) {
+	ty := new(TypeConv)
+	expected := `{"down":{"the":{"rabbit":{"hole":true}}},"foo":"bar","one":1,"true":true}`
+	in := map[string]interface{}{
+		"foo":  "bar",
+		"one":  1,
+		"true": true,
+		"down": map[string]interface{}{
+			"the": map[string]interface{}{
+				"rabbit": map[string]interface{}{
+					"hole": true,
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, ty.ToJSON(in))
+}
+
+func TestToYAML(t *testing.T) {
+	ty := new(TypeConv)
+	expected := `d: 2006-01-02T15:04:05.999999999-07:00
+foo: bar
+? |-
+  multi
+  line
+  key
+: hello: world
+one: 1
+"true": true
+`
+	mst, _ := time.LoadLocation("MST")
+	in := map[string]interface{}{
+		"foo":  "bar",
+		"one":  1,
+		"true": true,
+		`multi
+line
+key`: map[string]interface{}{
+			"hello": "world",
+		},
+		"d": time.Date(2006, time.January, 2, 15, 4, 5, 999999999, mst),
+	}
+	assert.Equal(t, expected, ty.ToYAML(in))
 }
 
 func TestSlice(t *testing.T) {


### PR DESCRIPTION
Adding `toJSON` and `toYAML` which marshal object into their stringified JSON or YAML representations.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>