### PR TITLE
Support for parallel processing with --parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ A few different forms are valid:
 Sometimes it's necessary to override the default template delimiters (`{{`/`}}`).
 Use `--left-delim`/`--right-delim` or set `$GOMPLATE_LEFT_DELIM`/`$GOMPLATE_RIGHT_DELIM`.
 
+#### Parallel processing
+
+You can switch on parallel template processing with `--parallel` (or `-p`) which can speed up the processing of many
+templates considerably. By default parallel processing is switched off.
+
 ## Syntax
 
 ### About `.Env`

--- a/process.go
+++ b/process.go
@@ -7,9 +7,16 @@ import (
 	"path/filepath"
 )
 
+type processor interface {
+	processInputFiles(stringTemplate string, input []string, output []string, g *Gomplate) error
+	processInputDir(input string, output string, g *Gomplate) error
+}
+
+type serialProcessor struct{}
+
 // == Direct input processing ========================================
 
-func processInputFiles(stringTemplate string, input []string, output []string, g *Gomplate) error {
+func (s serialProcessor) processInputFiles(stringTemplate string, input []string, output []string, g *Gomplate) error {
 	input, err := readInputs(stringTemplate, input)
 	if err != nil {
 		return err
@@ -29,7 +36,7 @@ func processInputFiles(stringTemplate string, input []string, output []string, g
 
 // == Recursive input dir processing ======================================
 
-func processInputDir(input string, output string, g *Gomplate) error {
+func (s serialProcessor) processInputDir(input string, output string, g *Gomplate) error {
 	input = filepath.Clean(input)
 	output = filepath.Clean(output)
 
@@ -56,7 +63,7 @@ func processInputDir(input string, output string, g *Gomplate) error {
 		nextOutPath := filepath.Join(output, entry.Name())
 
 		if entry.IsDir() {
-			err := processInputDir(nextInPath, nextOutPath, g)
+			err := s.processInputDir(nextInPath, nextOutPath, g)
 			if err != nil {
 				return err
 			}

--- a/process_parallel.go
+++ b/process_parallel.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"errors"
+)
+
+type renderResult struct {
+	err     error
+	inPath  string
+	outPath string
+}
+
+type parallelProcessor struct{}
+
+// == Direct input processing ========================================
+
+func (p parallelProcessor) processInputFiles(stringTemplate string, inFiles []string, outFiles []string, g *Gomplate) error {
+	inFiles, err := readInputs(stringTemplate, inFiles)
+	if err != nil {
+		return err
+	}
+
+	if len(outFiles) == 0 {
+		outFiles = []string{"-"}
+	}
+
+	results := make(chan *renderResult)
+	defer close(results)
+
+	for n, input := range inFiles {
+		go func(idx int, input string) {
+			err := renderTemplate(g, input, outFiles[idx])
+			results <- &renderResult{err, input, outFiles[idx]}
+		}(n, input)
+	}
+
+	return p.waitAndEvaluateResults(results, len(inFiles))
+}
+
+// == Recursive input dir processing ======================================
+
+func (p parallelProcessor) processInputDir(inputDir string, outDir string, g *Gomplate) error {
+	results := make(chan *renderResult)
+	defer close(results)
+	nr := p.processDir(inputDir, outDir, g, results, 0)
+	return p.waitAndEvaluateResults(results, nr)
+}
+
+func (p parallelProcessor) processDir(inPath string, outPath string, g *Gomplate, results chan *renderResult, nr int) int {
+	inPath = filepath.Clean(inPath)
+	outPath = filepath.Clean(outPath)
+
+	// assert tha input path exists
+	si, err := os.Stat(inPath)
+	if err != nil {
+		return p.reportError(err, inPath, outPath, results, nr)
+	}
+
+	// ensure output directory
+	if err = os.MkdirAll(outPath, si.Mode()); err != nil {
+		return p.reportError(err, inPath, outPath, results, nr)
+	}
+
+	// read directory
+	entries, err := ioutil.ReadDir(inPath)
+	if err != nil {
+		return p.reportError(err, inPath, outPath, results, nr)
+	}
+
+	// process or dive in again
+	for _, entry := range entries {
+		nextInPath := filepath.Join(inPath, entry.Name())
+		nextOutPath := filepath.Join(outPath, entry.Name())
+
+		if entry.IsDir() {
+			nr += p.processDir(nextInPath, nextOutPath, g, results, 0)
+		} else {
+			go (func(nextInPath string, nextOutPath string) {
+				inString, err := readInput(nextInPath)
+				if err == nil {
+					err = renderTemplate(g, inString, nextOutPath)
+				}
+				results <- &renderResult{err, nextInPath, nextOutPath}
+			})(nextInPath, nextOutPath)
+			nr++
+		}
+	}
+	return nr
+}
+
+func (p parallelProcessor) reportError(err error, inPath string, outPath string, results chan *renderResult, nr int) int {
+	go (func() {
+		results <- &renderResult{err, inPath, outPath}
+	})()
+	return nr + 1
+}
+
+// == Thread handling ================================================
+
+func (p parallelProcessor) waitAndEvaluateResults(results chan *renderResult, nr int) error {
+	errorMsg := ""
+	for i := 0; i < nr; i++ {
+		result := <-results
+		if result.err != nil {
+			errorMsg += fmt.Sprintf("   %s --> %s : %v", result.inPath, result.outPath, result.err)
+		}
+	}
+	if errorMsg != "" {
+		return errors.New("rendering of the following templates failed:\n" + errorMsg)
+	}
+	return nil
+}

--- a/process_test.go
+++ b/process_test.go
@@ -29,7 +29,15 @@ func TestReadInput(t *testing.T) {
 	assert.Equal(t, string(expected), actual[0])
 }
 
-func TestInputDir(t *testing.T) {
+func TestInputDirSerial(t *testing.T) {
+	inputDirTest(t, false, serialProcessor{})
+}
+
+func TestInputDirParallel(t *testing.T) {
+	inputDirTest(t, true, parallelProcessor{})
+}
+
+func inputDirTest(t *testing.T, parallel bool, p processor) {
 	outDir, err := ioutil.TempDir("test/files/input-dir", "out-temp-")
 	assert.Nil(t, err)
 	defer (func() {
@@ -42,10 +50,12 @@ func TestInputDir(t *testing.T) {
 	assert.Nil(t, err)
 
 	data := &Data{
-		Sources: map[string]*Source{"config": src},
+		Sources:  map[string]*Source{"config": src},
+		parallel: parallel,
 	}
 	gomplate := NewGomplate(data, "{{", "}}")
-	err = processInputDir("test/files/input-dir/in", outDir, gomplate)
+
+	err = p.processInputDir("test/files/input-dir/in", outDir, gomplate)
 	assert.Nil(t, err)
 
 	top, err := ioutil.ReadFile(filepath.Join(outDir, "top.txt"))


### PR DESCRIPTION
This PR adds an option `--parallel` or `-p` to allow parallel template processing. This is based on PR #119 and differs only in the commit https://github.com/rhuss/gomplate/commit/964af6fd864c6ee950344b5a50eed423bc4b11ad

By default parallel processing is disabled.