### PR TITLE
Relaxing restriction on empty datasources

### DIFF
--- a/data/datasource.go
+++ b/data/datasource.go
@@ -238,9 +238,6 @@ func (d *Data) Datasource(alias string, args ...string) (interface{}, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "Couldn't read datasource '%s'", alias)
 	}
-	if len(b) == 0 {
-		return nil, errors.Errorf("No value found for %s from datasource '%s'", args, alias)
-	}
 	s := string(b)
 	if source.Type == jsonMimetype {
 		return JSON(s), nil
@@ -410,6 +407,9 @@ func readVault(source *Source, args ...string) ([]byte, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, errors.Errorf("no value found for path %s", p)
 	}
 	source.Type = "application/json"
 

--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -165,8 +165,9 @@ func TestDatasource(t *testing.T) {
 	test("yml", "application/yaml", []byte("hello:\n  cruel: world\n"))
 
 	d := setup("", "text/plain", nil)
-	_, err := d.Datasource("foo")
-	assert.Errorf(t, err, "No value found for")
+	actual, err := d.Datasource("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, "", actual)
 }
 
 func TestDatasourceExists(t *testing.T) {

--- a/test/integration/datasources_vault_test.go
+++ b/test/integration/datasources_vault_test.go
@@ -141,7 +141,7 @@ func (s *VaultDatasourcesSuite) TestTokenAuth(c *C) {
 			"VAULT_TOKEN=" + tok,
 		}
 	})
-	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "No value found for [bar] from datasource 'vault'"})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "error calling ds: Couldn't read datasource 'vault': no value found for path /secret/bar"})
 
 	tokFile := fs.NewFile(c, "test-vault-token", fs.WithContent(tok))
 	defer tokFile.Remove()


### PR DESCRIPTION
Back when #200 was fixed (in #201), the assumption was made that if the data from the datasource was empty (i.e. an empty `[]byte`), then this was an error condition and gomplate should effectively stop processing the datasource.

It turns out that this was actually a regression, and there are valid scenarios for having empty datasources - maybe a file is empty, and _should_ be able to be parsed (like in #311).

I've re-thought this approach, and instead of being so heavy-handed, I'll allow empty datasources. In the specific Vault case (from #200), I'll simply return an `error` like I should've in the first place!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>