### PR TITLE
Preserve FileMode of input file when writing output file

### DIFF
--- a/gomplate.go
+++ b/gomplate.go
@@ -2,6 +2,7 @@ package gomplate
 
 import (
 	"io"
+	"os"
 	"text/template"
 
 	"github.com/hairyhenderson/gomplate/data"
@@ -29,6 +30,11 @@ type gomplate struct {
 	funcMap    template.FuncMap
 	leftDelim  string
 	rightDelim string
+}
+
+type outFile struct {
+	name string
+	mode os.FileMode
 }
 
 // runTemplate -

--- a/template_test.go
+++ b/template_test.go
@@ -189,9 +189,9 @@ func TestGatherTemplates(t *testing.T) {
 	fs = afero.NewMemMapFs()
 	afero.WriteFile(fs, "foo", []byte("bar"), 0644)
 
-	afero.WriteFile(fs, "in/1", []byte("foo"), 0644)
-	afero.WriteFile(fs, "in/2", []byte("bar"), 0644)
-	afero.WriteFile(fs, "in/3", []byte("baz"), 0644)
+	afero.WriteFile(fs, "in/1", []byte("foo"), 0744)
+	afero.WriteFile(fs, "in/2", []byte("bar"), 0754)
+	afero.WriteFile(fs, "in/3", []byte("baz"), 0640)
 
 	templates, err := gatherTemplates(&Config{})
 	assert.NoError(t, err)
@@ -221,4 +221,16 @@ func TestGatherTemplates(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, templates, 3)
 	assert.Equal(t, "foo", templates[0].contents)
+
+	f1Stat, err := fs.Stat("in/1")
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0744), f1Stat.Mode().Perm())
+
+	f2Stat, err := fs.Stat("in/2")
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0754), f2Stat.Mode().Perm())
+
+	f3Stat, err := fs.Stat("in/3")
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0640), f3Stat.Mode().Perm())
 }


### PR DESCRIPTION
Added the current files modes to be tracked though the gatherTemplates process, ensuring the current default of 644 if the input file is a string

Added tests for openOutFile and the full gatherTemplates