### PR TITLE
Adding more math functions

### DIFF
--- a/docs/content/functions/math.md
+++ b/docs/content/functions/math.md
@@ -9,13 +9,7 @@ A set of basic math functions to be able to perform simple arithmetic operations
 
 ### Supported input
 
-_**Note:** currently, `gomplate` supports only integer arithmetic. All functions
-return 64-bit integers (`int64` type). Floating point support will be added in
-later releases._
-
-In general, any input will be converted to the correct input type by the various
-functions in this package. For integer-based functions, floating-point inputs will
-be truncated (not rounded).
+In general, any input will be converted to the correct input type by the various functions in this package, and an appropriately-typed value will be returned type. Special cases are documented.
 
 In addition to regular base-10 numbers, integers can be
 [specified](https://golang.org/ref/spec#Integer_literals) as octal (prefix with
@@ -31,15 +25,37 @@ $ NUM=50 gomplate -i '{{ div (getenv "NUM") 10 }}'
 5
 $ gomplate -i '{{ add "0x2" "02" "2.0" "2e0" }}'
 8
-$ gomplate -i '{{ add 2.5 2.5 }}' # decimals are truncated!
-4
+$ gomplate -i '{{ add 2.5 2.5 }}'
+5.0
+```
+
+## `math.Abs`
+
+Returns the absolute value of a given number. When the input is an integer, , the result will be an `int64`, otherwise it will be an `float64`.
+
+### Usage
+```go
+math.Abs num
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `num`  | _(required)_ The input number |
+
+### Examples
+
+```console
+$ gomplate -i '{{ math.Abs -3.5 }} {{ math.Abs 3.5 }} {{ math.Abs -42 }}'
+3.5 3.5 42
 ```
 
 ## `math.Add`
 
 **Alias:** `add`
 
-Adds all given operators.
+Adds all given operators. When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
 
 ### Usage
 ```go
@@ -52,29 +68,209 @@ x | math.Add.Add n...
 ### Example
 
 ```console
-$ gomplate -i '{{ math.Add 1 2 3 4 }}
-10
+$ gomplate -i '{{ math.Add 1 2 3 4 }} {{ math.Add 1.5 2 3 }}'
+10 6.5
 ```
 
-## `math.Sub`
+## `math.Ceil`
 
-**Alias:** `sub`
+Returns the least integer value greater than or equal to a given floating-point number. This wraps Go's [`math.Ceil`](https://golang.org/pkg/math/#Ceil).
 
-Subtract the second from the first of the given operators.
+**Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
 ### Usage
 ```go
-math.Sub a b
+math.Ceil num
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
+
+### Examples
+
+```console
+$ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}ceil {{ printf "%#v" . }} = {{ math.Ceil . }}{{"\n"}}{{ end }}' 
+ceil 5.1 = 6
+ceil 42 = 42
+ceil "3.14" = 4
+ceil "0xFF" = 255
+ceil "NaN" = NaN
+ceil "Inf" = +Inf
+ceil "-0" = 0
+```
+
+## `math.Div`
+
+**Alias:** `div`
+
+Divide the first number by the second. Division by zero is disallowed. The result will be a `float64`.
+
+### Usage
+```go
+math.Div a b
 ```
 ```go
-b | math.Sub a
+b | math.Div a
 ```
 
 ### Example
 
 ```console
-$ gomplate -i '{{ math.Sub 3 1 }}'
-2
+$ gomplate -i '{{ math.Div 8 2 }} {{ math.Div 3 2 }}'
+4 1.5
+```
+
+## `math.Floor`
+
+Returns the greatest integer value less than or equal to a given floating-point number. This wraps Go's [`math.Floor`](https://golang.org/pkg/math/#Floor).
+
+**Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
+
+### Usage
+```go
+math.Floor num
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
+
+### Examples
+
+```console
+$ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}floor {{ printf "%#v" . }} = {{ math.Floor . }}{{"\n"}}{{ end }}'
+floor 5.1 = 4
+floor 42 = 42
+floor "3.14" = 3
+floor "0xFF" = 255
+floor "NaN" = NaN
+floor "Inf" = +Inf
+floor "-0" = 0
+```
+
+## `math.IsFloat`
+
+Returns whether or not the given number can be interpreted as a floating-point literal, as defined by the [Go language reference](https://golang.org/ref/spec#Floating-point_literals).
+
+**Note:** If a decimal point is part of the input number, it will be considered a floating-point number, even if the decimal is `0`.
+
+### Usage
+```go
+math.IsFloat num
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `num` | _(required)_ The value to test |
+
+### Examples
+
+```console
+$ gomplate -i '{{ range (slice 1.0 "-1.0" 5.1 42 "3.14" "foo" "0xFF" "NaN" "Inf" "-0") }}{{ if (math.IsFloat .) }}{{.}} is a float{{"\n"}}{{ end }}{{end}}'
+1 is a float
+-1.0 is a float
+5.1 is a float
+3.14 is a float
+NaN is a float
+Inf is a float
+```
+
+## `math.IsInt`
+
+Returns whether or not the given number is an integer.
+Returns whether or not the given number can be interpreted as a floating-point literal, as defined by the [Go language reference](https://golang.org/ref/spec#Integer_literals).
+
+### Usage
+```go
+math.IsInt num
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `num` | _(required)_ The value to test |
+
+### Examples
+
+```console
+$ gomplate -i '{{ range (slice 1.0 "-1.0" 5.1 42 "3.14" "foo" "0xFF" "NaN" "Inf" "-0") }}{{ if (math.IsInt .) }}{{.}} is an integer{{"\n"}}{{ end }}{{end}}'
+42 is an integer
+0xFF is an integer
+-0 is an integer
+```
+
+## `math.IsNum`
+
+Returns whether the given input is a number. Useful for `if` conditions.
+
+### Usage
+```go
+math.IsNum in
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `in` | _(required)_ The value to test |
+
+### Examples
+
+```console
+$ gomplate -i '{{ math.IsNum "foo" }} {{ math.IsNum 0xDeadBeef }}'
+false true
+```
+
+## `math.Max`
+
+Returns the largest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Max`](https://golang.org/pkg/math/#Max) are followed.
+
+### Usage
+```go
+math.Max nums...
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `nums` | _(required)_ One or more numbers to compare |
+
+### Examples
+
+```console
+$ gomplate -i '{{ math.Max 0 8.0 4.5 "-1.5e-11" }}'
+8
+```
+
+## `math.Min`
+
+Returns the smallest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Min`](https://golang.org/pkg/math/#Min) are followed.
+
+### Usage
+```go
+math.Min nums...
+```
+
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `nums` | _(required)_ One or more numbers to compare |
+
+### Examples
+
+```console
+$ gomplate -i '{{ math.Min 0 8 4.5 "-1.5e-11" }}'
+-1.5e-11
 ```
 
 ## `math.Mul`
@@ -98,25 +294,29 @@ $ gomplate -i '{{ math.Mul 8 8 2 }}'
 128
 ```
 
-## `math.Div`
+## `math.Pow`
 
-**Alias:** `div`
+**Alias:** `pow`
 
-Divide the first number by the second. Division by zero is disallowed.
+Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://golang.org/pkg/math/#Pow). If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned.
 
 ### Usage
 ```go
-math.Div a b
+math.Pow b n
 ```
 ```go
-b | math.Div a
+n | math.Pow b
 ```
 
 ### Example
 
 ```console
-$ gomplate -i '{{ math.Div 8 2 }}'
-4
+$ gomplate -i '{{ math.Pow 10 2 }}'
+100
+$ gomplate -i '{{ math.Pow 2 32 }}'
+4294967296
+$ gomplate -i '{{ math.Pow 1.5 2 }}'
+2.2
 ```
 
 ## `math.Rem`
@@ -142,27 +342,32 @@ $ gomplate -i '{{ math.Rem -5 3 }}'
 -2
 ```
 
-## `math.Pow`
+## `math.Round`
 
-**Alias:** `pow`
+Returns the nearest integer, rounding half away from zero.
 
-Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://golang.org/pkg/math/#Pow).
+**Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
 ### Usage
 ```go
-math.Pow b n
-```
-```go
-n | math.Pow b
+math.Round num
 ```
 
-### Example
+### Arguments
+
+| name   | description |
+|--------|-------|
+| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
+
+### Examples
 
 ```console
-$ gomplate -i '{{ math.Pow 10 2 }}'
-100
-$ gomplate -i '{{ math.Pow 2 32 }}'
-4294967296
+$ gomplate -i '{{ range (slice -6.5 5.1 42.9 "3.5" 6.5) }}round {{ printf "%#v" . }} = {{ math.Round . }}{{"\n"}}{{ end }}'
+round -6.5 = -7
+round 5.1 = 5
+round 42.9 = 43
+round "3.5" = 4
+round 6.5 = 7
 ```
 
 ## `math.Seq`
@@ -197,4 +402,25 @@ $ gomplate -i '{{ range (math.Seq 5) }}{{.}} {{end}}'
 ```console
 $ gomplate -i '{{ conv.Join (math.Seq 10 -3 2) ", " }}'
 10, 8, 6, 4, 2, 0, -2
+```
+
+## `math.Sub`
+
+**Alias:** `sub`
+
+Subtract the second from the first of the given operators.  When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
+
+### Usage
+```go
+math.Sub a b
+```
+```go
+b | math.Sub a
+```
+
+### Example
+
+```console
+$ gomplate -i '{{ math.Sub 3 1 }}'
+2
 ```

--- a/funcs/math_test.go
+++ b/funcs/math_test.go
@@ -1,6 +1,8 @@
 package funcs
 
 import (
+	"fmt"
+	gmath "math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +14,7 @@ func TestAdd(t *testing.T) {
 	assert.Equal(t, int64(2), m.Add(1, 1))
 	assert.Equal(t, int64(1), m.Add(1))
 	assert.Equal(t, int64(0), m.Add(-5, 5))
+	assert.InDelta(t, float64(5.1), m.Add(4.9, "0.2"), 0.000000001)
 }
 
 func TestMul(t *testing.T) {
@@ -21,6 +24,7 @@ func TestMul(t *testing.T) {
 	assert.Equal(t, int64(1), m.Mul(1))
 	assert.Equal(t, int64(-25), m.Mul("-5", 5))
 	assert.Equal(t, int64(28), m.Mul(14, "2"))
+	assert.Equal(t, float64(0.5), m.Mul("-1", -0.5))
 }
 
 func TestSub(t *testing.T) {
@@ -28,9 +32,10 @@ func TestSub(t *testing.T) {
 	assert.Equal(t, int64(0), m.Sub(1, 1))
 	assert.Equal(t, int64(-10), m.Sub(-5, 5))
 	assert.Equal(t, int64(-41), m.Sub(true, "42"))
+	assert.InDelta(t, -5.3, m.Sub(10, 15.3), 0.000000000000001)
 }
 
-func mustDiv(a, b interface{}) int64 {
+func mustDiv(a, b interface{}) interface{} {
 	m := MathNS()
 	r, err := m.Div(a, b)
 	if err != nil {
@@ -43,9 +48,10 @@ func TestDiv(t *testing.T) {
 	m := MathNS()
 	_, err := m.Div(1, 0)
 	assert.Error(t, err)
-	assert.Equal(t, int64(1), mustDiv(1, 1))
-	assert.Equal(t, int64(-1), mustDiv(-5, 5))
-	assert.Equal(t, int64(0), mustDiv(true, "42"))
+	assert.Equal(t, 1., mustDiv(1, 1))
+	assert.Equal(t, -1., mustDiv(-5, 5))
+	assert.Equal(t, 1./42, mustDiv(true, "42"))
+	assert.InDelta(t, 0.5, mustDiv(1, 2), 1e-12)
 }
 
 func TestRem(t *testing.T) {
@@ -57,6 +63,7 @@ func TestRem(t *testing.T) {
 func TestPow(t *testing.T) {
 	m := MathNS()
 	assert.Equal(t, int64(4), m.Pow(2, "2"))
+	assert.Equal(t, 2.25, m.Pow(1.5, 2))
 }
 
 func mustSeq(n ...interface{}) []int64 {
@@ -76,4 +83,243 @@ func TestSeq(t *testing.T) {
 	assert.EqualValues(t, []int64{0}, mustSeq(0, 5, 8))
 	_, err := m.Seq()
 	assert.Error(t, err)
+}
+
+func TestIsIntFloatNum(t *testing.T) {
+	tests := []struct {
+		in      interface{}
+		isInt   bool
+		isFloat bool
+	}{
+		{0, true, false},
+		{1, true, false},
+		{-1, true, false},
+		{uint(42), true, false},
+		{uint8(255), true, false},
+		{uint16(42), true, false},
+		{uint32(42), true, false},
+		{uint64(42), true, false},
+		{int(42), true, false},
+		{int8(127), true, false},
+		{int16(42), true, false},
+		{int32(42), true, false},
+		{int64(42), true, false},
+		{float32(18.3), false, true},
+		{float64(18.3), false, true},
+		{1.5, false, true},
+		{-18.6, false, true},
+		{"42", true, false},
+		{"052", true, false},
+		{"0xff", true, false},
+		{"-42", true, false},
+		{"-0", true, false},
+		{"3.14", false, true},
+		{"-3.14", false, true},
+		{"0.00", false, true},
+		{"NaN", false, true},
+		{"-Inf", false, true},
+		{"+Inf", false, true},
+		{"", false, false},
+		{"foo", false, false},
+		{nil, false, false},
+		{true, false, false},
+	}
+	m := MathNS()
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%T(%#v)", tt.in, tt.in), func(t *testing.T) {
+			assert.Equal(t, tt.isInt, m.IsInt(tt.in))
+			assert.Equal(t, tt.isFloat, m.IsFloat(tt.in))
+			assert.Equal(t, tt.isInt || tt.isFloat, m.IsNum(tt.in))
+		})
+	}
+}
+
+func BenchmarkIsFloat(b *testing.B) {
+	data := []interface{}{
+		0, 1, -1, uint(42), uint8(255), uint16(42), uint32(42), uint64(42), int(42), int8(127), int16(42), int32(42), int64(42), float32(18.3), float64(18.3), 1.5, -18.6, "42", "052", "0xff", "-42", "-0", "3.14", "-3.14", "0.00", "NaN", "-Inf", "+Inf", "", "foo", nil, true,
+	}
+	m := MathNS()
+	for _, n := range data {
+		b.Run(fmt.Sprintf("%T(%v)", n, n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				m.IsFloat(n)
+			}
+		})
+	}
+}
+
+func TestMax(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n        []interface{}
+		expected interface{}
+	}{
+		{[]interface{}{nil}, int64(0)},
+		{[]interface{}{0}, int64(0)},
+		{[]interface{}{"not a number"}, int64(0)},
+		{[]interface{}{1}, int64(1)},
+		{[]interface{}{-1}, int64(-1)},
+		{[]interface{}{-1, 0, 1}, int64(1)},
+		{[]interface{}{3.14, 3, 3.9}, 3.9},
+		{[]interface{}{"14", "0xff", -5}, int64(255)},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%v==%v", d.n, d.expected), func(t *testing.T) {
+			var actual interface{}
+			if len(d.n) == 1 {
+				actual, _ = m.Max(d.n[0])
+			} else {
+				actual, _ = m.Max(d.n[0], d.n[1:]...)
+			}
+			assert.Equal(t, d.expected, actual)
+		})
+	}
+}
+
+func TestMin(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n        []interface{}
+		expected interface{}
+	}{
+		{[]interface{}{nil}, int64(0)},
+		{[]interface{}{0}, int64(0)},
+		{[]interface{}{"not a number"}, int64(0)},
+		{[]interface{}{1}, int64(1)},
+		{[]interface{}{-1}, int64(-1)},
+		{[]interface{}{-1, 0, 1}, int64(-1)},
+		{[]interface{}{3.14, 3, 3.9}, 3.},
+		{[]interface{}{"14", "0xff", -5}, int64(-5)},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%v==%v", d.n, d.expected), func(t *testing.T) {
+			var actual interface{}
+			if len(d.n) == 1 {
+				actual, _ = m.Min(d.n[0])
+			} else {
+				actual, _ = m.Min(d.n[0], d.n[1:]...)
+			}
+			assert.Equal(t, d.expected, actual)
+		})
+	}
+}
+
+func TestContainsFloat(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n        []interface{}
+		expected bool
+	}{
+		{[]interface{}{nil}, false},
+		{[]interface{}{0}, false},
+		{[]interface{}{"not a number"}, false},
+		{[]interface{}{1}, false},
+		{[]interface{}{-1}, false},
+		{[]interface{}{-1, 0, 1}, false},
+		{[]interface{}{3.14, 3, 3.9}, true},
+		{[]interface{}{"14", "0xff", -5}, false},
+		{[]interface{}{"14.8", "0xff", -5}, true},
+		{[]interface{}{"-Inf", 2}, true},
+		{[]interface{}{"NaN"}, true},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%v==%v", d.n, d.expected), func(t *testing.T) {
+			if d.expected {
+				assert.True(t, m.containsFloat(d.n...))
+			} else {
+				assert.False(t, m.containsFloat(d.n...))
+			}
+		})
+	}
+}
+
+func TestCeil(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n interface{}
+		a float64
+	}{
+		{"", 0.},
+		{nil, 0.},
+		{"Inf", gmath.Inf(1)},
+		{0, 0.},
+		{4.99, 5.},
+		{42.1, 43},
+		{-1.9, -1},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%v==%v", d.n, d.a), func(t *testing.T) {
+			assert.InDelta(t, d.a, m.Ceil(d.n), 1e-12)
+		})
+	}
+}
+
+func TestFloor(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n interface{}
+		a float64
+	}{
+		{"", 0.},
+		{nil, 0.},
+		{"Inf", gmath.Inf(1)},
+		{0, 0.},
+		{4.99, 4.},
+		{42.1, 42},
+		{-1.9, -2.},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%v==%v", d.n, d.a), func(t *testing.T) {
+			assert.InDelta(t, d.a, m.Floor(d.n), 1e-12)
+		})
+	}
+}
+
+func TestRound(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n interface{}
+		a float64
+	}{
+		{"", 0.},
+		{nil, 0.},
+		{"Inf", gmath.Inf(1)},
+		{0, 0.},
+		{4.99, 5},
+		{42.1, 42},
+		{-1.9, -2.},
+		{3.5, 4},
+		{-3.5, -4},
+		{4.5, 5},
+		{-4.5, -5},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%v==%v", d.n, d.a), func(t *testing.T) {
+			assert.InDelta(t, d.a, m.Round(d.n), 1e-12)
+		})
+	}
+}
+
+func TestAbs(t *testing.T) {
+	m := MathNS()
+	data := []struct {
+		n interface{}
+		a interface{}
+	}{
+		{"", 0.},
+		{nil, 0.},
+		{"-Inf", gmath.Inf(1)},
+		{0, int64(0)},
+		{0., 0.},
+		{gmath.Copysign(0, -1), 0.},
+		{3.14, 3.14},
+		{-1.9, 1.9},
+		{2, int64(2)},
+		{-2, int64(2)},
+	}
+	for _, d := range data {
+		t.Run(fmt.Sprintf("%#v==%v", d.n, d.a), func(t *testing.T) {
+			assert.Equal(t, d.a, m.Abs(d.n))
+		})
+	}
 }

--- a/test/integration/math_test.go
+++ b/test/integration/math_test.go
@@ -15,8 +15,13 @@ func (s *MathSuite) TestMath(c *C) {
 	inOutTest(c, `{{ math.Add 1 2 3 4 }} {{ add -5 5 }}`, "10 0")
 	inOutTest(c, `{{ math.Sub 10 5 }} {{ sub -5 5 }}`, "5 -10")
 	inOutTest(c, `{{ math.Mul 1 2 3 4 }} {{ mul -5 5 }}`, "24 -25")
-	inOutTest(c, `{{ math.Div 5 3 }} {{ div -5 5 }}`, "1 -1")
+	inOutTest(c, `{{ math.Div 5 2 }} {{ div -5 5 }}`, "2.5 -1")
 	inOutTest(c, `{{ math.Rem 5 3 }} {{ rem 2 2 }}`, "2 0")
 	inOutTest(c, `{{ math.Pow 8 4 }} {{ pow 2 2 }}`, "4096 4")
-	inOutTest(c, `{{ math.Seq 0 }}, {{ seq 0 3 }}, {{ seq -5 -10 2 }}`, "[1 0], [0 1 2 3], [-5 -7 -9]")
+	inOutTest(c, `{{ math.Seq 0 }}, {{ seq 0 3 }}, {{ seq -5 -10 2 }}`,
+		`[1 0], [0 1 2 3], [-5 -7 -9]`)
+	inOutTest(c, `{{ math.Round 0.99 }}, {{ math.Round "foo" }}, {{math.Round 3.5}}`,
+		`1, 0, 4`)
+	inOutTest(c, `{{ math.Max -0 "+Inf" "NaN" }}, {{ math.Max 3.4 3.401 3.399 }}`,
+		`+Inf, 3.401`)
 }


### PR DESCRIPTION
More functions in the `math` namespace:

- `math.Abs`
- `math.IsInt`
- `math.IsFloat`
- `math.IsNum`
- `math.Max`
- `math.Min`
- `math.Ceil`
- `math.Floor`
- `math.Round`

Most other functions now also support floating-point arithmetic if at least one of the inputs is a float.

Plus, all functions return an `interface{}` instead of an explicit `int64` (or `float64`).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>