### PR TITLE
Don't panic on template errors

### DIFF
--- a/gomplate.go
+++ b/gomplate.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"io"
-	"log"
 	"text/template"
 
 	"github.com/hairyhenderson/gomplate/data"
@@ -20,16 +19,14 @@ type Gomplate struct {
 }
 
 // RunTemplate -
-func (g *Gomplate) RunTemplate(text string, out io.Writer) {
+func (g *Gomplate) RunTemplate(text string, out io.Writer) error {
 	context := &Context{}
 	tmpl, err := g.createTemplate().Delims(g.leftDelim, g.rightDelim).Parse(text)
 	if err != nil {
-		log.Fatalf("Line %q: %v\n", text, err)
+		return err
 	}
-
-	if err := tmpl.Execute(out, context); err != nil {
-		panic(err)
-	}
+	err = tmpl.Execute(out, context)
+	return err
 }
 
 // NewGomplate -
@@ -63,6 +60,6 @@ func renderTemplate(g *Gomplate, inString string, outPath string) error {
 	}
 	// nolint: errcheck
 	defer outFile.Close()
-	g.RunTemplate(inString, outFile)
-	return nil
+	err = g.RunTemplate(inString, outFile)
+	return err
 }

--- a/test/integration/envvars.bats
+++ b/test/integration/envvars.bats
@@ -11,7 +11,7 @@ load helper
 
 @test "errors with non-existant env var using .Env" {
   gomplate -i '{{.Env.FOO}}'
-  [ "$status" -eq 2 ]
+  [ "$status" -eq 1 ]
   [[ "${lines[0]}" == *"map has no entry for key"* ]]
 }
 


### PR DESCRIPTION
Instead of spitting out an ugly stack trace when handling an error, it's more helpful to simply print out the error and the usage message.

Before:
```console
$ gomplate -i '{{.Env.foo}}'
panic: template: template:1:6: executing "template" at <.Env.foo>: map has no entry for key "foo"

goroutine 1 [running]:
main.(*Gomplate).RunTemplate(0xc4202a3e30, 0x7fff5fbff584, 0xc, 0x1e95de0, 0xc42000c018)
        /go/src/github.com/hairyhenderson/gomplate/gomplate.go:31 +0x42c
main.renderTemplate(0xc4202a3e30, 0x7fff5fbff584, 0xc, 0x197bc94, 0x1, 0x0, 0x0)
        /go/src/github.com/hairyhenderson/gomplate/gomplate.go:66 +0xbc
main.processInputFiles(0x7fff5fbff584, 0xc, 0xc4202ba350, 0x1, 0x1, 0xc4202ba380, 0x1, 0x1, 0xc4202a3e30, 0xc42025e3c0, ...)
        /go/src/github.com/hairyhenderson/gomplate/process.go:23 +0x152
main.runTemplate(0x1ee5660, 0x0, 0x0)
        /go/src/github.com/hairyhenderson/gomplate/gomplate.go:55 +0x233
main.newGomplateCmd.func1(0xc4200a3d40, 0xc4202b8320, 0x0, 0x2, 0x0, 0x0)
        /go/src/github.com/hairyhenderson/gomplate/main.go:69 +0x7e
github.com/hairyhenderson/gomplate/vendor/github.com/spf13/cobra.(*Command).execute(0xc4200a3d40, 0xc42000e0d0, 0x2, 0x2, 0xc4200a3d40, 0xc42000e0d0)
        /go/src/github.com/hairyhenderson/gomplate/vendor/github.com/spf13/cobra/command.go:649 +0x456
github.com/hairyhenderson/gomplate/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4200a3d40, 0x2, 0x197bebc, 0x2)
        /go/src/github.com/hairyhenderson/gomplate/vendor/github.com/spf13/cobra/command.go:728 +0x2fe
github.com/hairyhenderson/gomplate/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4200a3d40, 0xc420159f70, 0x172fb44)
        /go/src/github.com/hairyhenderson/gomplate/vendor/github.com/spf13/cobra/command.go:687 +0x2b
main.main()
        /go/src/github.com/hairyhenderson/gomplate/main.go:97 +0x42
```

After:
```console
$ gomplate -i '{{.Env.foo}}'
Error: template: template:1:6: executing "template" at <.Env.foo>: map has no entry for key "foo"
Usage:
  gomplate [flags]

Flags:
  -d, --datasource datasource      datasource in alias=URL form. Specify multiple times to add multiple sources.
  -H, --datasource-header header   HTTP header field in 'alias=Name: value' form to be provided on HTTP-based data sources. Multiples can be set.
  -f, --file file                  Template file to process. Omit to use standard input, or use --in or --input-dir (default [-])
  -h, --help                       help for gomplate
  -i, --in string                  Template string to process (alternative to --file and --input-dir)
      --input-dir directory        directory which is examined recursively for templates (alternative to --file and --in)
      --left-delim delimiter       override the default left-delimiter [$GOMPLATE_LEFT_DELIM] (default "{{")
  -o, --out file                   output file name. Omit to use standard output. (default [-])
      --output-dir directory       directory to store the processed templates. Only used for --input-dir (default ".")
      --right-delim delimiter      override the default right-delimiter [$GOMPLATE_RIGHT_DELIM] (default "}}")
  -v, --version                    print the version
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>