### PR TITLE
Adding slice/array support to conv.Has

### DIFF
--- a/conv/conv.go
+++ b/conv/conv.go
@@ -109,12 +109,22 @@ func interfaceSlice(slice interface{}) ([]interface{}, error) {
 }
 
 // Has determines whether or not a given object has a property with the given key
-func Has(in interface{}, key string) bool {
+func Has(in interface{}, key interface{}) bool {
 	av := reflect.ValueOf(in)
-	kv := reflect.ValueOf(key)
 
-	if av.Kind() == reflect.Map {
+	switch av.Kind() {
+	case reflect.Map:
+		kv := reflect.ValueOf(key)
 		return av.MapIndex(kv).IsValid()
+	case reflect.Slice, reflect.Array:
+		l := av.Len()
+		for i := 0; i < l; i++ {
+			var v interface{}
+			v = av.Index(i).Interface()
+			if reflect.DeepEqual(v, key) {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/conv/conv_test.go
+++ b/conv/conv_test.go
@@ -59,6 +59,10 @@ func TestHas(t *testing.T) {
 	assert.True(t, Has(in, "foo"))
 	assert.False(t, Has(in, "bar"))
 	assert.True(t, Has(in["baz"], "qux"))
+	assert.True(t, Has([]string{"foo", "bar", "baz"}, "bar"))
+	assert.True(t, Has([]interface{}{"foo", "bar", "baz"}, "bar"))
+	assert.False(t, Has([]interface{}{"foo", "bar", "baz"}, 42))
+	assert.True(t, Has([]int{1, 2, 42}, 42))
 }
 
 func TestMustParseInt(t *testing.T) {

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -74,35 +74,40 @@ Hello, Maggie
 
 **Alias:** `has`
 
-Has reports whether or not a given object has a property with the given key. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
+Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
 
-#### Example
-
-_Let's say we're using a Vault datasource..._
-
-_`input.tmpl`:_
-```
-{{ $secret := datasource "vault" "mysecret" -}}
-The secret is '
-{{- if (has $secret "value") }}
-{{- $secret.value }}
-{{- else }}
-{{- $secret | toYAML }}
-{{- end }}'
+### Usage
+```go
+conv.Has in item
 ```
 
-If the `secret/foo/mysecret` secret in Vault has a property named `value` set to `supersecret`:
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in` | _(required)_ The object or list to search |
+| `item` | _(required)_ The item to search for |
+
+### Examples
 
 ```console
-$ gomplate -d vault:///secret/foo < input.tmpl
-The secret is 'supersecret'
+$ gomplate -i '{{ $l := slice "foo" "bar" "baz" -}}
+there is {{ if has $l "bar" }}a{{else}}no{{end}} bar'
+there is a bar
 ```
 
-On the other hand, if there is no `value` property:
+```console
+$ export DATA='{"foo": "bar"}'
+$ gomplate -i '{{ $o := data.JSON (getenv "DATA") -}}
+{{ if (has $o "foo") }}{{ $o.foo }}{{ else }}THERE IS NO FOO{{ end }}'
+bar
+```
 
 ```console
-$ gomplate -d vault:///secret/foo < input.tmpl
-The secret is 'foo: bar'
+$ export DATA='{"baz": "qux"}'
+$ gomplate -i '{{ $o := data.JSON (getenv "DATA") -}}
+{{ if (has $o "foo") }}{{ $o.foo }}{{ else }}THERE IS NO FOO{{ end }}'
+THERE IS NO FOO
 ```
 
 ## `conv.Join`


### PR DESCRIPTION
Teaching `has`/`conv.Has` to look for values in slices/arrays as well as maps.

Also expands map key support to handle any key type, not just `string`s.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>