### PR TITLE
Improving error handling for datasources

### DIFF
--- a/data/datasource_awssmp.go
+++ b/data/datasource_awssmp.go
@@ -1,11 +1,11 @@
 package data
 
 import (
-	"errors"
 	"path"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/pkg/errors"
 
 	gaws "github.com/hairyhenderson/gomplate/aws"
 )
@@ -45,9 +45,7 @@ func readAWSSMPParam(source *Source, paramPath string) ([]byte, error) {
 	response, err := source.ASMPG.GetParameter(input)
 
 	if err != nil {
-		logFatalf("Error reading aws+smp from AWS using GetParameter with input %v:\n%v",
-			input, err)
-		return nil, err
+		return nil, errors.Wrapf(err, "Error reading aws+smp from AWS using GetParameter with input %v", input)
 	}
 
 	result := *response.Parameter

--- a/data/datasource_awssmp_test.go
+++ b/data/datasource_awssmp_test.go
@@ -112,10 +112,6 @@ func TestAWSSMP_GetParameterMissing(t *testing.T) {
 		err: expectedErr,
 	})
 
-	defer restoreLogFatalf()
-	setupMockLogFatalf()
-	assert.Panics(t, func() {
-		readAWSSMP(s, "")
-	})
-	assert.Contains(t, spyLogFatalfMsg, "Test of error message")
+	_, err := readAWSSMP(s, "")
+	assert.Error(t, err, "Test of error message")
 }

--- a/gomplate.go
+++ b/gomplate.go
@@ -65,7 +65,10 @@ func newGomplate(d *data.Data, leftDelim, rightDelim string) *gomplate {
 func RunTemplates(o *Config) error {
 	Metrics = newMetrics()
 	defer runCleanupHooks()
-	d := data.NewData(o.DataSources, o.DataSourceHeaders)
+	d, err := data.NewData(o.DataSources, o.DataSourceHeaders)
+	if err != nil {
+		return err
+	}
 	addCleanupHook(d.Cleanup)
 
 	g := newGomplate(d, o.LDelim, o.RDelim)


### PR DESCRIPTION
Errors involving datasources (such as a missing or empty datasource) result in gomplate exiting with a message with little context. This improves the situation, as well removes (almost) the use of `log.Fatal`/`log.Fatalf`.

A few function signatures change (added `error` return value), but they're mostly intended for use in templates, where an `error` is OK (and handled by `text/template`).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>