### PR TITLE
Allowing datasources to be defined dynamically

### DIFF
--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -9,7 +9,9 @@ A collection of functions that retrieve, parse, and convert structured data.
 
 ## `datasource`
 
-Parses a given datasource (provided by the [`--datasource/-d`](#--datasource-d) argument).
+Parses a given datasource (provided by the [`--datasource/-d`](#--datasource-d) argument or [`defineDatasource`](#definedatasource)).
+
+If the `alias` is undefined, but is a valid URL, `datasource` will dynamically read from that URL. 
 
 See [Datasources](../../datasources) for (much!) more information.
 
@@ -23,7 +25,7 @@ datasource alias [subpath]
 
 | name   | description |
 |--------|-------|
-| `alias` | the datasource alias, as provided by [`--datasource`/`-d`](../usage/#datasource-d) |
+| `alias` | the datasource alias (or a URL for dynamic use) |
 | `subpath` | _(optional)_ the subpath to use, if supported by the datasource |
 
 ### Examples

--- a/test/integration/datasources_http_test.go
+++ b/test/integration/datasources_http_test.go
@@ -42,4 +42,8 @@ func (s *DatasourcesHTTPSuite) TestReportsVersion(c *C) {
 		"-H", "foo=Foo:bar",
 		"-i", "{{defineDatasource `foo` `http://"+s.l.Addr().String()+"/`}}{{ index (ds `foo`).headers.Foo 0 }}")
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar"})
+
+	result = icmd.RunCommand(GomplateBin,
+		"-i", "{{ $d := ds `http://"+s.l.Addr().String()+"/`}}{{ index (index $d.headers `Accept-Encoding`) 0 }}")
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "gzip"})
 }


### PR DESCRIPTION
Fixes #349 

Allows `datasource`/`ds` to be given a URL instead of an alias, for situations (like when ranging through a directory datasource) when the URL either can't be known in advance, or is awkward to specify in advance.

Behind the scenes, a new datasource is created dynamically, with the URL as the alias. This means the data is cached for multiple uses.

Note that the URL _must_ be an absolute URL in this case.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>