### PR TITLE
bind test binaries explicitly to 127.0.0.1

### DIFF
--- a/test/integration/awssvc/main.go
+++ b/test/integration/awssvc/main.go
@@ -13,13 +13,13 @@ type Req struct {
 	Headers http.Header `json:"headers"`
 }
 
-var port string
+var port int
 
 func main() {
-	flag.StringVar(&port, "p", "8082", "Port to listen to")
+	flag.IntVar(&port, "p", 8082, "Port to listen to")
 	flag.Parse()
 
-	l, err := net.Listen("tcp", ":"+port)
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/integration/metasvc/main.go
+++ b/test/integration/metasvc/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fullsailor/pkcs7"
 )
 
-var port string
+var port int
 var priv *rsa.PrivateKey
 var derBytes []byte
 
@@ -38,10 +38,10 @@ const instanceDocument = `{
 }`
 
 func main() {
-	flag.StringVar(&port, "p", "8081", "Port to listen to")
+	flag.IntVar(&port, "p", 8081, "Port to listen to")
 	flag.Parse()
 
-	l, err := net.Listen("tcp", ":"+port)
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/integration/mirrorsvc/main.go
+++ b/test/integration/mirrorsvc/main.go
@@ -19,7 +19,7 @@ func main() {
 	flag.IntVar(&port, "p", 8080, "Port to listen to")
 	flag.Parse()
 
-	l, err := net.ListenTCP("tcp", &net.TCPAddr{Port: port})
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Makes life a bit easier when running on macOS - prevents firewall pop-ups asking for permission to listen to ports...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>