### PR TITLE
Attempting to fix intermittent Integration Test failure

### DIFF
--- a/test/integration/awssvc/main.go
+++ b/test/integration/awssvc/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"time"
 )
 
 // Req -
@@ -184,7 +185,10 @@ func ec2Handler(w http.ResponseWriter, r *http.Request) {
 
 func quitHandler(l net.Listener) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		l.Close()
 		w.WriteHeader(http.StatusNoContent)
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			l.Close()
+		}()
 	}
 }

--- a/test/integration/helper.bash
+++ b/test/integration/helper.bash
@@ -28,6 +28,7 @@ function __gomplate_stdin () {
 
 function start_mirror_svc () {
   bin/mirror &
+  wait_for_url http://127.0.0.1:8080/
 }
 
 function stop_mirror_svc () {
@@ -36,6 +37,7 @@ function stop_mirror_svc () {
 
 function start_meta_svc () {
   bin/meta &> /tmp/meta.log &
+  wait_for_url http://127.0.0.1:8081/
 }
 
 function stop_meta_svc () {
@@ -44,6 +46,7 @@ function stop_meta_svc () {
 
 function start_aws_svc () {
   bin/aws &
+  wait_for_url http://127.0.0.1:8082/
 }
 
 function stop_aws_svc () {

--- a/test/integration/metasvc/main.go
+++ b/test/integration/metasvc/main.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/fullsailor/pkcs7"
 )
@@ -137,7 +138,10 @@ func certificateHandler(w http.ResponseWriter, r *http.Request) {
 
 func quitHandler(l net.Listener) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		l.Close()
 		w.WriteHeader(http.StatusNoContent)
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			l.Close()
+		}()
 	}
 }

--- a/test/integration/mirrorsvc/main.go
+++ b/test/integration/mirrorsvc/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"time"
 )
 
 // Req -
@@ -44,7 +45,10 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 
 func quitHandler(l net.Listener) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		l.Close()
 		w.WriteHeader(http.StatusNoContent)
+		go func() {
+			time.Sleep(500 * time.Millisecond)
+			l.Close()
+		}()
 	}
 }


### PR DESCRIPTION
Sometimes tests fail (like in https://circleci.com/gh/hairyhenderson/gomplate/925), and I'm pretty sure it's because the `/quit` endpoint closes the `net.Listener` too early (before `wget` is finished).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>