### PR TITLE
meta: Add release for freebsd-amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ VERSION_FLAG := -X `go list ./version`.Version=$(VERSION)
 GOOS ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\1/')
 GOARCH ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\2/')
 
-platforms := linux-amd64 linux-386 linux-arm linux-arm64 darwin-amd64 solaris-amd64 windows-amd64.exe windows-386.exe
+platforms := freebsd-amd64 linux-amd64 linux-386 linux-arm linux-arm64 darwin-amd64 solaris-amd64 windows-amd64.exe windows-386.exe
 compressed-platforms := linux-amd64-slim linux-arm-slim linux-arm64-slim darwin-amd64-slim windows-amd64-slim.exe
 
 clean:


### PR DESCRIPTION
This pull request enables release builds for FreeBSD on amd64 - my test shows that all is well building, so I don't think any other modifications need to be made!