### PR TITLE
Adding support for stdin: scheme for datasources

### DIFF
--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/blang/vfs"
@@ -306,4 +307,24 @@ func TestInclude(t *testing.T) {
 	}
 	actual := data.Include("foo")
 	assert.Equal(t, contents, actual)
+}
+
+type errorReader struct{}
+
+func (e errorReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("error")
+}
+
+func TestReadStdin(t *testing.T) {
+	defer func() {
+		stdin = nil
+	}()
+	stdin = strings.NewReader("foo")
+	out, err := readStdin(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("foo"), out)
+
+	stdin = errorReader{}
+	_, err = readStdin(nil)
+	assert.Error(t, err)
 }

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -11,7 +11,7 @@ A collection of functions that retrieve, parse, and convert structured data.
 
 Parses a given datasource (provided by the [`--datasource/-d`](#--datasource-d) argument).
 
-Currently, `file://`, `http://`, `https://`, and `vault://` URLs are supported.
+Currently, `file://`, `stdin://`, `http://`, `https://`, and `vault://` URLs are supported.
 
 Currently-supported formats are JSON, YAML, TOML, and CSV.
 
@@ -32,6 +32,25 @@ Hello {{ (datasource "person").name }}
 ```console
 $ gomplate -d person.json < input.tmpl
 Hello Dave
+```
+
+### Providing datasources on standard input (`stdin`)
+
+Normally `stdin` is used as the input for the template, but it can also be used
+to provide datasources. To do this, specify a URL with the `stdin:` scheme:
+
+```console
+$ echo 'foo: bar' | gomplate -i '{{(ds "data").foo}}' -d data=stdin:///foo.yaml
+bar
+```
+
+Note that the URL must have a file name with a supported extension in order for
+the input to be correctly parsed. If no parsing is required (i.e. if the data
+is being included verbatim with the include function), just `stdin:` is enough:
+
+```console
+$ echo 'foo' | gomplate -i '{{ include "data" }}' -d data=stdin:
+foo
 ```
 
 ### Usage with HTTP data


### PR DESCRIPTION
Fixes #230 

Adds support for a `stdin:` scheme for datasources. For now, MIME type is specified by setting a bogus filename and the extension is used. If no parsing is required (i.e. if the data is being included verbatim with the `include` function), just `stdin:` is enough.

```console
$ echo 'foo: bar' | gomplate -i '{{(ds "data").foo}}' -d data=stdin:///foo.yaml 
bar
$ echo 'foo' | gomplate -i '{{ include "data" }}' -d data=stdin:
foo
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>