### PR TITLE
Using the built-in Go version in Appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ clone_folder: c:\gopath\src\github.com\hairyhenderson\gomplate
 
 environment:
   GOPATH: c:\gopath
-  DEPTESTBYPASS501: 1
-  GOVERSION: 1.8
 
 init:
   - git config --global core.autocrlf input
@@ -16,13 +14,9 @@ init:
 # Build
 
 install:
-  # Install the specific Go version.
-  - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GOVERSION%.windows-amd64.msi
-  - msiexec /i go%GOVERSION%.windows-amd64.msi /q
-  # - choco install bzr
-  # - set Path=c:\go\bin;c:\gopath\bin;C:\Program Files (x86)\Bazaar\;C:\Program Files\Mercurial\%Path%
-  - set Path=c:\go\bin;c:\gopath\bin;%Path%
+  - echo %PATH%
+  - echo %GOPATH%
+  - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - go version
   - go env
 


### PR DESCRIPTION
This should make builds more stable - didn't realize Go was already installed!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>