### PR TITLE
Fixing bugs in ToInt64/ToFloat64

### DIFF
--- a/conv/conv.go
+++ b/conv/conv.go
@@ -114,7 +114,13 @@ func ToInt64(v interface{}) int64 {
 	if str, ok := v.(string); ok {
 		iv, err := strconv.ParseInt(str, 0, 64)
 		if err != nil {
-			return 0
+			// maybe it's a float?
+			var fv float64
+			fv, err = strconv.ParseFloat(str, 64)
+			if err != nil {
+				return 0
+			}
+			return ToInt64(fv)
 		}
 		return iv
 	}
@@ -168,11 +174,19 @@ func ToInts(in ...interface{}) []int {
 // ToFloat64 - taken from github.com/Masterminds/sprig
 func ToFloat64(v interface{}) float64 {
 	if str, ok := v.(string); ok {
-		iv, err := strconv.ParseFloat(str, 64)
+		// this is inefficient, but it's the only way I can think of to
+		// properly convert octal integers to floats
+		iv, err := strconv.ParseInt(str, 0, 64)
 		if err != nil {
-			return 0
+			// ok maybe it's a float?
+			var fv float64
+			fv, err = strconv.ParseFloat(str, 64)
+			if err != nil {
+				return 0
+			}
+			return fv
 		}
-		return iv
+		return float64(iv)
 	}
 
 	val := reflect.Indirect(reflect.ValueOf(v))

--- a/conv/conv_test.go
+++ b/conv/conv_test.go
@@ -93,6 +93,8 @@ func TestToInt64(t *testing.T) {
 	assert.Equal(t, int64(1), ToInt64(float32(1)))
 	assert.Equal(t, int64(1), ToInt64(float64(1)))
 	assert.Equal(t, int64(42), ToInt64(42))
+	assert.Equal(t, int64(42), ToInt64("42.0"))
+	assert.Equal(t, int64(3), ToInt64("3.5"))
 	assert.Equal(t, int64(-1), ToInt64(uint64(math.MaxUint64)))
 	assert.Equal(t, int64(0xFF), ToInt64(uint8(math.MaxUint8)))
 
@@ -145,12 +147,12 @@ func TestToInts(t *testing.T) {
 }
 
 func TestToFloat64(t *testing.T) {
-	z := []interface{}{0, 0.0, nil, false, float32(0), "", "0", "foo", int64(0), uint(0)}
+	z := []interface{}{0, 0.0, nil, false, float32(0), "", "0", "foo", int64(0), uint(0), "0x0", "00"}
 	for _, n := range z {
 		assert.Equal(t, 0.0, ToFloat64(n))
 	}
 	assert.Equal(t, 1.0, ToFloat64(true))
-	z = []interface{}{42, 42.0, float32(42), "42", "42.0", uint8(42)}
+	z = []interface{}{42, 42.0, float32(42), "42", "42.0", uint8(42), "0x2A", "052"}
 	for _, n := range z {
 		assert.Equal(t, 42.0, ToFloat64(n))
 	}


### PR DESCRIPTION
- `ToInt64` couldn't handle strings with floats (i.e. "3.0")
- `ToFloat64` couldn't handle strings with integers in hex or octal notation

Signed-off-by: Dave Henderson <dhenderson@gmail.com>