### PR TITLE
Fixes #192 - fail with unknown args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .git
 bin
 report.xml
+gomplate

--- a/main.go
+++ b/main.go
@@ -68,12 +68,7 @@ func newGomplateCmd() *cobra.Command {
 			}
 			return runTemplate(&opts)
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unrecognized argument '%s'", args[0])
-			}
-			return nil
-		},
+		Args: cobra.NoArgs,
 	}
 	return rootCmd
 }

--- a/main.go
+++ b/main.go
@@ -68,6 +68,12 @@ func newGomplateCmd() *cobra.Command {
 			}
 			return runTemplate(&opts)
 		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unrecognized argument '%s'", args[0])
+			}
+			return nil
+		},
 	}
 	return rootCmd
 }

--- a/test/integration/basic.bats
+++ b/test/integration/basic.bats
@@ -75,7 +75,7 @@ function teardown () {
   [[ "${output}" == "hi" ]]
 }
 
-@test "unknown arguments result in error" {
+@test "unknown argument results in error" {
   gomplate -in flibbit
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = 'Error: unknown command "flibbit" for "gomplate"' ]

--- a/test/integration/basic.bats
+++ b/test/integration/basic.bats
@@ -74,3 +74,9 @@ function teardown () {
   [ "$status" -eq 0 ]
   [[ "${output}" == "hi" ]]
 }
+
+@test "unknown arguments result in error" {
+  gomplate -in flibbit
+  [ "$status" -eq 1 ]
+  [[ "${lines[0]}" == "Error: unrecognized argument 'flibbit'" ]]
+}

--- a/test/integration/basic.bats
+++ b/test/integration/basic.bats
@@ -78,5 +78,5 @@ function teardown () {
 @test "unknown arguments result in error" {
   gomplate -in flibbit
   [ "$status" -eq 1 ]
-  [[ "${lines[0]}" == "Error: unrecognized argument 'flibbit'" ]]
+  [ "${lines[0]}" = 'Error: unknown command "flibbit" for "gomplate"' ]
 }

--- a/test/integration/basic.bats
+++ b/test/integration/basic.bats
@@ -78,5 +78,5 @@ function teardown () {
 @test "unknown argument results in error" {
   gomplate -in flibbit
   [ "$status" -eq 1 ]
-  [ "${lines[0]}" = 'Error: unknown command "flibbit" for "gomplate"' ]
+  [[ "${lines[0]}" == 'Error: unknown command "flibbit" for "gomplate"' ]]
 }


### PR DESCRIPTION
Fixes #192 

Test case:
```
gomplate -in flibbit
```

This PR causes gomplate to exit with a non-zero exit status and display an error message to the user:
```
Error: unknown argument 'flibbit'
```