### PR TITLE
Dockerizing the build-release target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ Dockerfile
 .vscode
 *.md
 bin/
+*.cid
+*.iid

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 bin
 report.xml
 gomplate
+*.cid
+*.iid

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PREFIX := .
 
 COMMIT ?= `git rev-parse --short HEAD 2>/dev/null`
 VERSION ?= `git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1) 2>/dev/null | sed 's/v\(.*\)/\1/'`
+BUILD_DATE ?= `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 COMMIT_FLAG := -X `go list ./version`.GitCommit=$(COMMIT)
 VERSION_FLAG := -X `go list ./version`.Version=$(VERSION)
@@ -16,16 +17,9 @@ GOARCH ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\2/')
 platforms := linux-amd64 linux-386 linux-arm linux-arm64 darwin-amd64 solaris-amd64 windows-amd64.exe windows-386.exe
 compressed-platforms := linux-amd64-slim linux-arm-slim linux-arm64-slim darwin-amd64-slim windows-amd64-slim.exe
 
-define gocross-tool
-	GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 \
-		$(GO) build \
-			-ldflags "-w -s $(COMMIT_FLAG) $(VERSION_FLAG)" \
-			-o $(PREFIX)/bin/$(3)_$(1)-$(2)$(call extension,$(1)) \
-			$(PREFIX)/test/integration/$(3)svc;
-endef
-
 clean:
 	rm -Rf $(PREFIX)/bin/*
+	rm -f $(PREFIX)/*.[ci]id
 	rm -f $(PREFIX)/test/integration/gomplate
 	rm -f $(PREFIX)/test/integration/mirror
 	rm -f $(PREFIX)/test/integration/meta
@@ -43,6 +37,22 @@ $(PREFIX)/bin/$(PKG_NAME)_%-slim.exe: $(PREFIX)/bin/$(PKG_NAME)_%.exe
 
 compress: $(PREFIX)/bin/$(PKG_NAME)_$(GOOS)-$(GOARCH)-slim$(call extension,$(GOOS))
 	cp $< $(PREFIX)/bin/$(PKG_NAME)-slim$(call extension,$(GOOS))
+
+%.iid: Dockerfile
+	@docker build \
+		--build-arg BUILD_DATE=$(BUILD_DATE) \
+		--build-arg VCS_REF=$(COMMIT) \
+		--target $(subst .iid,,$@) \
+		--iidfile $@ \
+		.
+
+%.cid: %.iid
+	@docker create $(shell cat $<) > $@
+
+build-release: artifacts.cid
+	@docker cp $(shell cat $<):/bin/. bin/
+
+docker-images: gomplate.iid gomplate-slim.iid
 
 $(PREFIX)/bin/$(PKG_NAME)_%: $(shell find $(PREFIX) -type f -name '*.go' -not -path "$(PREFIX)/test/*")
 	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- | cut -f1 -d.) CGO_ENABLED=0 \
@@ -112,6 +122,6 @@ lint:
 	gometalinter -j $(shell nproc) --vendor --deadline 120s --disable gotype --enable gofmt --enable goimports --enable misspell --enable unused --disable gas
 endif
 
-.PHONY: gen-changelog clean test build-x compress-all build-release build build-integration-image test-integration-docker gen-docs lint
+.PHONY: gen-changelog clean test build-x compress-all build-release build build-integration-image test-integration-docker gen-docs lint clean-images clean-containers docker-images
 .DELETE_ON_ERROR:
 .SECONDARY:

--- a/hooks/build
+++ b/hooks/build
@@ -10,6 +10,9 @@ export DOCKER_REPO=${DOCKER_REPO:-hairyhenderson/gomplate}
 export DOCKER_TAG=${DOCKER_TAG:-latest}
 export IMAGE_NAME=${IMAGE_NAME:-${DOCKER_REPO}:${DOCKER_TAG}}
 
+docker build --target artifacts \
+             -t ${DOCKER_REPO}:artifacts .
+
 echo "======== Building $IMAGE_NAME"
 docker build --build-arg BUILD_DATE \
              --build-arg VCS_REF \

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -4,6 +4,9 @@ set -exuo pipefail
 export DOCKER_REPO=${DOCKER_REPO:-hairyhenderson/gomplate}
 export DOCKER_TAG=${DOCKER_TAG:-latest}
 export IMAGE_NAME=${IMAGE_NAME:-${DOCKER_REPO}:${DOCKER_TAG}}
+
+docker push ${DOCKER_REPO}:artifacts
+
 if [ "$DOCKER_TAG" == "latest" ]; then
   export SLIM_TAG="slim"
 else


### PR DESCRIPTION
A bunch of stuff here...

- doing `build-release` as a Docker build so I can control the version of Go being used
- can build multi-arch images by setting `OS` and `ARCH` build args (except Windows right now)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>