### PR TITLE
Open datasource file in read-only mode

### DIFF
--- a/data.go
+++ b/data.go
@@ -224,7 +224,7 @@ func readFile(source *Source, args ...string) ([]byte, error) {
 		return nil, err
 	}
 
-	f, err := source.FS.OpenFile(source.URL.Path, os.O_RDWR, 0)
+	f, err := source.FS.OpenFile(source.URL.Path, os.O_RDONLY, 0)
 	if err != nil {
 		log.Fatalf("Can't open %s: %#v", source.URL.Path, err)
 		return nil, err


### PR DESCRIPTION
read-write is not required here and in fact prevents many use cases
to work when the file is not writable by the user (because the call will fail in this case)