### PR TITLE
Add ability to generate checksums of binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,17 @@ $(PREFIX)/bin/$(PKG_NAME)_%-slim: $(PREFIX)/bin/$(PKG_NAME)_%
 $(PREFIX)/bin/$(PKG_NAME)_%-slim.exe: $(PREFIX)/bin/$(PKG_NAME)_%.exe
 	upx --lzma $< -o $@
 
+$(PREFIX)/bin/$(PKG_NAME)_%_checksum.txt: $(PREFIX)/bin/$(PKG_NAME)_%
+	@sha256sum $< > $@
+
+$(PREFIX)/bin/checksums.txt: \
+		$(patsubst %,$(PREFIX)/bin/$(PKG_NAME)_%_checksum.txt,$(platforms)) \
+		$(patsubst %,$(PREFIX)/bin/$(PKG_NAME)_%_checksum.txt,$(compressed-platforms))
+	@cat $^ > $@
+
+$(PREFIX)/bin/checksums-signed.txt: $(PREFIX)/bin/checksums.txt
+	@keybase sign < $< > $@
+
 compress: $(PREFIX)/bin/$(PKG_NAME)_$(GOOS)-$(GOARCH)-slim$(call extension,$(GOOS))
 	cp $< $(PREFIX)/bin/$(PKG_NAME)-slim$(call extension,$(GOOS))
 


### PR DESCRIPTION
Fixes #318 

The next release of gomplate will have `checksums.txt` and `checksums.txt.signed` available for verifying the binaries.

Note: to verify the signed file, `keybase verify < checksums.txt.signed` - should confirm that I ([dhenderson](https://keybase.io/dhenderson) on [keybase](https://keybase.io/)) created the checksums file, and therefore built and uploaded the binaries.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>