### PR TITLE
Adding env datasource

### DIFF
--- a/data/datasource_env.go
+++ b/data/datasource_env.go
@@ -1,0 +1,23 @@
+package data
+
+import (
+	"strings"
+
+	"github.com/hairyhenderson/gomplate/env"
+)
+
+func init() {
+	addSourceReader("env", readEnv)
+}
+
+func readEnv(source *Source, args ...string) (b []byte, err error) {
+	n := source.URL.Path
+	n = strings.TrimPrefix(n, "/")
+	if n != "" {
+	} else if n == "" {
+		n = source.URL.Opaque
+	}
+
+	b = []byte(env.Getenv(n))
+	return b, nil
+}

--- a/data/datasource_env_test.go
+++ b/data/datasource_env_test.go
@@ -1,0 +1,52 @@
+package data
+
+import (
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustParseURL(in string) *url.URL {
+	u, _ := url.Parse(in)
+	return u
+}
+
+func TestReadEnv(t *testing.T) {
+	content := []byte(`hello world`)
+	os.Setenv("HELLO_WORLD", "hello world")
+	defer os.Unsetenv("HELLO_WORLD")
+	os.Setenv("HELLO_UNIVERSE", "hello universe")
+	defer os.Unsetenv("HELLO_UNIVERSE")
+
+	source, _ := NewSource("foo", mustParseURL("env:HELLO_WORLD"))
+
+	actual, err := readEnv(source)
+	assert.NoError(t, err)
+	assert.Equal(t, content, actual)
+
+	source, _ = NewSource("foo", mustParseURL("env:/HELLO_WORLD"))
+
+	actual, err = readEnv(source)
+	assert.NoError(t, err)
+	assert.Equal(t, content, actual)
+
+	source, _ = NewSource("foo", mustParseURL("env:///HELLO_WORLD"))
+
+	actual, err = readEnv(source)
+	assert.NoError(t, err)
+	assert.Equal(t, content, actual)
+
+	source, _ = NewSource("foo", mustParseURL("env:HELLO_WORLD?foo=bar"))
+
+	actual, err = readEnv(source)
+	assert.NoError(t, err)
+	assert.Equal(t, content, actual)
+
+	source, _ = NewSource("foo", mustParseURL("env:///HELLO_WORLD?foo=bar"))
+
+	actual, err = readEnv(source)
+	assert.NoError(t, err)
+	assert.Equal(t, content, actual)
+}

--- a/data/datasource_file_test.go
+++ b/data/datasource_file_test.go
@@ -3,18 +3,12 @@
 package data
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/blang/vfs"
 	"github.com/blang/vfs/memfs"
 	"github.com/stretchr/testify/assert"
 )
-
-func mustParseURL(in string) *url.URL {
-	u, _ := url.Parse(in)
-	return u
-}
 
 func TestReadFile(t *testing.T) {
 	content := []byte(`hello world`)

--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -42,6 +42,7 @@ Gomplate supports a number of datasources, each specified with a particular URL 
 | [AWS Systems Manager Parameter Store](#using-aws-smp-datasources) | `aws+smp` | [AWS Systems Manager Parameter Store][AWS SMP] is a hierarchically-organized key/value store which allows storage of text, lists, or encrypted secrets for retrieval by AWS resources |
 | [BoltDB](#using-boltdb-datasources) | `boltdb` | [BoltDB][] is a simple local key/value store used by many Go tools |
 | [Consul](#using-consul-datasources) | `consul`, `consul+http`, `consul+https` | [HashiCorp Consul][] provides (among many other features) a key/value store |
+| [Environment](#using-env-datasources) | `env` | Environment variables can be used as datasources - useful for testing |
 | [File](#using-file-datasources) | `file` | Files can be read in any of the [supported formats](#supported-formats), including by piping through standard input (`Stdin`) |
 | [HTTP](#using-http-datasources) | `http`, `https` | Data can be sourced from HTTP/HTTPS sites in many different formats. Arbitrary HTTP headers can be set with the [`--datasource-header`/`-H`][] flag |
 | [Stdin](#using-stdin-datasources) | `stdin` | A special case of the `file` datasource; allows piping through standard input (`Stdin`) |
@@ -224,6 +225,35 @@ value for foo/bar key
 
 $ gomplate -d consul=consul:///foo -i '{{(datasource "consul" "bar/baz")}}'
 value for foo/bar/baz key
+```
+
+## Using `env` datasources
+
+The `env` datasource type provides access to environment variables. This can be useful for rendering templates that would normally use a different sort of datasource, in test and development scenarios.
+
+No hierarchy or directory semantics are currently supported.
+
+**Note:** Variable names are _case-sensitive!_
+
+### URL Considerations
+
+The _scheme_ and either the _path_ or the _opaque_ part are used, and the _query_ component can be used to [override the MIME type](#overriding-mime-types).
+
+- the _scheme_ must be `env`
+- one of the _path_ or _opaque_ component is required, and is interpreted as the environment variable's name. Leading `/` characters are stripped from the _path_.
+
+### Examples
+
+```console
+$ gomplate -d user=env:USER -i 'Hello {{ include "user" }}!'
+Hello hairyhenderson!
+
+$ gomplate -d homedir=env:///HOME -i '{{ files.IsDir (ds "homedir") }}'
+true
+
+$ export foo='{"one":1, "two":2}'
+$ gomplate -d foo=env:/foo?type=application/json -i '{{ (ds "foo").two }}'
+2
 ```
 
 ## Using `file` datasources

--- a/test/integration/datasources_env_test.go
+++ b/test/integration/datasources_env_test.go
@@ -1,0 +1,57 @@
+//+build integration
+//+build !windows
+
+package integration
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/gotestyourself/gotestyourself/fs"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+type EnvDatasourcesSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&EnvDatasourcesSuite{})
+
+func (s *EnvDatasourcesSuite) SetUpSuite(c *C) {
+	os.Setenv("HELLO_WORLD", "hello world")
+	os.Setenv("HELLO_UNIVERSE", "hello universe")
+	os.Setenv("FOO", "bar")
+	os.Setenv("foo", "baz")
+}
+
+func (s *EnvDatasourcesSuite) TearDownSuite(c *C) {
+	os.Unsetenv("HELLO_WORLD")
+	os.Unsetenv("HELLO_UNIVERSE")
+	os.Unsetenv("FOO")
+	os.Unsetenv("foo")
+}
+
+func (s *EnvDatasourcesSuite) TestEnvDatasources(c *C) {
+	result := icmd.RunCommand(GomplateBin,
+		"-d", "foo=env:FOO",
+		"-i", `{{ ds "foo" }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar"})
+
+	result = icmd.RunCommand(GomplateBin,
+		"-d", "foo=env:///foo",
+		"-i", `{{ ds "foo" }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "baz"})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"-d", "e=env:json_value?type=application/json",
+		"-i", `{{ (ds "e").value}}`,
+	), func(c *icmd.Cmd) {
+		c.Env = []string{
+			`json_value={"value":"corge"}`,
+		}
+	})
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "corge"})
+}


### PR DESCRIPTION
A simple `env` datasource, mostly for test/dev. Could support directory semantics - `env:/` could return an array of all variable names, or `env:///FOO_/` could list vars with the prefix `FOO_`, or maybe glob semantics could be added instead (`env:FOO_*`). For now, this is just simple direct references.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>