### PR TITLE
Adding AWS_TIMEOUT environment variable

### DIFF
--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -94,7 +94,7 @@ func TestNewEc2Info(t *testing.T) {
 			},
 		},
 	}
-	e := NewEc2Info()
+	e := NewEc2Info(ClientOptions{})
 	e.describer = func() InstanceDescriber {
 		return client
 	}

--- a/aws/ec2meta.go
+++ b/aws/ec2meta.go
@@ -18,11 +18,12 @@ type Ec2Meta struct {
 	Client   *http.Client
 	nonAWS   bool
 	cache    map[string]string
+	options  ClientOptions
 }
 
 // NewEc2Meta -
-func NewEc2Meta() *Ec2Meta {
-	return &Ec2Meta{cache: make(map[string]string)}
+func NewEc2Meta(options ClientOptions) *Ec2Meta {
+	return &Ec2Meta{cache: make(map[string]string), options: options}
 }
 
 // returnDefault -
@@ -53,7 +54,11 @@ func (e *Ec2Meta) retrieveMetadata(url string, def ...string) string {
 	}
 
 	if e.Client == nil {
-		e.Client = &http.Client{Timeout: 500 * time.Millisecond}
+		timeout := e.options.Timeout
+		if timeout == 0 {
+			timeout = 500 * time.Millisecond
+		}
+		e.Client = &http.Client{Timeout: timeout}
 	}
 	resp, err := e.Client.Get(url)
 	if err != nil {

--- a/aws/ec2meta_test.go
+++ b/aws/ec2meta_test.go
@@ -68,7 +68,7 @@ func TestUnreachable(t *testing.T) {
 }
 
 func TestRetrieveMetadata_NonEC2(t *testing.T) {
-	ec2meta := NewEc2Meta()
+	ec2meta := NewEc2Meta(ClientOptions{})
 	ec2meta.nonAWS = true
 
 	assert.Equal(t, "foo", ec2meta.retrieveMetadata("", "foo"))

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -23,7 +23,7 @@ func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
 	}
 	httpClient := &http.Client{Transport: tr}
 
-	client := &Ec2Meta{server.URL + "/", httpClient, false, make(map[string]string)}
+	client := &Ec2Meta{server.URL + "/", httpClient, false, make(map[string]string), ClientOptions{}}
 	return server, client
 }
 

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -5,6 +5,15 @@ menu:
     parent: functions
 ---
 
+The functions in the `aws` namespace interface with various Amazon Web Services
+APIs to make it possible for a template to render differently based on the AWS
+environment and metadata.
+
+#### `AWS_TIMEOUT` variable
+
+In some cases AWS APIs may be slower to respond. The timeout for these requests
+can be adjusted by setting the `AWS_TIMEOUT` environment variable. The value
+must be in milliseconds, and defaults to 500 milliseconds.
 
 ## `aws.EC2Meta`
 


### PR DESCRIPTION
Fixes #168 by making the HTTP client timeout for AWS API calls configurable.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>