### PR TITLE
Add --input-dir and --output-dir as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,18 @@ By default, `gomplate` will read from `Stdin` and write to `Stdout`. This behavi
 
 You can specify multiple `--file` and `--out` arguments. The same number of each much be given. This allows `gomplate` to process multiple templates _slightly_ faster than invoking `gomplate` multiple times in a row.
 
+##### `--input-dir` and `--output-dir`
+
+For processing multiple templates in a directory you can use `--input-dir` and `--output-dir` together. In this case all files in input directory will be processed as templates and the resulting files stored in `--output-dir`. The output directory will be created if it does not exist and the directory structure of the input directory will be preserved.  
+
+Example:
+
+```bash
+# Process all files in directory "templates" with the datasource given
+# and store the files with the same directory structure in "config"
+gomplate --input-dir=templates --output-dir=config --datasource config=config.yaml
+```
+
 #### `--datasource`/`-d`
 
 Add a data source in `name=URL` form. Specify multiple times to add multiple sources. The data can then be used by the [`datasource`](#datasource) function.

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"testing"
@@ -149,18 +148,4 @@ func TestCustomDelim(t *testing.T) {
 		funcMap:    template.FuncMap{},
 	}
 	assert.Equal(t, "hi", testTemplate(g, `[print "hi"]`))
-}
-
-func TestReadInput(t *testing.T) {
-	actual := readInputs("foo", nil)
-	assert.Equal(t, "foo", actual[0])
-
-	// stdin is "" because during tests it's given /dev/null
-	actual = readInputs("", []string{"-"})
-	assert.Equal(t, "", actual[0])
-
-	actual = readInputs("", []string{"main_test.go"})
-	thisFile, _ := os.Open("main_test.go")
-	expected, _ := ioutil.ReadAll(thisFile)
-	assert.Equal(t, string(expected), actual[0])
 }

--- a/process.go
+++ b/process.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// == Direct input processing ========================================
+
+func processInputFiles(stringTemplate string, input []string, output []string, g *Gomplate) error {
+	input, err := readInputs(stringTemplate, input)
+	if err != nil {
+		return err
+	}
+
+	if len(output) == 0 {
+		output = []string{"-"}
+	}
+
+	for n, input := range input {
+		if err := renderTemplate(g, input, output[n]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// == Recursive input dir processing ======================================
+
+func processInputDir(input string, output string, g *Gomplate) error {
+	input = filepath.Clean(input)
+	output = filepath.Clean(output)
+
+	// assert tha input path exists
+	si, err := os.Stat(input)
+	if err != nil {
+		return err
+	}
+
+	// read directory
+	entries, err := ioutil.ReadDir(input)
+	if err != nil {
+		return err
+	}
+
+	// ensure output directory
+	if err = os.MkdirAll(output, si.Mode()); err != nil {
+		return err
+	}
+
+	// process or dive in again
+	for _, entry := range entries {
+		nextInPath := filepath.Join(input, entry.Name())
+		nextOutPath := filepath.Join(output, entry.Name())
+
+		if entry.IsDir() {
+			err := processInputDir(nextInPath, nextOutPath, g)
+			if err != nil {
+				return err
+			}
+		} else {
+			inString, err := readInput(nextInPath)
+			if err != nil {
+				return err
+			}
+			if err := renderTemplate(g, inString, nextOutPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// == File handling ================================================
+
+func readInputs(input string, files []string) ([]string, error) {
+	if input != "" {
+		return []string{input}, nil
+	}
+	if len(files) == 0 {
+		files = []string{"-"}
+	}
+	ins := make([]string, len(files))
+
+	for n, filename := range files {
+		inString, err := readInput(filename)
+		if err != nil {
+			return nil, err
+		}
+		ins[n] = inString
+	}
+	return ins, nil
+}
+
+func readInput(filename string) (string, error) {
+	var err error
+	var inFile *os.File
+	if filename == "-" {
+		inFile = os.Stdin
+	} else {
+		inFile, err = os.Open(filename)
+		if err != nil {
+			return "", fmt.Errorf("failed to open %s\n%v", filename, err)
+		}
+		// nolint: errcheck
+		defer inFile.Close()
+	}
+	bytes, err := ioutil.ReadAll(inFile)
+	if err != nil {
+		err = fmt.Errorf("read failed for %s\n%v", filename, err)
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func openOutFile(filename string) (out *os.File, err error) {
+	if filename == "-" {
+		return os.Stdout, nil
+	}
+	return os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+}

--- a/process_test.go
+++ b/process_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"path/filepath"
+
+	"log"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadInput(t *testing.T) {
+	actual, err := readInputs("foo", nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "foo", actual[0])
+
+	// stdin is "" because during tests it's given /dev/null
+	actual, err = readInputs("", []string{"-"})
+	assert.Nil(t, err)
+	assert.Equal(t, "", actual[0])
+
+	actual, err = readInputs("", []string{"main_test.go"})
+	assert.Nil(t, err)
+	thisFile, _ := os.Open("main_test.go")
+	expected, _ := ioutil.ReadAll(thisFile)
+	assert.Equal(t, string(expected), actual[0])
+}
+
+func TestInputDir(t *testing.T) {
+	outDir, err := ioutil.TempDir("test/files/input-dir", "out-temp-")
+	assert.Nil(t, err)
+	defer (func() {
+		if cerr := os.RemoveAll(outDir); cerr != nil {
+			log.Fatalf("Error while removing temporary directory %s : %v", outDir, cerr)
+		}
+	})()
+
+	src, err := ParseSource("config=test/files/input-dir/config.yml")
+	assert.Nil(t, err)
+
+	data := &Data{
+		Sources: map[string]*Source{"config": src},
+	}
+	gomplate := NewGomplate(data, "{{", "}}")
+	err = processInputDir("test/files/input-dir/in", outDir, gomplate)
+	assert.Nil(t, err)
+
+	top, err := ioutil.ReadFile(filepath.Join(outDir, "top.txt"))
+	assert.Nil(t, err)
+	assert.Equal(t, "eins", string(top))
+
+	inner, err := ioutil.ReadFile(filepath.Join(outDir, "inner/nested.txt"))
+	assert.Nil(t, err)
+	assert.Equal(t, "zwei", string(inner))
+}

--- a/test/files/input-dir/config.yml
+++ b/test/files/input-dir/config.yml
@@ -1,0 +1,2 @@
+one: eins
+two: zwei

--- a/test/files/input-dir/in/inner/nested.txt
+++ b/test/files/input-dir/in/inner/nested.txt
@@ -1,0 +1,1 @@
+{{ (datasource "config").two }}

--- a/test/files/input-dir/in/top.txt
+++ b/test/files/input-dir/in/top.txt
@@ -1,0 +1,1 @@
+{{ (datasource "config").one }}

--- a/test/integration/input-dir.bats
+++ b/test/integration/input-dir.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+load helper
+
+tmpdir=$(mktemp -u)
+
+function setup () {
+  mkdir -p $tmpdir
+  mkdir -p $tmpdir/in/inner
+  echo -n "{{ (datasource \"config\").one }}" > $tmpdir/in/eins.txt
+  echo -n "{{ (datasource \"config\").two }}" > $tmpdir/in/inner/deux.txt
+
+  cat <<"EOT"  > $tmpdir/config.yml
+one: eins
+two: deux
+EOT
+}
+
+function teardown () {
+  # rm -rf $tmpdir
+  echo
+}
+
+@test "takes --input-dir and produces proper output files" {
+  rm -rf $tmpdir/out || true
+  gomplate --input-dir $tmpdir/in --output-dir $tmpdir/out -d config=$tmpdir/config.yml
+  [ "$status" -eq 0 ]
+  [[ "$(ls $tmpdir/out | wc -l)" == 2 ]]
+  [[ "$(ls $tmpdir/out/inner | wc -l)" == 1 ]]
+  [[ "$(cat $tmpdir/out/eins.txt)" == "eins" ]]
+  [[ "$(cat $tmpdir/out/inner/deux.txt)" == "deux" ]]
+}
+
+@test "test . as default --output-dir param" {
+  rm -rf $tmpdir/out_dot || true
+  mkdir -p $tmpdir/out_dot
+  g=$(pwd)/bin/gomplate
+  cd $tmpdir/out_dot
+  run $g --input-dir $tmpdir/in -d config=$tmpdir/config.yml
+  [ "$?" -eq 0 ]
+  [[ "$(ls | wc -l)" == 2 ]]
+  [[ "$(ls inner | wc -l)" == 1 ]]
+  [[ "$(cat eins.txt)" == "eins" ]]
+  [[ "$(cat inner/deux.txt)" == "deux" ]]
+}
+
+@test "errors given --output-dir but no --input-dir" {
+  gomplate --output-dir "."
+  [ "$status" -eq 1 ]
+  [[ "${output}" == "--input-dir must be set when --output-dir is set" ]]
+}
+
+@test "errors given both --input-dir and --in" {
+  gomplate --input-dir "." --in "param"
+  [ "$status" -eq 1 ]
+  [[ "${output}" == "--input-dir can not be used together with --in or --file" ]]
+}
+
+@test "errors given both --input-dir and --file" {
+  gomplate --input-dir "." --file input.txt
+  [ "$status" -eq 1 ]
+  [[ "${output}" == "--input-dir can not be used together with --in or --file" ]]
+}
+
+@test "errors given both --output-dir and --out" {
+  gomplate --input-dir "." --output-dir /tmp --out out
+  [ "$status" -eq 1 ]
+  [[ "${output}" == "--out can not be used together with --output-dir" ]]
+}


### PR DESCRIPTION
- Use these options when a whole directory hierarchy needs to be processed.
- Extracted file processing logic in an extra process.go

Partial solution to #117

Bear with me, Golang is not my mother tongue (which was in fact Perl at those days, but is Java & JavaScript since some times). Looking forward to a review ;-)