### PR TITLE
Relax inputs for many functions

### DIFF
--- a/funcs/base64.go
+++ b/funcs/base64.go
@@ -1,11 +1,10 @@
 package funcs
 
 import (
-	"fmt"
-	"strconv"
 	"sync"
 
 	"github.com/hairyhenderson/gomplate/base64"
+	"github.com/hairyhenderson/gomplate/conv"
 )
 
 var (
@@ -35,7 +34,7 @@ func (f *Base64Funcs) Encode(in interface{}) string {
 
 // Decode -
 func (f *Base64Funcs) Decode(in interface{}) string {
-	return string(base64.Decode(toString(in)))
+	return string(base64.Decode(conv.ToString(in)))
 }
 
 type byter interface {
@@ -55,30 +54,5 @@ func toBytes(in interface{}) []byte {
 	if s, ok := in.(string); ok {
 		return []byte(s)
 	}
-	return []byte(fmt.Sprintf("%s", in))
-}
-
-func toString(in interface{}) string {
-	if s, ok := in.(string); ok {
-		return s
-	}
-	if s, ok := in.(fmt.Stringer); ok {
-		return s.String()
-	}
-	if i, ok := in.(int); ok {
-		return strconv.Itoa(i)
-	}
-	if u, ok := in.(uint64); ok {
-		return strconv.FormatUint(u, 10)
-	}
-	if f, ok := in.(float64); ok {
-		return strconv.FormatFloat(f, 'f', -1, 64)
-	}
-	if b, ok := in.(bool); ok {
-		return strconv.FormatBool(b)
-	}
-	if in == nil {
-		return "nil"
-	}
-	return fmt.Sprintf("%s", in)
+	return []byte(conv.ToString(in))
 }

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -33,8 +33,8 @@ func AddConvFuncs(f map[string]interface{}) {
 type ConvFuncs struct{}
 
 // Bool -
-func (f *ConvFuncs) Bool(s string) bool {
-	return conv.Bool(s)
+func (f *ConvFuncs) Bool(s interface{}) bool {
+	return conv.Bool(conv.ToString(s))
 }
 
 // Slice -
@@ -53,28 +53,28 @@ func (f *ConvFuncs) Has(in interface{}, key string) bool {
 }
 
 // ParseInt -
-func (f *ConvFuncs) ParseInt(s string, base, bitSize int) int64 {
-	return conv.MustParseInt(s, base, bitSize)
+func (f *ConvFuncs) ParseInt(s interface{}, base, bitSize int) int64 {
+	return conv.MustParseInt(conv.ToString(s), base, bitSize)
 }
 
 // ParseFloat -
-func (f *ConvFuncs) ParseFloat(s string, bitSize int) float64 {
-	return conv.MustParseFloat(s, bitSize)
+func (f *ConvFuncs) ParseFloat(s interface{}, bitSize int) float64 {
+	return conv.MustParseFloat(conv.ToString(s), bitSize)
 }
 
 // ParseUint -
-func (f *ConvFuncs) ParseUint(s string, base, bitSize int) uint64 {
-	return conv.MustParseUint(s, base, bitSize)
+func (f *ConvFuncs) ParseUint(s interface{}, base, bitSize int) uint64 {
+	return conv.MustParseUint(conv.ToString(s), base, bitSize)
 }
 
 // Atoi -
-func (f *ConvFuncs) Atoi(s string) int {
-	return conv.MustAtoi(s)
+func (f *ConvFuncs) Atoi(s interface{}) int {
+	return conv.MustAtoi(conv.ToString(s))
 }
 
 // URL -
-func (f *ConvFuncs) URL(s string) (*url.URL, error) {
-	return url.Parse(s)
+func (f *ConvFuncs) URL(s interface{}) (*url.URL, error) {
+	return url.Parse(conv.ToString(s))
 }
 
 // ToInt64 -

--- a/funcs/data.go
+++ b/funcs/data.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/data"
 )
 
@@ -45,28 +46,28 @@ func AddDataFuncs(f map[string]interface{}, d *data.Data) {
 type DataFuncs struct{}
 
 // JSON -
-func (f *DataFuncs) JSON(in string) map[string]interface{} {
-	return data.JSON(in)
+func (f *DataFuncs) JSON(in interface{}) map[string]interface{} {
+	return data.JSON(conv.ToString(in))
 }
 
 // JSONArray -
-func (f *DataFuncs) JSONArray(in string) []interface{} {
-	return data.JSONArray(in)
+func (f *DataFuncs) JSONArray(in interface{}) []interface{} {
+	return data.JSONArray(conv.ToString(in))
 }
 
 // YAML -
-func (f *DataFuncs) YAML(in string) map[string]interface{} {
-	return data.YAML(in)
+func (f *DataFuncs) YAML(in interface{}) map[string]interface{} {
+	return data.YAML(conv.ToString(in))
 }
 
 // YAMLArray -
-func (f *DataFuncs) YAMLArray(in string) []interface{} {
-	return data.YAMLArray(in)
+func (f *DataFuncs) YAMLArray(in interface{}) []interface{} {
+	return data.YAMLArray(conv.ToString(in))
 }
 
 // TOML -
-func (f *DataFuncs) TOML(in string) interface{} {
-	return data.TOML(in)
+func (f *DataFuncs) TOML(in interface{}) interface{} {
+	return data.TOML(conv.ToString(in))
 }
 
 // CSV -

--- a/funcs/env.go
+++ b/funcs/env.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/env"
 )
 
@@ -29,11 +30,11 @@ func AddEnvFuncs(f map[string]interface{}) {
 type EnvFuncs struct{}
 
 // Getenv -
-func (f *EnvFuncs) Getenv(key string, def ...string) string {
-	return env.Getenv(key, def...)
+func (f *EnvFuncs) Getenv(key interface{}, def ...string) string {
+	return env.Getenv(conv.ToString(key), def...)
 }
 
 // ExpandEnv -
-func (f *EnvFuncs) ExpandEnv(s string) string {
-	return env.ExpandEnv(s)
+func (f *EnvFuncs) ExpandEnv(s interface{}) string {
+	return env.ExpandEnv(conv.ToString(s))
 }

--- a/funcs/file.go
+++ b/funcs/file.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/file"
 	"github.com/spf13/afero"
 )
@@ -30,36 +31,36 @@ type FileFuncs struct {
 }
 
 // Read -
-func (f *FileFuncs) Read(path string) (string, error) {
-	return file.Read(path)
+func (f *FileFuncs) Read(path interface{}) (string, error) {
+	return file.Read(conv.ToString(path))
 }
 
 // Stat -
-func (f *FileFuncs) Stat(path string) (os.FileInfo, error) {
-	return f.fs.Stat(path)
+func (f *FileFuncs) Stat(path interface{}) (os.FileInfo, error) {
+	return f.fs.Stat(conv.ToString(path))
 }
 
 // Exists -
-func (f *FileFuncs) Exists(path string) bool {
-	_, err := f.Stat(path)
+func (f *FileFuncs) Exists(path interface{}) bool {
+	_, err := f.Stat(conv.ToString(path))
 	return err == nil
 }
 
 // IsDir -
-func (f *FileFuncs) IsDir(path string) bool {
-	i, err := f.Stat(path)
+func (f *FileFuncs) IsDir(path interface{}) bool {
+	i, err := f.Stat(conv.ToString(path))
 	return err == nil && i.IsDir()
 }
 
 // ReadDir -
-func (f *FileFuncs) ReadDir(path string) ([]string, error) {
-	return file.ReadDir(path)
+func (f *FileFuncs) ReadDir(path interface{}) ([]string, error) {
+	return file.ReadDir(conv.ToString(path))
 }
 
 // Walk -
-func (f *FileFuncs) Walk(path string) ([]string, error) {
+func (f *FileFuncs) Walk(path interface{}) ([]string, error) {
 	files := make([]string, 0)
-	afero.Walk(f.fs, path, func(subpath string, finfo os.FileInfo, err error) error {
+	afero.Walk(f.fs, conv.ToString(path), func(subpath string, finfo os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -4,6 +4,8 @@ import (
 	stdnet "net"
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
+
 	"github.com/hairyhenderson/gomplate/net"
 )
 
@@ -27,31 +29,31 @@ func AddNetFuncs(f map[string]interface{}) {
 type NetFuncs struct{}
 
 // LookupIP -
-func (f *NetFuncs) LookupIP(name string) string {
-	return net.LookupIP(name)
+func (f *NetFuncs) LookupIP(name interface{}) string {
+	return net.LookupIP(conv.ToString(name))
 }
 
 // LookupIPs -
-func (f *NetFuncs) LookupIPs(name string) []string {
-	return net.LookupIPs(name)
+func (f *NetFuncs) LookupIPs(name interface{}) []string {
+	return net.LookupIPs(conv.ToString(name))
 }
 
 // LookupCNAME -
-func (f *NetFuncs) LookupCNAME(name string) string {
-	return net.LookupCNAME(name)
+func (f *NetFuncs) LookupCNAME(name interface{}) string {
+	return net.LookupCNAME(conv.ToString(name))
 }
 
 // LookupSRV -
-func (f *NetFuncs) LookupSRV(name string) *stdnet.SRV {
-	return net.LookupSRV(name)
+func (f *NetFuncs) LookupSRV(name interface{}) *stdnet.SRV {
+	return net.LookupSRV(conv.ToString(name))
 }
 
 // LookupSRVs -
-func (f *NetFuncs) LookupSRVs(name string) []*stdnet.SRV {
-	return net.LookupSRVs(name)
+func (f *NetFuncs) LookupSRVs(name interface{}) []*stdnet.SRV {
+	return net.LookupSRVs(conv.ToString(name))
 }
 
 // LookupTXT -
-func (f *NetFuncs) LookupTXT(name string) []string {
-	return net.LookupTXT(name)
+func (f *NetFuncs) LookupTXT(name interface{}) []string {
+	return net.LookupTXT(conv.ToString(name))
 }

--- a/funcs/regexp.go
+++ b/funcs/regexp.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/regexp"
 )
 
@@ -26,11 +27,11 @@ func AddReFuncs(f map[string]interface{}) {
 type ReFuncs struct{}
 
 // Replace -
-func (f *ReFuncs) Replace(re, replacement, input string) string {
-	return regexp.Replace(re, replacement, input)
+func (f *ReFuncs) Replace(re, replacement string, input interface{}) string {
+	return regexp.Replace(re, replacement, conv.ToString(input))
 }
 
 // Match -
-func (f *ReFuncs) Match(re, input string) bool {
-	return regexp.Match(re, input)
+func (f *ReFuncs) Match(re string, input interface{}) bool {
+	return regexp.Match(re, conv.ToString(input))
 }

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -9,6 +9,8 @@ import (
 	"log"
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
+
 	"strings"
 
 	gompstrings "github.com/hairyhenderson/gomplate/strings"
@@ -49,73 +51,71 @@ func AddStringFuncs(f map[string]interface{}) {
 type StringFuncs struct{}
 
 // ReplaceAll -
-func (f *StringFuncs) ReplaceAll(old, new, s string) string {
-	return strings.Replace(s, old, new, -1)
+func (f *StringFuncs) ReplaceAll(old, new string, s interface{}) string {
+	return strings.Replace(conv.ToString(s), old, new, -1)
 }
 
 // Contains -
-func (f *StringFuncs) Contains(substr, s string) bool {
-	return strings.Contains(s, substr)
+func (f *StringFuncs) Contains(substr string, s interface{}) bool {
+	return strings.Contains(conv.ToString(s), substr)
 }
 
 // HasPrefix -
-func (f *StringFuncs) HasPrefix(prefix, s string) bool {
-	return strings.HasPrefix(s, prefix)
+func (f *StringFuncs) HasPrefix(prefix string, s interface{}) bool {
+	return strings.HasPrefix(conv.ToString(s), prefix)
 }
 
 // HasSuffix -
-func (f *StringFuncs) HasSuffix(suffix, s string) bool {
-	return strings.HasSuffix(s, suffix)
+func (f *StringFuncs) HasSuffix(suffix string, s interface{}) bool {
+	return strings.HasSuffix(conv.ToString(s), suffix)
 }
 
 // Split -
-func (f *StringFuncs) Split(sep, s string) []string {
-	return strings.Split(s, sep)
+func (f *StringFuncs) Split(sep string, s interface{}) []string {
+	return strings.Split(conv.ToString(s), sep)
 }
 
 // SplitN -
-func (f *StringFuncs) SplitN(sep string, n int, s string) []string {
-	return strings.SplitN(s, sep, n)
+func (f *StringFuncs) SplitN(sep string, n int, s interface{}) []string {
+	return strings.SplitN(conv.ToString(s), sep, n)
 }
 
 // Trim -
-func (f *StringFuncs) Trim(cutset, s string) string {
-	return strings.Trim(s, cutset)
+func (f *StringFuncs) Trim(cutset string, s interface{}) string {
+	return strings.Trim(conv.ToString(s), cutset)
 }
 
-// Trim Prefix-
-func (f *StringFuncs) TrimPrefix(cutset, s string) string {
-	return strings.TrimPrefix(s, cutset)
+// TrimPrefix -
+func (f *StringFuncs) TrimPrefix(cutset string, s interface{}) string {
+	return strings.TrimPrefix(conv.ToString(s), cutset)
 }
 
 // Title -
-func (f *StringFuncs) Title(s string) string {
-	return strings.Title(s)
+func (f *StringFuncs) Title(s interface{}) string {
+	return strings.Title(conv.ToString(s))
 }
 
 // ToUpper -
-func (f *StringFuncs) ToUpper(s string) string {
-	return strings.ToUpper(s)
+func (f *StringFuncs) ToUpper(s interface{}) string {
+	return strings.ToUpper(conv.ToString(s))
 }
 
 // ToLower -
-func (f *StringFuncs) ToLower(s string) string {
-	return strings.ToLower(s)
+func (f *StringFuncs) ToLower(s interface{}) string {
+	return strings.ToLower(conv.ToString(s))
 }
 
 // TrimSpace -
-func (f *StringFuncs) TrimSpace(s string) string {
-	return strings.TrimSpace(s)
+func (f *StringFuncs) TrimSpace(s interface{}) string {
+	return strings.TrimSpace(conv.ToString(s))
 }
 
 // Indent -
 func (f *StringFuncs) Indent(args ...interface{}) string {
-	input, ok := args[len(args)-1].(string)
-	if !ok {
-		log.Fatal("Indent: invalid arguments")
-	}
+	input := conv.ToString(args[len(args)-1])
 	indent := " "
 	width := 1
+	var ok bool
 	switch len(args) {
 	case 2:
 		indent, ok = args[0].(string)

--- a/funcs/time.go
+++ b/funcs/time.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	gotime "time"
 
+	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/time"
 )
 
@@ -74,22 +75,22 @@ func (f *TimeFuncs) ZoneOffset() int {
 }
 
 // Parse -
-func (f *TimeFuncs) Parse(layout, value string) (gotime.Time, error) {
-	return gotime.Parse(layout, value)
+func (f *TimeFuncs) Parse(layout string, value interface{}) (gotime.Time, error) {
+	return gotime.Parse(layout, conv.ToString(value))
 }
 
 // ParseLocal -
-func (f *TimeFuncs) ParseLocal(layout, value string) (gotime.Time, error) {
-	return gotime.ParseInLocation(layout, value, gotime.Local)
+func (f *TimeFuncs) ParseLocal(layout string, value interface{}) (gotime.Time, error) {
+	return gotime.ParseInLocation(layout, conv.ToString(value), gotime.Local)
 }
 
 // ParseInLocation -
-func (f *TimeFuncs) ParseInLocation(layout, location, value string) (gotime.Time, error) {
+func (f *TimeFuncs) ParseInLocation(layout, location string, value interface{}) (gotime.Time, error) {
 	loc, err := gotime.LoadLocation(location)
 	if err != nil {
 		return gotime.Time{}, err
 	}
-	return gotime.ParseInLocation(layout, value, loc)
+	return gotime.ParseInLocation(layout, conv.ToString(value), loc)
 }
 
 // Now -
@@ -108,33 +109,33 @@ func (f *TimeFuncs) Unix(in interface{}) (gotime.Time, error) {
 }
 
 // Nanosecond -
-func (f *TimeFuncs) Nanosecond(n int64) gotime.Duration {
-	return gotime.Nanosecond * gotime.Duration(n)
+func (f *TimeFuncs) Nanosecond(n interface{}) gotime.Duration {
+	return gotime.Nanosecond * gotime.Duration(conv.ToInt64(n))
 }
 
 // Microsecond -
-func (f *TimeFuncs) Microsecond(n int64) gotime.Duration {
-	return gotime.Microsecond * gotime.Duration(n)
+func (f *TimeFuncs) Microsecond(n interface{}) gotime.Duration {
+	return gotime.Microsecond * gotime.Duration(conv.ToInt64(n))
 }
 
 // Millisecond -
-func (f *TimeFuncs) Millisecond(n int64) gotime.Duration {
-	return gotime.Millisecond * gotime.Duration(n)
+func (f *TimeFuncs) Millisecond(n interface{}) gotime.Duration {
+	return gotime.Millisecond * gotime.Duration(conv.ToInt64(n))
 }
 
 // Second -
-func (f *TimeFuncs) Second(n int64) gotime.Duration {
-	return gotime.Second * gotime.Duration(n)
+func (f *TimeFuncs) Second(n interface{}) gotime.Duration {
+	return gotime.Second * gotime.Duration(conv.ToInt64(n))
 }
 
 // Minute -
-func (f *TimeFuncs) Minute(n int64) gotime.Duration {
-	return gotime.Minute * gotime.Duration(n)
+func (f *TimeFuncs) Minute(n interface{}) gotime.Duration {
+	return gotime.Minute * gotime.Duration(conv.ToInt64(n))
 }
 
 // Hour -
-func (f *TimeFuncs) Hour(n int64) gotime.Duration {
-	return gotime.Hour * gotime.Duration(n)
+func (f *TimeFuncs) Hour(n interface{}) gotime.Duration {
+	return gotime.Hour * gotime.Duration(conv.ToInt64(n))
 }
 
 // convert a number input to a pair of int64s, representing the integer portion and the decimal remainder

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -17,7 +17,10 @@ import (
 
 func testTemplate(g *gomplate, tmpl string) string {
 	var out bytes.Buffer
-	g.runTemplate(&tplate{name: "testtemplate", contents: tmpl, target: &out})
+	err := g.runTemplate(&tplate{name: "testtemplate", contents: tmpl, target: &out})
+	if err != nil {
+		panic(err)
+	}
 	return out.String()
 }
 


### PR DESCRIPTION
This relaxes the input types required for many functions where previously a `string` or `int64` was explicitly required. This is mainly for the use-case where functions need to be able to participate in a pipeline that doesn't produce exactly the right input.

This will now work, for example:

```console
$ gomplate -i '{{ conv.Bool 1 }} {{ time.Second "15" }}'
true 15s
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>