### PR TITLE
Vault write support

### DIFF
--- a/data.go
+++ b/data.go
@@ -322,11 +322,35 @@ func readVault(source *Source, args ...string) ([]byte, error) {
 	}
 
 	p := source.URL.Path
-	if len(args) == 1 {
-		p = p + "/" + args[0]
+
+	var write = false
+
+	params := make(map[string]interface{})
+
+	if len(args) > 0 {
+		var index = 0
+		if !strings.Contains(args[0], "=") && args[0] != "" {
+			index = 1
+			p = p + "/" + args[0]
+		}
+		for len(args) > index {
+			write = true
+			var parts = strings.SplitAfterN(args[index], "=", 2)
+			if len(parts) == 2 {
+				params[strings.TrimSuffix(parts[0], "=")] = parts[1]
+			}
+			index++
+		}
 	}
 
-	data, err := source.VC.Read(p)
+	var data []byte
+	var err error
+
+	if write {
+		data, err = source.VC.Write(p, params)
+	} else {
+		data, err = source.VC.Read(p)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/docs/content/functions/general.md
+++ b/docs/content/functions/general.md
@@ -627,6 +627,16 @@ $ echo 'db_password={{(datasource "vault" "db/pass").value}}' \
 db_password=prodsecret
 ```
 
+It is also possible to use dynamic secrets by using the write capibility of the datasource. To use
+add additional `"name=value"` parameters after the optional key name. These values are then included
+within the JSON body of the request.
+
+```console
+$ echo 'otp={{(datasource "vault" "ssh/creds/test" "ip=10.1.2.3" "username=user").key}}' \
+  | gomplate -d vault=vault:///
+otp=604a4bd5-7afd-30a2-d2d8-80c4aebc6183
+```
+
 ## `datasourceExists`
 
 Tests whether or not a given datasource was defined on the commandline (with the

--- a/docs/content/functions/general.md
+++ b/docs/content/functions/general.md
@@ -628,11 +628,11 @@ db_password=prodsecret
 ```
 
 It is also possible to use dynamic secrets by using the write capibility of the datasource. To use
-add additional `"name=value"` parameters after the optional key name. These values are then included
-within the JSON body of the request.
+add an additional query string style section to the optional key name (i.e.
+`"key?name=value&name=value"`). These values are then included within the JSON body of the request.
 
 ```console
-$ echo 'otp={{(datasource "vault" "ssh/creds/test" "ip=10.1.2.3" "username=user").key}}' \
+$ echo 'otp={{(datasource "vault" "ssh/creds/test?ip=10.1.2.3&username=user").key}}' \
   | gomplate -d vault=vault:///
 otp=604a4bd5-7afd-30a2-d2d8-80c4aebc6183
 ```

--- a/test/integration/datasources_vault.bats
+++ b/test/integration/datasources_vault.bats
@@ -126,7 +126,7 @@ function teardown () {
   vault mount ssh
   vault write ssh/roles/test key_type=otp default_user=user cidr_list=10.0.0.0/8
   VAULT_TOKEN=$(vault token-create -format=json -policy=writepol -use-limit=2 -ttl=1m | jq -j .auth.client_token)
-  VAULT_TOKEN=$VAULT_TOKEN gomplate -d vault=vault:/// -i '{{(datasource "vault" "ssh/creds/test" "ip=10.1.2.3" "username=user").ip}}'
+  VAULT_TOKEN=$VAULT_TOKEN gomplate -d vault=vault:/// -i '{{(datasource "vault" "ssh/creds/test?ip=10.1.2.3&username=user").ip}}'
   [ "$status" -eq 0 ]
   [[ "${output}" == "10.1.2.3" ]]
 }
@@ -135,7 +135,7 @@ function teardown () {
   vault mount ssh
   vault write ssh/roles/test key_type=otp default_user=user cidr_list=10.0.0.0/8
   VAULT_TOKEN=$(vault token-create -format=json -policy=writepol -use-limit=2 -ttl=1m | jq -j .auth.client_token)
-  VAULT_TOKEN=$VAULT_TOKEN gomplate -d vault=vault:///ssh/creds/test -i '{{(datasource "vault" "ip=10.1.2.3" "username=user").ip}}'
+  VAULT_TOKEN=$VAULT_TOKEN gomplate -d vault=vault:///ssh/creds/test -i '{{(datasource "vault" "?ip=10.1.2.3&username=user").ip}}'
   [ "$status" -eq 0 ]
   [[ "${output}" == "10.1.2.3" ]]
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -55,3 +55,17 @@ func (v *Vault) Read(path string) ([]byte, error) {
 	}
 	return buf.Bytes(), nil
 }
+
+func (v *Vault) Write(path string, data map[string]interface{}) ([]byte, error) {
+	secret, err := v.client.Logical().Write(path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(secret.Data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
This requires #177 to be merged first.

This PR adds write support to the Vault datasource, enabling use of dynamic secrets (such as database credentials).