### PR TITLE
Avoid closing stdout

### DIFF
--- a/gomplate.go
+++ b/gomplate.go
@@ -2,6 +2,7 @@ package gomplate
 
 import (
 	"io"
+	"os"
 	"text/template"
 	"time"
 
@@ -42,8 +43,10 @@ func (g *gomplate) runTemplate(t *tplate) error {
 
 	switch t.target.(type) {
 	case io.Closer:
-		// nolint: errcheck
-		defer t.target.(io.Closer).Close()
+		if t.target != os.Stdout {
+			// nolint: errcheck
+			defer t.target.(io.Closer).Close()
+		}
 	}
 	err = tmpl.Execute(t.target, context)
 	return err


### PR DESCRIPTION
Now that gomplate can more easily be called programmatically, we need to make sure it doesn't close `os.Stdout`!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>