### PR TITLE
Allow custom auth backend mount point for app-id backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,9 +577,12 @@ The special `vault://` URL scheme can be used to retrieve data from [Hashicorp
 Vault](https://vaultproject.io). To use this, you must put the Vault server's
 URL in the `$VAULT_ADDR` environment variable.
 
-Currently, the [`app-id`](https://www.vaultproject.io/docs/auth/app-id.html)
-auth backend is supported, as well as Vault tokens obtained through external
-means.
+This table describes the currently-supported authentication mechanisms and how to use them, in order of precedence:
+
+| auth backend | configuration |
+| ---: |--|
+| [`app-id`](https://www.vaultproject.io/docs/auth/app-id.html) | Environment variables `$VAULT_APP_ID` and `$VAULT_USER_ID` must be set to the appropriate values.<br/> If the backend is mounted to a different location, set `$VAULT_AUTH_APP_ID_MOUNT`. |
+| [`token`](https://www.vaultproject.io/docs/auth/token.html) | Determined from either the `$VAULT_TOKEN` environment variable, or read from the file `~/.vault-token` |
 
 To use a Vault datasource with a single secret, just use a URL of
 `vault:///secret/mysecret`. Note the 3 `/`s - the host portion of the URL is left

--- a/vault/app-id_strategy_test.go
+++ b/vault/app-id_strategy_test.go
@@ -1,9 +1,6 @@
 package vault
 
 import (
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
@@ -36,7 +33,7 @@ func TestGetToken_AppIDErrorsGivenNetworkError(t *testing.T) {
 
 	vaultURL, _ := url.Parse("http://vault:8200")
 
-	auth := &AppIDAuthStrategy{"foo", "bar", client}
+	auth := &AppIDAuthStrategy{"foo", "bar", "app-id", client}
 	_, err := auth.GetToken(vaultURL)
 	assert.Error(t, err)
 }
@@ -47,7 +44,7 @@ func TestGetToken_AppIDErrorsGivenHTTPErrorStatus(t *testing.T) {
 
 	vaultURL, _ := url.Parse("http://vault:8200")
 
-	auth := &AppIDAuthStrategy{"foo", "bar", client}
+	auth := &AppIDAuthStrategy{"foo", "bar", "app-id", client}
 	_, err := auth.GetToken(vaultURL)
 	assert.Error(t, err)
 }
@@ -58,7 +55,7 @@ func TestGetToken_AppIDErrorsGivenBadJSON(t *testing.T) {
 
 	vaultURL, _ := url.Parse("http://vault:8200")
 
-	auth := &AppIDAuthStrategy{"foo", "bar", client}
+	auth := &AppIDAuthStrategy{"foo", "bar", "app-id", client}
 	_, err := auth.GetToken(vaultURL)
 	assert.Error(t, err)
 }
@@ -69,43 +66,9 @@ func TestGetToken_AppID(t *testing.T) {
 
 	vaultURL, _ := url.Parse("http://vault:8200")
 
-	auth := &AppIDAuthStrategy{"foo", "bar", client}
+	auth := &AppIDAuthStrategy{"foo", "bar", "app-id", client}
 	token, err := auth.GetToken(vaultURL)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "baz", token)
-}
-
-func setupHTTP(code int, mimetype string, body string) (*httptest.Server, *http.Client) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", mimetype)
-		w.WriteHeader(code)
-		fmt.Fprintln(w, body)
-	}))
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			Proxy: func(req *http.Request) (*url.URL, error) {
-				return url.Parse(server.URL)
-			},
-		},
-	}
-
-	return server, client
-}
-
-func setupErrorHTTP() (*httptest.Server, *http.Client) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		panic("boo")
-	}))
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			Proxy: func(req *http.Request) (*url.URL, error) {
-				return url.Parse(server.URL)
-			},
-		},
-	}
-
-	return server, client
 }

--- a/vault/testutils.go
+++ b/vault/testutils.go
@@ -1,0 +1,42 @@
+package vault
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+func setupHTTP(code int, mimetype string, body string) (*httptest.Server, *http.Client) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", mimetype)
+		w.WriteHeader(code)
+		fmt.Fprintln(w, body)
+	}))
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(req *http.Request) (*url.URL, error) {
+				return url.Parse(server.URL)
+			},
+		},
+	}
+
+	return server, client
+}
+
+func setupErrorHTTP() (*httptest.Server, *http.Client) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boo")
+	}))
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: func(req *http.Request) (*url.URL, error) {
+				return url.Parse(server.URL)
+			},
+		},
+	}
+
+	return server, client
+}


### PR DESCRIPTION
Set `VAULT_AUTH_APP_ID_MOUNT` to customize the mount-point. Defaults to `app-id`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>