### PR TITLE
Namespacing the aws funcs

### DIFF
--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -8,26 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// test doubles
-type DummyInstanceDescriber struct {
-	tags []*ec2.Tag
-}
-
-func (d DummyInstanceDescriber) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	output := &ec2.DescribeInstancesOutput{
-		Reservations: []*ec2.Reservation{
-			{
-				Instances: []*ec2.Instance{
-					{
-						Tags: d.tags,
-					},
-				},
-			},
-		},
-	}
-	return output, nil
-}
-
 func TestTag_MissingKey(t *testing.T) {
 	server, ec2meta := MockServer(200, `"i-1234"`)
 	defer server.Close()

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 // MockServer -
@@ -23,4 +25,39 @@ func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
 
 	client := &Ec2Meta{server.URL + "/", httpClient, false, make(map[string]string)}
 	return server, client
+}
+
+// NewDummyEc2Info -
+func NewDummyEc2Info(metaClient *Ec2Meta) *Ec2Info {
+	i := &Ec2Info{
+		metaClient: metaClient,
+		describer:  func() InstanceDescriber { return DummyInstanceDescriber{} },
+	}
+	return i
+}
+
+// NewDummyEc2Meta -
+func NewDummyEc2Meta() *Ec2Meta {
+	return &Ec2Meta{nonAWS: true}
+}
+
+// DummyInstanceDescriber - test doubles
+type DummyInstanceDescriber struct {
+	tags []*ec2.Tag
+}
+
+// DescribeInstances -
+func (d DummyInstanceDescriber) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
+	output := &ec2.DescribeInstancesOutput{
+		Reservations: []*ec2.Reservation{
+			{
+				Instances: []*ec2.Instance{
+					{
+						Tags: d.tags,
+					},
+				},
+			},
+		},
+	}
+	return output, nil
 }

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -4,7 +4,6 @@ title = "gomplate documentation"
 
 theme = "hugo-material-docs"
 
-
 [params]
   author = "hairyhenderson"
   description = "gomplate documentation"
@@ -19,33 +18,3 @@ theme = "hugo-material-docs"
 [social]
   twitter = "hairyhenderson"
   github  = "hairyhenderson"
-
-[[menu.main]]
-  name   = "About"
-  url    = "/"
-  weight = 1
-  pre    = ""
-
-[[menu.main]]
-  name   = "Installing"
-  url    = "installing/"
-  weight = 10
-  pre    = ""
-
-[[menu.main]]
-  name   = "Usage"
-  url    = "usage/"
-  weight = 11
-  pre    = ""
-
-[[menu.main]]
-  name   = "Syntax"
-  url    = "syntax/"
-  weight = 12
-  pre    = ""
-
-[[menu.main]]
-  name   = "Built-in Functions"
-  url    = "functions/"
-  weight = 13
-  pre    = ""

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -1,0 +1,75 @@
+---
+title: aws functions
+menu:
+  main:
+    parent: functions
+---
+
+
+## `aws.EC2Meta`
+
+**Alias:** _(to be deprecated)_ `ec2meta`
+
+Queries AWS [EC2 Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `meta-data` path -- for data in the `dynamic` path use `aws.EC2Dynamic`.
+
+This only works when running `gomplate` on an EC2 instance. If the EC2 instance metadata API isn't available, the tool will timeout and fail.
+
+#### Example
+
+```console
+$ echo '{{aws.EC2Meta "instance-id"}}' | gomplate
+i-12345678
+```
+
+## `aws.EC2Dynamic`
+
+**Alias:** _(to be deprecated)_ `ec2dynamic`
+
+Queries AWS [EC2 Instance Dynamic Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `dynamic` path -- for data in the `meta-data` path use `aws.EC2Meta`.
+
+This only works when running `gomplate` on an EC2 instance. If the EC2 instance metadata API isn't available, the tool will timeout and fail.
+
+#### Example
+
+```console
+$ echo '{{ (aws.EC2Dynamic "instance-identity/document" | json).region }}' | ./gomplate
+us-east-1
+```
+
+## `aws.EC2Region`
+
+**Alias:** _(to be deprecated)_ `ec2region`
+
+Queries AWS to get the region. An optional default can be provided, or returns
+`unknown` if it can't be determined for some reason.
+
+#### Example
+
+_In EC2_
+```console
+$ echo '{{ aws.EC2Region }}' | ./gomplate
+us-east-1
+```
+_Not in EC2_
+```console
+$ echo '{{ aws.EC2Region }}' | ./gomplate
+unknown
+$ echo '{{ aws.EC2Region "foo" }}' | ./gomplate
+foo
+```
+
+## `aws.EC2Tag`
+
+**Alias:** _(to be deprecated)_ `ec2tag`
+
+Queries the AWS EC2 API to find the value of the given [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). An optional default
+can be provided.
+
+#### Example
+
+```console
+$ echo 'This server is in the {{ aws.EC2Tag "Account" }} account.' | ./gomplate
+foo
+$ echo 'I am a {{ aws.EC2Tag "classification" "meat popsicle" }}.' | ./gomplate
+I am a meat popsicle.
+```

--- a/docs/content/functions/general.md
+++ b/docs/content/functions/general.md
@@ -1,11 +1,9 @@
 ---
-title: Built-in functions
-weight: 0
+title: other functions
+menu:
+  main:
+    parent: functions
 ---
-
-In addition to all of the functions and operators that the [Go template](https://golang.org/pkg/text/template/)
-language provides (`if`, `else`, `eq`, `and`, `or`, `range`, etc...), there are
-some additional functions baked in to `gomplate`:
 
 ## `contains`
 
@@ -813,64 +811,4 @@ $ gomplate -d person.json -f input.tmpl
     { "name": "Dave" }
   ]
 }
-```
-
-## `ec2meta`
-
-Queries AWS [EC2 Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `meta-data` path -- for data in the `dynamic` path use `ec2dynamic`.
-
-This only works when running `gomplate` on an EC2 instance. If the EC2 instance metadata API isn't available, the tool will timeout and fail.
-
-#### Example
-
-```console
-$ echo '{{ec2meta "instance-id"}}' | gomplate
-i-12345678
-```
-
-## `ec2dynamic`
-
-Queries AWS [EC2 Instance Dynamic Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `dynamic` path -- for data in the `meta-data` path use `ec2meta`.
-
-This only works when running `gomplate` on an EC2 instance. If the EC2 instance metadata API isn't available, the tool will timeout and fail.
-
-#### Example
-
-```console
-$ echo '{{ (ec2dynamic "instance-identity/document" | json).region }}' | ./gomplate
-us-east-1
-```
-
-## `ec2region`
-
-Queries AWS to get the region. An optional default can be provided, or returns
-`unknown` if it can't be determined for some reason.
-
-#### Example
-
-_In EC2_
-```console
-$ echo '{{ ec2region }}' | ./gomplate
-us-east-1
-```
-_Not in EC2_
-```console
-$ echo '{{ ec2region }}' | ./gomplate
-unknown
-$ echo '{{ ec2region "foo" }}' | ./gomplate
-foo
-```
-
-## `ec2tag`
-
-Queries the AWS EC2 API to find the value of the given [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). An optional default
-can be provided.
-
-#### Example
-
-```console
-$ echo 'This server is in the {{ ec2tag "Account" }} account.' | ./gomplate
-foo
-$ echo 'I am a {{ ec2tag "classification" "meat popsicle" }}.' | ./gomplate
-I am a meat popsicle.
 ```

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,7 +1,10 @@
 ---
 title: gomplate
 type: index
-weight: 0
+weight: 1
+menu:
+  main:
+    name: About
 ---
 
 A [Go template](https://golang.org/pkg/text/template/)-based CLI tool. `gomplate` can be used as an alternative to

--- a/docs/content/installing.md
+++ b/docs/content/installing.md
@@ -1,6 +1,7 @@
 ---
 title: Installing
 weight: 10
+menu: main
 ---
 # Installing
 

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -1,6 +1,7 @@
 ---
 title: Syntax
-weight: 0
+weight: 12
+menu: main
 ---
 
 ## About `.Env`
@@ -13,3 +14,9 @@ Sometimes, this behaviour is desired; if the output is unusable without certain
 strings, this is a sure way to know that variables are missing!
 
 If you want different behaviour, try [`getenv`](../functions/#getenv).
+
+## Built-in functions
+
+In addition to all of the functions and operators that the [Go template](https://golang.org/pkg/text/template/)
+language provides (`if`, `else`, `eq`, `and`, `or`, `range`, etc...), there are
+some additional functions baked in to `gomplate`. See the links on the left.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -1,6 +1,7 @@
 ---
 title: Usage
-weight: 0
+weight: 11
+menu: main
 ---
 
 The simplest usage of `gomplate` is to just replace environment

--- a/funcs.go
+++ b/funcs.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"text/template"
+
+	"github.com/hairyhenderson/gomplate/funcs"
+)
+
+// initFuncs - The function mappings are defined here!
+func initFuncs(data *Data) template.FuncMap {
+	env := &Env{}
+	typeconv := &TypeConv{}
+	stringfunc := &stringFunc{}
+
+	f := template.FuncMap{
+		"getenv":           env.Getenv,
+		"bool":             typeconv.Bool,
+		"has":              typeconv.Has,
+		"json":             typeconv.JSON,
+		"jsonArray":        typeconv.JSONArray,
+		"yaml":             typeconv.YAML,
+		"yamlArray":        typeconv.YAMLArray,
+		"toml":             typeconv.TOML,
+		"csv":              typeconv.CSV,
+		"csvByRow":         typeconv.CSVByRow,
+		"csvByColumn":      typeconv.CSVByColumn,
+		"slice":            typeconv.Slice,
+		"indent":           typeconv.indent,
+		"join":             typeconv.Join,
+		"toJSON":           typeconv.ToJSON,
+		"toJSONPretty":     typeconv.toJSONPretty,
+		"toYAML":           typeconv.ToYAML,
+		"toTOML":           typeconv.ToTOML,
+		"toCSV":            typeconv.ToCSV,
+		"contains":         strings.Contains,
+		"hasPrefix":        strings.HasPrefix,
+		"hasSuffix":        strings.HasSuffix,
+		"replaceAll":       stringfunc.replaceAll,
+		"split":            strings.Split,
+		"splitN":           strings.SplitN,
+		"title":            strings.Title,
+		"toUpper":          strings.ToUpper,
+		"toLower":          strings.ToLower,
+		"trim":             strings.Trim,
+		"trimSpace":        strings.TrimSpace,
+		"urlParse":         url.Parse,
+		"datasource":       data.Datasource,
+		"ds":               data.Datasource,
+		"datasourceExists": data.DatasourceExists,
+		"include":          data.include,
+	}
+	funcs.AWSFuncs(f)
+	return f
+}

--- a/funcs/aws.go
+++ b/funcs/aws.go
@@ -1,0 +1,73 @@
+package funcs
+
+import (
+	"sync"
+
+	"github.com/hairyhenderson/gomplate/aws"
+)
+
+var (
+	af     *Funcs
+	afInit sync.Once
+)
+
+// AWSNS - the aws namespace
+func AWSNS() *Funcs {
+	afInit.Do(func() { af = &Funcs{} })
+	return af
+}
+
+// AWSFuncs -
+func AWSFuncs(f map[string]interface{}) {
+	f["aws"] = AWSNS
+
+	// global aliases - for backwards compatibility
+	f["ec2meta"] = AWSNS().EC2Meta
+	f["ec2dynamic"] = AWSNS().EC2Dynamic
+	f["ec2tag"] = AWSNS().EC2Tag
+	f["ec2region"] = AWSNS().EC2Region
+}
+
+// Funcs -
+type Funcs struct {
+	meta     *aws.Ec2Meta
+	metaInit sync.Once
+	info     *aws.Ec2Info
+	infoInit sync.Once
+}
+
+// EC2Region -
+func (a *Funcs) EC2Region(def ...string) string {
+	a.metaInit.Do(a.initMeta)
+	return a.meta.Region(def...)
+}
+
+// EC2Meta -
+func (a *Funcs) EC2Meta(key string, def ...string) string {
+	a.metaInit.Do(a.initMeta)
+	return a.meta.Meta(key, def...)
+}
+
+// EC2Dynamic -
+func (a *Funcs) EC2Dynamic(key string, def ...string) string {
+	a.metaInit.Do(a.initMeta)
+	return a.meta.Dynamic(key, def...)
+}
+
+// EC2Tag -
+func (a *Funcs) EC2Tag(tag string, def ...string) string {
+	a.infoInit.Do(a.initInfo)
+	return a.info.Tag(tag, def...)
+}
+
+func (a *Funcs) initMeta() {
+	if a.meta == nil {
+		a.meta = aws.NewEc2Meta()
+	}
+}
+
+func (a *Funcs) initInfo() {
+	if a.info == nil {
+		a.info = aws.NewEc2Info()
+	}
+}

--- a/funcs/aws_test.go
+++ b/funcs/aws_test.go
@@ -1,0 +1,21 @@
+package funcs
+
+import (
+	"testing"
+
+	"github.com/hairyhenderson/gomplate/aws"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNSIsIdempotent(t *testing.T) {
+	assert.True(t, AWSNS() == AWSNS())
+}
+func TestFuncs(t *testing.T) {
+	m := aws.NewDummyEc2Meta()
+	i := aws.NewDummyEc2Info(m)
+	af := &Funcs{meta: m, info: i}
+	assert.Equal(t, "unknown", af.EC2Region())
+	assert.Equal(t, "", af.EC2Meta("foo"))
+	assert.Equal(t, "", af.EC2Tag("foo"))
+	assert.Equal(t, "unknown", af.EC2Region())
+}

--- a/gomplate.go
+++ b/gomplate.go
@@ -3,11 +3,7 @@ package main
 import (
 	"io"
 	"log"
-	"net/url"
-	"strings"
 	"text/template"
-
-	"github.com/hairyhenderson/gomplate/aws"
 )
 
 func (g *Gomplate) createTemplate() *template.Template {
@@ -36,55 +32,10 @@ func (g *Gomplate) RunTemplate(text string, out io.Writer) {
 
 // NewGomplate -
 func NewGomplate(data *Data, leftDelim, rightDelim string) *Gomplate {
-	env := &Env{}
-	typeconv := &TypeConv{}
-	stringfunc := &stringFunc{}
-	ec2meta := aws.NewEc2Meta()
-	ec2info := aws.NewEc2Info()
 	return &Gomplate{
 		leftDelim:  leftDelim,
 		rightDelim: rightDelim,
-		funcMap: template.FuncMap{
-			"getenv":           env.Getenv,
-			"bool":             typeconv.Bool,
-			"has":              typeconv.Has,
-			"json":             typeconv.JSON,
-			"jsonArray":        typeconv.JSONArray,
-			"yaml":             typeconv.YAML,
-			"yamlArray":        typeconv.YAMLArray,
-			"toml":             typeconv.TOML,
-			"csv":              typeconv.CSV,
-			"csvByRow":         typeconv.CSVByRow,
-			"csvByColumn":      typeconv.CSVByColumn,
-			"slice":            typeconv.Slice,
-			"indent":           typeconv.indent,
-			"join":             typeconv.Join,
-			"toJSON":           typeconv.ToJSON,
-			"toJSONPretty":     typeconv.toJSONPretty,
-			"toYAML":           typeconv.ToYAML,
-			"toTOML":           typeconv.ToTOML,
-			"toCSV":            typeconv.ToCSV,
-			"ec2meta":          ec2meta.Meta,
-			"ec2dynamic":       ec2meta.Dynamic,
-			"ec2tag":           ec2info.Tag,
-			"ec2region":        ec2meta.Region,
-			"contains":         strings.Contains,
-			"hasPrefix":        strings.HasPrefix,
-			"hasSuffix":        strings.HasSuffix,
-			"replaceAll":       stringfunc.replaceAll,
-			"split":            strings.Split,
-			"splitN":           strings.SplitN,
-			"title":            strings.Title,
-			"toUpper":          strings.ToUpper,
-			"toLower":          strings.ToLower,
-			"trim":             strings.Trim,
-			"trimSpace":        strings.TrimSpace,
-			"urlParse":         url.Parse,
-			"datasource":       data.Datasource,
-			"ds":               data.Datasource,
-			"datasourceExists": data.DatasourceExists,
-			"include":          data.include,
-		},
+		funcMap:    initFuncs(data),
 	}
 }
 


### PR DESCRIPTION
This is an offshoot of #145 to try and figure out the best way to namespace built-in functions.

Ideally, I'd like to be able to use the existing function names, and simply move them under a namespace. So, instead of `{{ ec2region }}`, I'd like `{{ aws.ec2region }}`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>