### PR TITLE
Adding basic metrics around template rendering

### DIFF
--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -167,4 +167,7 @@ func TestRunTemplates(t *testing.T) {
 	err := RunTemplates(config)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", buf.String())
+	assert.Equal(t, 1, Metrics.TemplatesGathered)
+	assert.Equal(t, 1, Metrics.TemplatesProcessed)
+	assert.Equal(t, 0, Metrics.Errors)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,24 @@
+package gomplate
+
+import "time"
+
+// Metrics tracks interesting basic metrics around gomplate executions. Warning: experimental!
+// This may change in breaking ways without warning. This is not subject to any semantic versioning guarantees!
+var Metrics *MetricsType
+
+// MetricsType - Warning: experimental! This may change in breaking ways without warning.
+// This is not subject to any semantic versioning guarantees!
+type MetricsType struct {
+	TemplatesGathered   int
+	TemplatesProcessed  int
+	Errors              int
+	GatherDuration      time.Duration            // time it took to gather templates
+	TotalRenderDuration time.Duration            // time it took to render all templates
+	RenderDuration      map[string]time.Duration // times for rendering each template
+}
+
+func newMetrics() *MetricsType {
+	return &MetricsType{
+		RenderDuration: make(map[string]time.Duration),
+	}
+}


### PR DESCRIPTION
This isn't (currently) used in gomplate itself, but I'd like to report this sort of information in tools that call gomplate programmatically.

This is intended to be an unstable API right now, so I'll be considering changes to this as automatically non-breaking.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>