### PR TITLE
Support setting MIME type with URL query string

### DIFF
--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -42,6 +42,13 @@ func TestNewSource(t *testing.T) {
 	assert.Equal(t, ".json", s.Ext)
 
 	s = NewSource("foo", &url.URL{
+		Scheme: "file",
+		Path:   "/foo",
+	})
+	assert.Equal(t, "text/plain", s.Type)
+	assert.Equal(t, "", s.Ext)
+
+	s = NewSource("foo", &url.URL{
 		Scheme: "http",
 		Host:   "example.com",
 		Path:   "/foo.json",
@@ -56,6 +63,28 @@ func TestNewSource(t *testing.T) {
 	})
 	assert.Equal(t, "application/json", s.Type)
 	assert.Equal(t, ".json", s.Ext)
+
+	s = NewSource("foo", &url.URL{
+		Scheme:   "ftp",
+		Host:     "example.com",
+		Path:     "/foo.blarb",
+		RawQuery: "type=application/json%3Bcharset=utf-8",
+	})
+
+	assert.Equal(t, "application/json", s.Type)
+	assert.Equal(t, ".blarb", s.Ext)
+	assert.Equal(t, map[string]string{"charset": "utf-8"}, s.Params)
+
+	s = NewSource("foo", &url.URL{
+		Scheme:   "stdin",
+		Host:     "",
+		Path:     "",
+		RawQuery: "type=application/json",
+	})
+
+	assert.Equal(t, "application/json", s.Type)
+	assert.Equal(t, "", s.Ext)
+	assert.Equal(t, map[string]string{}, s.Params)
 }
 
 func TestNewData(t *testing.T) {

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -11,7 +11,7 @@ A collection of functions that retrieve, parse, and convert structured data.
 
 Parses a given datasource (provided by the [`--datasource/-d`](#--datasource-d) argument).
 
-Currently, `file://`, `stdin://`, `http://`, `https://`, and `vault://` URLs are supported.
+Currently, `file://`, `stdin://`, `http://`, `https://`, `vault://`, and `boltdb://` URLs are supported.
 
 Currently-supported formats are JSON, YAML, TOML, and CSV.
 
@@ -51,6 +51,22 @@ is being included verbatim with the include function), just `stdin:` is enough:
 ```console
 $ echo 'foo' | gomplate -i '{{ include "data" }}' -d data=stdin:
 foo
+```
+
+### Overriding the MIME type
+
+On occasion it's necessary to override the MIME type a datasource is parsed with.
+To accomplish this, gomplate supports a `type` query string parameter on
+datasource URLs. This can contain the same value as a standard
+[HTTP Content-Type](https://tools.ietf.org/html/rfc7231#section-3.1.1.1)
+header.
+
+For example, to force a file named `data.txt` to be parsed as a JSON document:
+
+```console
+$ echo '{"foo": "bar"}' > /tmp/data.txt
+$ gomplate -d data=file:///tmp/data.txt?type=application/json -i '{{ (ds "data").foo }}'
+bar
 ```
 
 ### Usage with HTTP data

--- a/test/integration/datasources_consul.bats
+++ b/test/integration/datasources_consul.bats
@@ -21,6 +21,13 @@ function teardown () {
   [[ "${output}" == "$BATS_TEST_DESCRIPTION" ]]
 }
 
+@test "Consul datasource works with MIME override" {
+  consul kv put foo "{\"desc\":$BATS_TEST_DESCRIPTION}"
+  gomplate -d consul=consul://?type=application/json -i '{{(datasource "consul" "foo").desc}}'
+  [ "$status" -eq 0 ]
+  [[ "${output}" == "$BATS_TEST_DESCRIPTION" ]]
+}
+
 @test "Consul datasource works with hostname in URL" {
   consul kv put foo "$BATS_TEST_DESCRIPTION"
   unset CONSUL_HTTP_ADDR


### PR DESCRIPTION
Sometimes it's handy to be able to set or override a datasource's MIME type. This PR makes it possible:

```console
$ echo 'foo: bar' | bin/gomplate -i '{{(ds "config").foo}}' -d config=stdin:///?type=application/yaml                 
bar
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>