### PR TITLE
Adding new conv.Default function

### DIFF
--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -28,6 +28,24 @@ $ FOO=true gomplate < input.tmpl
 foo
 ```
 
+## `conv.Default`
+
+**Alias:** `default`
+
+Provides a default value given an empty input. Empty inputs are `0` for numeric
+types, `""` for strings, `false` for booleans, empty arrays/maps, and `nil`. 
+
+Note that this will not provide a default for the case where the input is undefined
+(i.e. referencing things like `.foo` where there is no `foo` field of `.`), but
+[`conv.Has`](#conv-has) can be used for that.
+
+#### Example
+
+```console
+$ gomplate -i '{{ "" | default "foo" }} {{ "bar" | default "baz" }}'
+foo bar
+```
+
 ## `conv.Slice`
 
 **Alias:** `slice`

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"net/url"
 	"sync"
+	"text/template"
 
 	"github.com/hairyhenderson/gomplate/conv"
 )
@@ -27,6 +28,7 @@ func AddConvFuncs(f map[string]interface{}) {
 	f["has"] = ConvNS().Has
 	f["slice"] = ConvNS().Slice
 	f["join"] = ConvNS().Join
+	f["default"] = ConvNS().Default
 }
 
 // ConvFuncs -
@@ -110,4 +112,12 @@ func (f *ConvFuncs) ToFloat64s(in ...interface{}) []float64 {
 // ToString -
 func (f *ConvFuncs) ToString(in interface{}) string {
 	return conv.ToString(in)
+}
+
+// Default -
+func (f *ConvFuncs) Default(def, in interface{}) interface{} {
+	if truth, ok := template.IsTrue(in); truth && ok {
+		return in
+	}
+	return def
 }

--- a/funcs/conv_test.go
+++ b/funcs/conv_test.go
@@ -1,0 +1,39 @@
+package funcs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault(t *testing.T) {
+	s := struct{}{}
+	c := ConvNS()
+	def := "DEFAULT"
+	data := []struct {
+		val   interface{}
+		empty bool
+	}{
+		{0, true},
+		{1, false},
+		{nil, true},
+		{"", true},
+		{"foo", false},
+		{[]string{}, true},
+		{[]string{"foo"}, false},
+		{[]string{""}, false},
+		{c, false},
+		{s, false},
+	}
+
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%T/%#v empty==%v", d.val, d.val, d.empty), func(t *testing.T) {
+			if d.empty {
+				assert.Equal(t, def, c.Default(def, d.val))
+			} else {
+				assert.Equal(t, d.val, c.Default(def, d.val))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #213 

Note that this will _not_ fix the case where the input is undefined (i.e. referencing things like `.foo` where there is no `foo` field of `.`), but `conv.Has` can still be used for that.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>