### PR TITLE
Remove VFS argument from ReadSource which isn't used

### DIFF
--- a/data.go
+++ b/data.go
@@ -183,7 +183,7 @@ func (d *Data) Datasource(alias string, args ...string) interface{} {
 	if !ok {
 		log.Fatalf("Undefined datasource '%s'", alias)
 	}
-	b, err := d.ReadSource(source.FS, source, args...)
+	b, err := d.ReadSource(source, args...)
 	if err != nil {
 		log.Fatalf("Couldn't read datasource '%s': %s", alias, err)
 	}
@@ -214,7 +214,7 @@ func (d *Data) include(alias string, args ...string) interface{} {
 	if !ok {
 		log.Fatalf("Undefined datasource '%s'", alias)
 	}
-	b, err := d.ReadSource(source.FS, source, args...)
+	b, err := d.ReadSource(source, args...)
 	if err != nil {
 		log.Fatalf("Couldn't read datasource '%s': %s", alias, err)
 	}
@@ -222,7 +222,7 @@ func (d *Data) include(alias string, args ...string) interface{} {
 }
 
 // ReadSource -
-func (d *Data) ReadSource(fs vfs.Filesystem, source *Source, args ...string) ([]byte, error) {
+func (d *Data) ReadSource(source *Source, args ...string) ([]byte, error) {
 	if d.cache == nil {
 		d.cache = make(map[string][]byte)
 	}


### PR DESCRIPTION
ReadSource is passed a VFS argument (set from source.FS) as the first argument, but this is never used. Instead source is passed so the readFile proc uses that instead (and directly accesses source.FS)