### PR TITLE
Reducing output on template errors

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -80,7 +80,11 @@ func newGomplateCmd() *cobra.Command {
 				printVersion(cmd.Name())
 				return nil
 			}
-			return gomplate.RunTemplates(&opts)
+
+			err := gomplate.RunTemplates(&opts)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			return err
 		},
 		PostRunE: postRunExec,
 		Args:     optionalExecArgs,
@@ -111,7 +115,7 @@ func main() {
 	command := newGomplateCmd()
 	initFlags(command)
 	if err := command.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/tests/integration/basic_test.go
+++ b/tests/integration/basic_test.go
@@ -73,7 +73,7 @@ func (s *BasicSuite) TestErrorsWithInputOutputImbalance(c *C) {
 	})
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Err:      "Error: Must provide same number of --out (1) as --file (2) options",
+		Err:      "Must provide same number of --out (1) as --file (2) options",
 	})
 }
 
@@ -101,31 +101,31 @@ func (s *BasicSuite) TestFlagRules(c *C) {
 	result := icmd.RunCommand(GomplateBin, "-f", "-", "-i", "HELLO WORLD")
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Out:      "--in and --file may not be used together",
+		Err:      "--in and --file may not be used together",
 	})
 
 	result = icmd.RunCommand(GomplateBin, "--output-dir", ".")
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Out:      "--input-dir must be set when --output-dir is set",
+		Err:      "--input-dir must be set when --output-dir is set",
 	})
 
 	result = icmd.RunCommand(GomplateBin, "--input-dir", ".", "--in", "param")
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Out:      "--input-dir can not be used together with --in or --file",
+		Err:      "--input-dir can not be used together with --in or --file",
 	})
 
 	result = icmd.RunCommand(GomplateBin, "--input-dir", ".", "--file", "input.txt")
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Out:      "--input-dir can not be used together with --in or --file",
+		Err:      "--input-dir can not be used together with --in or --file",
 	})
 
 	result = icmd.RunCommand(GomplateBin, "--output-dir", ".", "--out", "param")
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Out:      "--output-dir can not be used together with --out",
+		Err:      "--output-dir can not be used together with --out",
 	})
 }
 
@@ -150,7 +150,7 @@ func (s *BasicSuite) TestDelimsChangedThroughEnvVars(c *C) {
 
 func (s *BasicSuite) TestUnknownArgErrors(c *C) {
 	result := icmd.RunCommand(GomplateBin, "-in", "flibbit")
-	result.Assert(c, icmd.Expected{ExitCode: 1, Out: `unknown command "flibbit" for "gomplate"`})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: `unknown command "flibbit" for "gomplate"`})
 }
 
 func (s *BasicSuite) TestExecCommand(c *C) {

--- a/tests/integration/inputdir_test.go
+++ b/tests/integration/inputdir_test.go
@@ -99,6 +99,6 @@ func (s *InputDirSuite) TestReportsFilenameWithBadInputFile(c *C) {
 	)
 	result.Assert(c, icmd.Expected{
 		ExitCode: 1,
-		Out:      "template: " + s.tmpDir.Join("bad_in", "bad.tmpl") + ":1: unexpected {{end}}",
+		Err:      "template: " + s.tmpDir.Join("bad_in", "bad.tmpl") + ":1: unexpected {{end}}",
 	})
 }

--- a/tests/integration/strings_test.go
+++ b/tests/integration/strings_test.go
@@ -37,11 +37,11 @@ func (s *StringsSuite) TestRepeat(c *C) {
 
 	result = icmd.RunCommand(GomplateBin, "-i",
 		`ba{{ strings.Repeat 9223372036854775807 "na" }}`)
-	result.Assert(c, icmd.Expected{ExitCode: 1, Out: `too long: causes overflow`})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: `too long: causes overflow`})
 
 	result = icmd.RunCommand(GomplateBin, "-i",
 		`ba{{ strings.Repeat -1 "na" }}`)
-	result.Assert(c, icmd.Expected{ExitCode: 1, Out: `negative count`})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: `negative count`})
 }
 
 func (s *StringsSuite) TestSlug(c *C) {


### PR DESCRIPTION
This makes gomplate a little less noisy when there's an error during template rendering, as opposed to commandline parsing or setup errors.

Now, instead of printing the usage message and the error message twice (top and bottom), it'll just print the error once:

```
$ gomplate -i '{{ foo }}'
template: <arg>:1: function "foo" not defined
```

In the case of errors during function calls (like `fail`, for example), it's a bit more verbose:

```
$ gomplate -i '{{ fail }}'
template: <arg>:1:3: executing "<arg>" at <fail>: error calling fail: template generation failed
```

When providing a bogus commandline flag, the behaviour will remain the same:

```
$ gomplate --blargh
Error: unknown flag: --blargh
Usage:
  gomplate [flags]

Flags:
  -d, --datasource datasource      datasource in alias=URL form. Specify multiple times to add multiple sources.
  -H, --datasource-header header   HTTP header field in 'alias=Name: value' form to be provided on HTTP-based data sources. Multiples can be set.
      --exclude stringArray        glob of files to not parse
  -f, --file file                  Template file to process. Omit to use standard input, or use --in or --input-dir (default [-])
  -h, --help                       help for gomplate
  -i, --in string                  Template string to process (alternative to --file and --input-dir)
      --input-dir directory        directory which is examined recursively for templates (alternative to --file and --in)
      --left-delim delimiter       override the default left-delimiter [$GOMPLATE_LEFT_DELIM] (default "{{")
  -o, --out file                   output file name. Omit to use standard output. (default [-])
      --output-dir directory       directory to store the processed templates. Only used for --input-dir (default ".")
      --right-delim delimiter      override the default right-delimiter [$GOMPLATE_RIGHT_DELIM] (default "}}")
  -v, --version                    print the version

unknown flag: --blargh
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>