### PR TITLE
Adding strings.TrimSuffix and strings.Repeat

### DIFF
--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -164,6 +164,29 @@ foo
 bar:baz
 ```
 
+## `strings.Repeat`
+
+Returns a new string consisting of `count` copies of the input string.
+
+It errors if `count` is negative or if the length of `input` multiplied by `count` overflows.
+
+This wraps Go's [`strings.Repeat`](https://golang.org/pkg/strings/#Repeat).
+
+### Usage
+```go
+strings.Repeat count input
+```
+```go
+input | strings.Repeat count
+```
+
+#### Example
+
+```console
+$ gomplate -i '{{ "hello, world" | strings.Repeat "world" }}jello'
+hello, jello
+```
+
 ## `strings.ReplaceAll`
 
 **Alias:** `replaceAll`
@@ -311,6 +334,28 @@ input | strings.TrimSpace
 ```console
 $ gomplate -i '{{ "  \n\t foo" | strings.TrimSpace }}'
 foo
+```
+
+
+## `strings.TrimSuffix`
+
+Returns a string without the provided trailing suffix string, if the suffix is present.
+
+This wraps Go's [`strings.TrimSuffix`](https://golang.org/pkg/strings/#TrimSuffix).
+
+### Usage
+```go
+strings.TrimSuffix suffix input
+```
+```go
+input | strings.TrimSuffix suffix
+```
+
+#### Example
+
+```console
+$ gomplate -i '{{ "hello, world" | strings.TrimSuffix "world" }}jello'
+hello, jello
 ```
 
 ## `contains`

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/pkg/errors"
 
 	"strings"
 
@@ -70,6 +71,18 @@ func (f *StringFuncs) HasSuffix(suffix string, s interface{}) bool {
 	return strings.HasSuffix(conv.ToString(s), suffix)
 }
 
+// Repeat -
+func (f *StringFuncs) Repeat(count int, s interface{}) (string, error) {
+	if count < 0 {
+		return "", errors.Errorf("negative count %d", count)
+	}
+	str := conv.ToString(s)
+	if count > 0 && len(str)*count/count != len(str) {
+		return "", errors.Errorf("count %d too long: causes overflow", count)
+	}
+	return strings.Repeat(str, count), nil
+}
+
 // Split -
 func (f *StringFuncs) Split(sep string, s interface{}) []string {
 	return strings.Split(conv.ToString(s), sep)
@@ -88,6 +101,11 @@ func (f *StringFuncs) Trim(cutset string, s interface{}) string {
 // TrimPrefix -
 func (f *StringFuncs) TrimPrefix(cutset string, s interface{}) string {
 	return strings.TrimPrefix(conv.ToString(s), cutset)
+}
+
+// TrimSuffix -
+func (f *StringFuncs) TrimSuffix(cutset string, s interface{}) string {
+	return strings.TrimSuffix(conv.ToString(s), cutset)
 }
 
 // Title -

--- a/test/integration/strings_test.go
+++ b/test/integration/strings_test.go
@@ -29,3 +29,17 @@ func (s *StringsSuite) TestIndent(c *C) {
     hello
      world`})
 }
+
+func (s *StringsSuite) TestRepeat(c *C) {
+	result := icmd.RunCommand(GomplateBin, "-i",
+		`ba{{ strings.Repeat 2 "na" }}`)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: `banana`})
+
+	result = icmd.RunCommand(GomplateBin, "-i",
+		`ba{{ strings.Repeat 9223372036854775807 "na" }}`)
+	result.Assert(c, icmd.Expected{ExitCode: 1, Out: `too long: causes overflow`})
+
+	result = icmd.RunCommand(GomplateBin, "-i",
+		`ba{{ strings.Repeat -1 "na" }}`)
+	result.Assert(c, icmd.Expected{ExitCode: 1, Out: `negative count`})
+}


### PR DESCRIPTION
Wrapping two more functions from `strings`.

Had to adapt `strings.Repeat` a bit so that it won't panic!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>