### PR TITLE
Making the built Docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM golang:onbuild
+FROM golang:1.8-alpine AS build
+
+RUN mkdir -p /go/src/github.com/hairyhenderson/gomplate
+WORKDIR /go/src/github.com/hairyhenderson/gomplate
+COPY . /go/src/github.com/hairyhenderson/gomplate
+
+RUN apk add --no-cache \
+    make \
+    git
+
+RUN make build
+
+FROM alpine:3.5
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -7,7 +19,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/hairyhenderson/gomplate"
 
-RUN mv /go/bin/app /go/bin/gomplate
+COPY --from=build /go/src/github.com/hairyhenderson/gomplate/bin/gomplate /usr/bin/gomplate
 
 ENTRYPOINT [ "gomplate" ]
 


### PR DESCRIPTION
This uses multi-stage builds to make the `hairyhenderson/gomplate` docker image smaller (from ~370MB to ~15MB).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>