### PR TITLE
Adding fail and assert functions

### DIFF
--- a/docs/content/functions/test.md
+++ b/docs/content/functions/test.md
@@ -1,0 +1,81 @@
+---
+title: test functions
+menu:
+  main:
+    parent: functions
+---
+
+The `test` namespace contains some simple functions to help validate
+assumptions and can cause template generation to fail in specific cases.
+
+## `test.Assert`
+
+
+**Alias:** `assert`
+
+
+Asserts that the given expression or value is `true`. If it is not, causes
+template generation to fail immediately with an optional message.
+
+
+### Usage
+```go
+test.Assert [message] value 
+```
+
+```go
+value | test.Assert [message]  
+```
+
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `message` | _(optional)_ The optional message to provide in the case of failure |
+| `value` | _(required)_ The value to test |
+
+
+### Examples
+
+```console
+$ gomplate -i '{{ assert (eq "foo" "bar") }}'
+template: <arg>:1:3: executing "<arg>" at <assert (eq "foo" "ba...>: error calling assert: assertion failed
+$ gomplate -i '{{ assert "something horrible happened" false }}'
+template: <arg>:1:3: executing "<arg>" at <assert "something ho...>: error calling assert: assertion failed: something horrible happened
+```
+
+## `test.Fail`
+
+
+**Alias:** `fail`
+
+
+Cause template generation to fail immediately, with an optional message.
+
+
+### Usage
+```go
+test.Fail [message] 
+```
+
+```go
+message | test.Fail  
+```
+
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `message` | _(optional)_ The optional message to provide |
+
+
+### Examples
+
+```console
+$ gomplate -i '{{ fail }}'
+template: <arg>:1:3: executing "<arg>" at <fail>: error calling fail: template generation failed
+$ gomplate -i '{{ test.Fail "something is wrong!" }}'
+template: <arg>:1:7: executing "<arg>" at <test.Fail>: error calling Fail: template generation failed: something is wrong!
+```

--- a/funcs.go
+++ b/funcs.go
@@ -25,5 +25,6 @@ func initFuncs(d *data.Data) template.FuncMap {
 	funcs.AddFilePathFuncs(f)
 	funcs.AddPathFuncs(f)
 	funcs.AddSockaddrFuncs(f)
+	funcs.AddTestFuncs(f)
 	return f
 }

--- a/funcs/aws_test.go
+++ b/funcs/aws_test.go
@@ -12,7 +12,7 @@ func TestNSIsIdempotent(t *testing.T) {
 	right := AWSNS()
 	assert.True(t, left == right)
 }
-func TestFuncs(t *testing.T) {
+func TestAWSFuncs(t *testing.T) {
 	m := aws.NewDummyEc2Meta()
 	i := aws.NewDummyEc2Info(m)
 	af := &Funcs{meta: m, info: i}

--- a/funcs/test.go
+++ b/funcs/test.go
@@ -1,0 +1,61 @@
+package funcs
+
+import (
+	"sync"
+
+	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/pkg/errors"
+
+	"github.com/hairyhenderson/gomplate/test"
+)
+
+var (
+	testNS     *TestFuncs
+	testNSInit sync.Once
+)
+
+// TestNS -
+func TestNS() *TestFuncs {
+	testNSInit.Do(func() { testNS = &TestFuncs{} })
+	return testNS
+}
+
+// AddTestFuncs -
+func AddTestFuncs(f map[string]interface{}) {
+	f["test"] = TestNS
+
+	f["assert"] = TestNS().Assert
+	f["fail"] = TestNS().Fail
+}
+
+// TestFuncs -
+type TestFuncs struct{}
+
+// Assert -
+func (f *TestFuncs) Assert(args ...interface{}) (string, error) {
+	input := conv.ToBool(args[len(args)-1])
+	switch len(args) {
+	case 1:
+		return test.Assert(input, "")
+	case 2:
+		message, ok := args[0].(string)
+		if !ok {
+			return "", errors.Errorf("at <1>: expected string; found %T", args[0])
+		}
+		return test.Assert(input, message)
+	default:
+		return "", errors.Errorf("wrong number of args: want 1 or 2, got %d", len(args))
+	}
+}
+
+// Fail -
+func (f *TestFuncs) Fail(args ...interface{}) (string, error) {
+	switch len(args) {
+	case 0:
+		return "", test.Fail("")
+	case 1:
+		return "", test.Fail(conv.ToString(args[0]))
+	default:
+		return "", errors.Errorf("wrong number of args: want 0 or 1, got %d", len(args))
+	}
+}

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Assert -
+func Assert(value bool, message string) (string, error) {
+	if !value {
+		if message != "" {
+			return "", errors.Errorf("assertion failed: %s", message)
+		}
+		return "", errors.New("assertion failed")
+	}
+	return "", nil
+}
+
+// Fail -
+func Fail(message string) error {
+	if message != "" {
+		return errors.Errorf("template generation failed: %s", message)
+	}
+	return errors.New("template generation failed")
+}

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssert(t *testing.T) {
+	_, err := Assert(false, "")
+	assert.Error(t, err)
+	_, err = Assert(false, "a message")
+	assert.EqualError(t, err, "assertion failed: a message")
+
+	_, err = Assert(true, "")
+	assert.NoError(t, err)
+}
+
+func TestFail(t *testing.T) {
+	err := Fail("")
+	assert.Error(t, err)
+	err = Fail("msg")
+	assert.EqualError(t, err, "template generation failed: msg")
+}


### PR DESCRIPTION
New namespace `test` with two functions for now:
- `test.Assert` (or `assert`): assert some condition to be true, or fail template generation
- `test.Fail` (or `fail`): fail template generation immediately

Signed-off-by: Dave Henderson <dhenderson@gmail.com>