### PR TITLE
strings.Indent should not indent when width is 0

### DIFF
--- a/strings/strings.go
+++ b/strings/strings.go
@@ -4,6 +4,9 @@ import "strings"
 
 // Indent - indent each line of the string with the given indent string
 func Indent(width int, indent, s string) string {
+	if width == 0 {
+		return s
+	}
 	if width > 1 {
 		indent = strings.Repeat(indent, width)
 	}

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -9,6 +9,7 @@ import (
 func TestIndent(t *testing.T) {
 	actual := "hello\nworld\n!"
 	expected := "  hello\n  world\n  !"
+	assert.Equal(t, actual, Indent(0, "  ", actual))
 	assert.Equal(t, expected, Indent(1, "  ", actual))
 	assert.Equal(t, "\n", Indent(1, "  ", "\n"))
 	assert.Equal(t, "  foo\n", Indent(1, "  ", "foo\n"))


### PR DESCRIPTION
When recursively generating YAML, it is useful to have a simple generic template definition that starts with an indent of 0 and increments at each level YAML.  If you pass `width` of 0 to the function as it was before this change, it would indent it one level without complaining, which was a great source of confusion to me.