### PR TITLE
Fixing crash on 404

### DIFF
--- a/data/datasource.go
+++ b/data/datasource.go
@@ -204,7 +204,10 @@ func (d *Data) Datasource(alias string, args ...string) interface{} {
 	}
 	b, err := d.ReadSource(source, args...)
 	if err != nil {
-		log.Fatalf("Couldn't read datasource '%s': %s", alias, err)
+		logFatalf("Couldn't read datasource '%s': %s", alias, err)
+	}
+	if b == nil || len(b) == 0 {
+		logFatalf("No value found for %s from datasource '%s'", args, alias)
 	}
 	s := string(b)
 	if source.Type == "application/json" {

--- a/test/integration/datasources_vault.bats
+++ b/test/integration/datasources_vault.bats
@@ -47,6 +47,13 @@ function teardown () {
   [[ "${output}" == "$BATS_TEST_DESCRIPTION" ]]
 }
 
+@test "Testing failure with non-existant secret" {
+  VAULT_TOKEN=$(vault token-create -format=json -policy=readpol -use-limit=1 -ttl=1m | jq -j .auth.client_token)
+  VAULT_TOKEN=$VAULT_TOKEN gomplate -d vault=vault:///secret -i '{{(datasource "vault" "bar").value}}'
+  [ "$status" -eq 1 ]
+  [[ "${output}" == *"No value found for [bar] from datasource 'vault'" ]]
+}
+
 @test "Testing token vault auth using file" {
   vault write secret/foo value="$BATS_TEST_DESCRIPTION"
   vault token-create -format=json -policy=readpol -use-limit=1 -ttl=1m | jq -j .auth.client_token > $tmpdir/token

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -1,0 +1,27 @@
+package vault
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogin(t *testing.T) {
+	server, v := MockServer(404, "Not Found")
+	defer server.Close()
+	os.Setenv("VAULT_TOKEN", "foo")
+	defer os.Unsetenv("VAULT_TOKEN")
+	v.Login()
+	assert.Equal(t, "foo", v.client.Token())
+}
+
+func TestTokenLogin(t *testing.T) {
+	server, v := MockServer(404, "Not Found")
+	defer server.Close()
+	os.Setenv("VAULT_TOKEN", "foo")
+	defer os.Unsetenv("VAULT_TOKEN")
+
+	token := v.TokenLogin()
+	assert.Equal(t, "foo", token)
+}

--- a/vault/testutils.go
+++ b/vault/testutils.go
@@ -1,0 +1,31 @@
+package vault
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// MockServer -
+func MockServer(code int, body string) (*httptest.Server, *Vault) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		fmt.Fprintln(w, body)
+	}))
+
+	tr := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(server.URL)
+		},
+	}
+	httpClient := &http.Client{Transport: tr}
+	config := &api.Config{
+		Address:    server.URL,
+		HttpClient: httpClient,
+	}
+	c, _ := api.NewClient(config)
+	return server, &Vault{c}
+}

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -16,7 +16,7 @@ type Vault struct {
 	client *vaultapi.Client
 }
 
-// NewVault - instantiate a new
+// New -
 func New() *Vault {
 	vaultConfig := vaultapi.DefaultConfig()
 
@@ -42,10 +42,15 @@ func (v *Vault) Login() {
 func (v *Vault) Logout() {
 }
 
+// Read - returns the value of a given path. If no value is found at the given
+// path, returns empty slice.
 func (v *Vault) Read(path string) ([]byte, error) {
 	secret, err := v.client.Logical().Read(path)
 	if err != nil {
 		return nil, err
+	}
+	if secret == nil {
+		return []byte{}, nil
 	}
 
 	var buf bytes.Buffer
@@ -58,6 +63,9 @@ func (v *Vault) Read(path string) ([]byte, error) {
 
 func (v *Vault) Write(path string, data map[string]interface{}) ([]byte, error) {
 	secret, err := v.client.Logical().Write(path, data)
+	if secret == nil {
+		return []byte{}, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -1,0 +1,37 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRead(t *testing.T) {
+	server, v := MockServer(404, "Not Found")
+	defer server.Close()
+	val, err := v.Read("secret/bogus")
+	assert.Empty(t, val)
+	assert.NoError(t, err)
+
+	expected := "{\"value\":\"foo\"}\n"
+	server, v = MockServer(200, `{"data":`+expected+`}`)
+	defer server.Close()
+	val, err = v.Read("s")
+	assert.Equal(t, expected, string(val))
+	assert.NoError(t, err)
+}
+
+func TestWrite(t *testing.T) {
+	server, v := MockServer(404, "Not Found")
+	defer server.Close()
+	val, err := v.Write("secret/bogus", nil)
+	assert.Empty(t, val)
+	assert.Error(t, err)
+
+	expected := "{\"value\":\"foo\"}\n"
+	server, v = MockServer(200, `{"data":`+expected+`}`)
+	defer server.Close()
+	val, err = v.Write("s", nil)
+	assert.Equal(t, expected, string(val))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #200 

New behaviour:

```console
$  bin/gomplate -d vault=vault:///secret/path/to/secret -i '{{ ds "vault" "foo" }}'
2017/09/02 18:58:12 No value found for [foo] from datasource 'vault'
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>