### PR TITLE
Support arbitrary headers with HTTP datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,13 @@ $ echo 'Hello there, {{(datasource "foo").headers.Host}}...' | gomplate -d foo=h
 Hello there, httpbin.org...
 ```
 
+Additional headers can be provided with the `--datasource-header`/`-H` option:
+
+```console
+$ gomplate -d foo=https://httpbin.org/get -H 'foo=Foo: bar' -i '{{(datasource "foo").headers.Foo}}'
+bar
+```
+
 ###### Usage with Vault data
 
 The special `vault://` URL scheme can be used to retrieve data from [Hashicorp

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func openOutFile(filename string) (out *os.File, err error) {
 
 func runTemplate(c *cli.Context) error {
 	defer runCleanupHooks()
-	data := NewData(c.StringSlice("datasource"))
+	data := NewData(c.StringSlice("datasource"), c.StringSlice("datasource-header"))
 	lDelim := c.String("left-delim")
 	rDelim := c.String("right-delim")
 
@@ -165,6 +165,10 @@ func main() {
 		cli.StringSliceFlag{
 			Name:  "datasource, d",
 			Usage: "Data source in alias=URL form. Specify multiple times to add multiple sources.",
+		},
+		cli.StringSliceFlag{
+			Name:  "datasource-header, H",
+			Usage: "HTTP Header field in 'alias=Name: value' form to be provided on HTTP-based data sources. Multiples can be set.",
 		},
 		cli.StringFlag{
 			Name:   "left-delim",

--- a/test/integration/datasources_http.bats
+++ b/test/integration/datasources_http.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+load helper
+
+@test "HTTP datasource with headers" {
+  gomplate \
+    -d foo=http://httpbin.org/get \
+    -H foo=Foo:bar \
+    -i '{{ (datasource "foo").headers.Foo }}'
+  [ "$status" -eq 0 ]
+  [[ "${output}" == "bar" ]]
+}


### PR DESCRIPTION
Fixes #113

Adds new a command-line option `--datasource-header`/`-H`, which allows sending custom headers when accessing HTTP[S] datasources. For example:

```console
$ gomplate -d foo=https://httpbin.org/get -H 'foo=Foo: bar' -i '{{(datasource "foo").headers.Foo}}'
bar
```

This can be used e.g. for authentication, by setting the `Authorization` or related headers...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>