### PR TITLE
Add "replace" function and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Gomplate is an alternative that will let you process templates which also includ
 		- [`slice`](#slice)
 		- [`split`](#split)
 		- [`splitN`](#splitn)
+		- [`replaceAll`](#replaceAll)
 		- [`title`](#title)
 		- [`toLower`](#tolower)
 		- [`toUpper`](#toupper)
@@ -354,6 +355,23 @@ the number of substrings to return. Equivalent to [strings.SplitN](https://golan
 $ gomplate -i '{{ range splitN "foo:bar:baz" ":" 2 }}{{.}}{{end}}'
 foo
 bar:baz
+```
+#### `replaceAll`
+
+Replaces all occurrences of a given string with another.
+
+##### Example
+
+```console
+$ gomplate -i '{{ replaceAll "." "-" "172.21.1.42" }}'
+172-21-1-42
+```
+
+##### Example (with pipeline)
+
+```console
+$ gomplate -i '{{ "172.21.1.42" | replaceAll "." "-" }}'
+172-21-1-42
 ```
 
 #### `title`

--- a/gomplate.go
+++ b/gomplate.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"log"
 	"net/url"
-
 	"strings"
 	"text/template"
 
@@ -39,6 +38,7 @@ func (g *Gomplate) RunTemplate(text string, out io.Writer) {
 func NewGomplate(data *Data, leftDelim, rightDelim string) *Gomplate {
 	env := &Env{}
 	typeconv := &TypeConv{}
+	stringfunc := &stringFunc{}
 	ec2meta := aws.NewEc2Meta()
 	ec2info := aws.NewEc2Info()
 	return &Gomplate{
@@ -65,6 +65,7 @@ func NewGomplate(data *Data, leftDelim, rightDelim string) *Gomplate {
 			"contains":         strings.Contains,
 			"hasPrefix":        strings.HasPrefix,
 			"hasSuffix":        strings.HasSuffix,
+			"replaceAll":       stringfunc.replaceAll,
 			"split":            strings.Split,
 			"splitN":           strings.SplitN,
 			"title":            strings.Title,

--- a/stringfunc.go
+++ b/stringfunc.go
@@ -1,0 +1,10 @@
+package main
+
+import "strings"
+
+// stringFunc - string manipulation function wrappers
+type stringFunc struct{}
+
+func (t stringFunc) replaceAll(old, new, s string) string {
+	return strings.Replace(s, old, new, -1)
+}

--- a/stringfunc_test.go
+++ b/stringfunc_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceAll(t *testing.T) {
+	sf := &stringFunc{}
+
+	assert.Equal(t, "Replaced",
+		sf.replaceAll("Orig", "Replaced", "Orig"))
+	assert.Equal(t, "ReplacedReplaced",
+		sf.replaceAll("Orig", "Replaced", "OrigOrig"))
+}


### PR DESCRIPTION
This pull request adds a `replace` function which takes three arguments - an original string, the substring to replace, and the string with which to replace it. This is of particular use when generating node names from IP addresses where the node name may not contain "." characters.

The `strings.Replace` function in the Go standard library seems like it would be better named `strings.ReplaceN`, so we wrap it to replace all occurences of the string. If necessary, a gomplate function named `replaceN` could be introduced calling `strings.Replace` directly.