### PR TITLE
Adding time.ZoneOffset function

### DIFF
--- a/docs/content/functions/time.md
+++ b/docs/content/functions/time.md
@@ -162,3 +162,19 @@ time.ZoneName
 $ gomplate -i '{{time.ZoneName}}'
 EDT
 ```
+
+## `time.ZoneOffset`
+
+Return the local system's time zone offset, in seconds east of UTC.
+
+### Usage
+```go
+time.ZoneOffset
+```
+
+### Example
+
+```console
+$ gomplate -i '{{time.ZoneOffset}}'
+-14400
+```

--- a/funcs/time.go
+++ b/funcs/time.go
@@ -68,6 +68,11 @@ func (f *TimeFuncs) ZoneName() string {
 	return time.ZoneName()
 }
 
+// ZoneOffset - return the local system's time zone's name
+func (f *TimeFuncs) ZoneOffset() int {
+	return time.ZoneOffset()
+}
+
 // Parse -
 func (f *TimeFuncs) Parse(layout, value string) (gotime.Time, error) {
 	return gotime.Parse(layout, value)

--- a/test/integration/time.bats
+++ b/test/integration/time.bats
@@ -8,6 +8,12 @@ load helper
   [[ "${output}" == `date +"%Z"` ]]
 }
 
+@test "'time.ZoneOffset'" {
+  TZ=UTC gomplate -i '{{ time.ZoneOffset }}'
+  [ "$status" -eq 0 ]
+  [[ "${output}" == "0" ]]
+}
+
 @test "'(time.Now).Format'" {
   gomplate -i '{{ (time.Now).Format "2006-01-02 15 -0700" }}'
   [ "$status" -eq 0 ]

--- a/time/time.go
+++ b/time/time.go
@@ -9,3 +9,9 @@ func ZoneName() string {
 	n, _ := time.Now().Zone()
 	return n
 }
+
+// ZoneOffset - determine the current timezone's offset, in seconds east of UTC
+func ZoneOffset() int {
+	_, o := time.Now().Zone()
+	return o
+}

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -1,0 +1,14 @@
+package time
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZoneFuncs(t *testing.T) {
+	name, offset := time.Now().Zone()
+	assert.Equal(t, name, ZoneName())
+	assert.Equal(t, offset, ZoneOffset())
+}


### PR DESCRIPTION
Adding new `time.ZoneOffset` function to return the current timezone's offset in seconds east of UTC.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>