### PR TITLE
Adding conv.ToInt64, conv.ToFloat64, and others...

### DIFF
--- a/conv/conv.go
+++ b/conv/conv.go
@@ -108,3 +108,98 @@ func MustAtoi(s string) int {
 	i, _ := strconv.Atoi(s)
 	return i
 }
+
+// ToInt64 - taken from github.com/Masterminds/sprig
+func ToInt64(v interface{}) int64 {
+	if str, ok := v.(string); ok {
+		iv, err := strconv.ParseInt(str, 0, 64)
+		if err != nil {
+			return 0
+		}
+		return iv
+	}
+
+	val := reflect.Indirect(reflect.ValueOf(v))
+	switch val.Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return val.Int()
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return int64(val.Uint())
+	case reflect.Uint, reflect.Uint64:
+		tv := val.Uint()
+		// this can overflow and give -1, but IMO this is better than
+		// returning maxint64
+		return int64(tv)
+	case reflect.Float32, reflect.Float64:
+		return int64(val.Float())
+	case reflect.Bool:
+		if val.Bool() == true {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// ToInt -
+func ToInt(in interface{}) int {
+	return int(ToInt64(in))
+}
+
+// ToInt64s -
+func ToInt64s(in ...interface{}) []int64 {
+	out := make([]int64, len(in))
+	for i, v := range in {
+		out[i] = ToInt64(v)
+	}
+	return out
+}
+
+// ToInts -
+func ToInts(in ...interface{}) []int {
+	out := make([]int, len(in))
+	for i, v := range in {
+		out[i] = ToInt(v)
+	}
+	return out
+}
+
+// ToFloat64 - taken from github.com/Masterminds/sprig
+func ToFloat64(v interface{}) float64 {
+	if str, ok := v.(string); ok {
+		iv, err := strconv.ParseFloat(str, 64)
+		if err != nil {
+			return 0
+		}
+		return iv
+	}
+
+	val := reflect.Indirect(reflect.ValueOf(v))
+	switch val.Kind() {
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return float64(val.Int())
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32:
+		return float64(val.Uint())
+	case reflect.Uint, reflect.Uint64:
+		return float64(val.Uint())
+	case reflect.Float32, reflect.Float64:
+		return val.Float()
+	case reflect.Bool:
+		if val.Bool() == true {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// ToFloat64s -
+func ToFloat64s(in ...interface{}) []float64 {
+	out := make([]float64, len(in))
+	for i, v := range in {
+		out[i] = ToFloat64(v)
+	}
+	return out
+}

--- a/conv/conv_test.go
+++ b/conv/conv_test.go
@@ -1,6 +1,7 @@
 package conv
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -83,4 +84,79 @@ func TestMustParseFloat(t *testing.T) {
 	}
 	assert.Equal(t, 1.0, MustParseFloat("1", 64))
 	assert.Equal(t, -1.0, MustParseFloat("-1", 64))
+}
+
+func TestToInt64(t *testing.T) {
+	assert.Equal(t, int64(1), ToInt64(1))
+	assert.Equal(t, int64(1), ToInt64(int32(1)))
+	assert.Equal(t, int64(1), ToInt64(int64(1)))
+	assert.Equal(t, int64(1), ToInt64(float32(1)))
+	assert.Equal(t, int64(1), ToInt64(float64(1)))
+	assert.Equal(t, int64(42), ToInt64(42))
+	assert.Equal(t, int64(-1), ToInt64(uint64(math.MaxUint64)))
+	assert.Equal(t, int64(0xFF), ToInt64(uint8(math.MaxUint8)))
+
+	assert.Equal(t, int64(0), ToInt64(nil))
+	assert.Equal(t, int64(0), ToInt64(false))
+	assert.Equal(t, int64(1), ToInt64(true))
+	assert.Equal(t, int64(0), ToInt64(""))
+	assert.Equal(t, int64(0), ToInt64("foo"))
+	assert.Equal(t, int64(0xFFFF), ToInt64("0xFFFF"))
+	assert.Equal(t, int64(8), ToInt64("010"))
+}
+
+func TestToInt(t *testing.T) {
+	assert.Equal(t, 1, ToInt(1))
+	assert.Equal(t, 1, ToInt(int32(1)))
+	assert.Equal(t, 1, ToInt(int64(1)))
+	assert.Equal(t, 1, ToInt(float32(1)))
+	assert.Equal(t, 1, ToInt(float64(1)))
+	assert.Equal(t, 42, ToInt(42))
+	assert.Equal(t, -1, ToInt(uint64(math.MaxUint64)))
+	assert.Equal(t, 0xFF, ToInt(uint8(math.MaxUint8)))
+
+	assert.Equal(t, 0, ToInt(nil))
+	assert.Equal(t, 0, ToInt(false))
+	assert.Equal(t, 1, ToInt(true))
+	assert.Equal(t, 0, ToInt(""))
+	assert.Equal(t, 0, ToInt("foo"))
+	assert.Equal(t, 0xFFFF, ToInt("0xFFFF"))
+	assert.Equal(t, 8, ToInt("010"))
+}
+
+func TestToInt64s(t *testing.T) {
+	assert.Equal(t, []int64{}, ToInt64s())
+
+	assert.Equal(t, []int64{0}, ToInt64s(""))
+	assert.Equal(t, []int64{0}, ToInt64s("0"))
+	assert.Equal(t, []int64{42, 15}, ToInt64s("42", "15"))
+	assert.Equal(t, []int64{0, 0, 0, 1, 1, 2, 3, 5, 8, 13},
+		ToInt64s(nil, false, "", true, 1, 2.0, uint8(3), int64(5), float32(8), "13"))
+}
+
+func TestToInts(t *testing.T) {
+	assert.Equal(t, []int{}, ToInts())
+
+	assert.Equal(t, []int{0}, ToInts(""))
+	assert.Equal(t, []int{0}, ToInts("0"))
+	assert.Equal(t, []int{42, 15}, ToInts("42", "15"))
+	assert.Equal(t, []int{0, 0, 0, 1, 1, 2, 3, 5, 8, 13},
+		ToInts(nil, false, "", true, 1, 2.0, uint8(3), int64(5), float32(8), "13"))
+}
+
+func TestToFloat64(t *testing.T) {
+	z := []interface{}{0, 0.0, nil, false, float32(0), "", "0", "foo", int64(0), uint(0)}
+	for _, n := range z {
+		assert.Equal(t, 0.0, ToFloat64(n))
+	}
+	assert.Equal(t, 1.0, ToFloat64(true))
+	z = []interface{}{42, 42.0, float32(42), "42", "42.0", uint8(42)}
+	for _, n := range z {
+		assert.Equal(t, 42.0, ToFloat64(n))
+	}
+}
+
+func TestToFloat64s(t *testing.T) {
+	assert.Equal(t, []float64{}, ToFloat64s())
+	assert.Equal(t, []float64{0, 1.0, 2.0, math.Pi, 4.0}, ToFloat64s(nil, true, "2", math.Pi, uint8(4)))
 }

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -199,3 +199,37 @@ The number is less than 5
 $ NUMBER=21 gomplate < input.tmpl
 The number is greater than 5
 ```
+
+## `conv.ToInt64`
+
+Converts the input to an `int64`.
+
+```console
+$ gomplate -i '{{conv.ToInt64 "9223372036854775807"}}'
+9223372036854775807
+```
+
+## `conv.ToInt`
+
+Converts the input to an `int`. This is similar to `conv.Atoi`, but handles booleans and numbers as well as strings.
+
+```console
+$ gomplate -i '{{conv.ToInt (gt 1 2)}}'
+0
+```
+
+## `conv.ToInt64s`
+
+Converts the inputs to an array of `int64`s
+
+## `conv.ToInts`
+
+Converts the inputs to an array of `int`s
+
+## `conv.ToFloat64`
+
+Converts the input to a `float64`
+
+## `conv.ToFloat64s`
+
+Converts the inputs to an array of `float64`s

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -62,3 +62,27 @@ func (f *ConvFuncs) Atoi(s string) int {
 func (f *ConvFuncs) URL(s string) (*url.URL, error) {
 	return url.Parse(s)
 }
+
+func (f *ConvFuncs) ToInt64(in interface{}) int64 {
+	return conv.ToInt64(in)
+}
+
+func (f *ConvFuncs) ToInt(in interface{}) int {
+	return conv.ToInt(in)
+}
+
+func (f *ConvFuncs) ToInt64s(in ...interface{}) []int64 {
+	return conv.ToInt64s(in)
+}
+
+func (f *ConvFuncs) ToInts(in ...interface{}) []int {
+	return conv.ToInts(in)
+}
+
+func (f *ConvFuncs) ToFloat64(in interface{}) float64 {
+	return conv.ToFloat64(in)
+}
+
+func (f *ConvFuncs) ToFloat64s(in ...interface{}) []float64 {
+	return conv.ToFloat64s(in)
+}


### PR DESCRIPTION
Adding number conversion functions:

- `conv.ToInt64`
- `conv.ToInt`
- `conv.ToInt64s`
- `conv.ToInts`
- `conv.ToFloat64`
- `conv.ToFloat64s`

These are taken mostly from https://github.com/Masterminds/sprig

Signed-off-by: Dave Henderson <dhenderson@gmail.com>