### PR TITLE
Generating docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ docs/themes/hugo-material-docs:
 gen-docs: docs/themes/hugo-material-docs
 	cd docs/; hugo
 
+docs/content/functions/%.md: docs-src/content/functions/%.yml docs-src/content/functions/func_doc.md.tmpl
+	gomplate -d data=$< -f docs-src/content/functions/func_doc.md.tmpl -o $@
+
 # this target doesn't usually get used - it's mostly here as a reminder to myself
 # hint: make sure CLOUDCONVERT_API_KEY is set ;)
 gomplate.png: gomplate.svg

--- a/docs-src/content/functions/conv.yml
+++ b/docs-src/content/functions/conv.yml
@@ -1,0 +1,60 @@
+ns: conv
+preamble: |
+  These are a collection of functions that mostly help converting from one type
+  to another - generally from a `string` to something else, and vice-versa.
+funcs:
+  - name: conv.Bool
+    alias: bool
+  - name: conv.Default
+    alias: default
+  - name: conv.Slice
+    alias: slice
+  - name: conv.Has
+    alias: has
+  - name: conv.Join
+    alias: join
+  - name: conv.URL
+  - name: conv.ParseInt
+  - name: conv.ParseFloat
+  - name: conv.ParseUint
+  - name: conv.Atoi
+  - name: conv.ToBool
+    description: |
+      Converts the input to a boolean value.
+      Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
+      (any capitalizations). All other values are considered `false`.
+    pipeline: true
+    arguments:
+      - name: input
+        required: true
+        description: The input to convert
+    examples:
+      - |
+        $ gomplate -i '{{ conv.ToBool "yes" }} {{ conv.ToBool true }} {{ conv.ToBool "0x01" }}'
+        true true true
+        $ gomplate -i '{{ conv.ToBool false }} {{ conv.ToBool "blah" }} {{ conv.ToBool 0 }}'
+        false false false
+  - name: conv.ToBools
+    description: |
+      Converts a list of inputs to an array of boolean values.
+      Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
+      (any capitalizations). All other values are considered `false`.
+    pipeline: true
+    arguments:
+      - name: input
+        required: true
+        description: The input array to convert
+    examples:
+      - |
+        $ gomplate -i '{{ conv.ToBools "yes" true "0x01" }}'
+        [true true true]
+        $ gomplate -i '{{ conv.ToBools false "blah" 0 }}'
+        [false false false]
+  - name: conv.ToInt64
+  - name: conv.ToInt
+  - name: conv.ToInt64s
+  - name: conv.ToInts
+  - name: conv.ToFloat64
+  - name: conv.ToFloat64s
+  - name: conv.ToString
+  - name: conv.ToStrings

--- a/docs-src/content/functions/filepath.yml
+++ b/docs-src/content/functions/filepath.yml
@@ -1,0 +1,195 @@
+ns: filepath
+preamble: |
+  gomplate's path functions are split into 2 namespaces:
+  - `path`, which is useful for manipulating slash-based (`/`) paths, such as in URLs
+  - `filepath`, which should be used for local filesystem paths, especially when Windows paths may be involved.
+
+  This page documents the `filepath` namespace - see also the [`path`](../path) documentation.
+
+  These functions are wrappers for Go's [`path/filepath`](https://golang.org/pkg/path/filepath/) package.
+funcs:
+  - name: filepath.Base
+    description: |
+      Returns the last element of path. Trailing path separators are removed before extracting the last element. If the path is empty, Base returns `.`. If the path consists entirely of separators, Base returns a single separator.
+
+      A wrapper for Go's [`filepath.Base`](https://golang.org/pkg/path/filepath/#Base) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Base "/tmp/foo" }}'
+        foo
+  - name: filepath.Clean
+    description: |
+      Clean returns the shortest path name equivalent to path by purely lexical processing.
+
+      A wrapper for Go's [`filepath.Clean`](https://golang.org/pkg/path/filepath/#Clean) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Clean "/tmp//foo/../" }}'
+        /tmp
+  - name: filepath.Dir
+    description: |
+      Returns all but the last element of path, typically the path's directory.
+
+      A wrapper for Go's [`filepath.Dir`](https://golang.org/pkg/path/filepath/#Dir) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Dir "/tmp/foo" }}'
+        /tmp
+  - name: filepath.Ext
+    description: |
+      Returns the file name extension used by path.
+
+      A wrapper for Go's [`filepath.Ext`](https://golang.org/pkg/path/filepath/#Ext) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Ext "/tmp/foo.csv" }}'
+        .csv
+  - name: filepath.FromSlash
+    description: |
+      Returns the result of replacing each slash (`/`) character in the path with the platform's separator character.
+
+      A wrapper for Go's [`filepath.FromSlash`](https://golang.org/pkg/path/filepath/#FromSlash) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.FromSlash "/foo/bar" }}'
+        /foo/bar
+        C:\> gomplate.exe -i '{{ filepath.FromSlash "/foo/bar" }}'
+        C:\foo\bar
+  - name: filepath.IsAbs
+    description: |
+      Reports whether the path is absolute.
+
+      A wrapper for Go's [`filepath.IsAbs`](https://golang.org/pkg/path/filepath/#IsAbs) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i 'the path is {{ if (filepath.IsAbs "/tmp/foo.csv") }}absolute{{else}}relative{{end}}'
+        the path is absolute
+        $ gomplate -i 'the path is {{ if (filepath.IsAbs "../foo.csv") }}absolute{{else}}relative{{end}}'
+        the path is relative
+  - name: filepath.Join
+    description: |
+      Joins any number of path elements into a single path, adding a separator if necessary.
+
+      A wrapper for Go's [`filepath.Join`](https://golang.org/pkg/path/filepath/#Join) function.
+    arguments:
+      - name: elem...
+        required: true
+        description: The path elements to join (0 or more)
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Join "/tmp" "foo" "bar" }}'
+        /tmp/foo/bar
+        C:\> gomplate.exe -i '{{ filepath.Join "C:\tmp" "foo" "bar" }}'
+        C:\tmp\foo\bar
+  - name: filepath.Match
+    description: |
+      Reports whether name matches the shell file name pattern.
+
+      A wrapper for Go's [`filepath.Match`](https://golang.org/pkg/path/filepath/#Match) function.
+    arguments:
+      - name: pattern
+        required: true
+        description: The pattern to match on
+      - name: path
+        required: true
+        description: The path to match
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Match "*.csv" "foo.csv" }}'
+        true
+  - name: filepath.Rel
+    description: |
+      Returns a relative path that is lexically equivalent to targetpath when joined to basepath with an intervening separator.
+
+      A wrapper for Go's [`filepath.Rel`](https://golang.org/pkg/path/filepath/#Rel) function.
+    arguments:
+      - name: basepath
+        required: true
+        description: The base path
+      - name: targetpath
+        required: true
+        description: The target path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.Rel "/a" "/a/b/c" }}'
+        b/c
+  - name: filepath.Split
+    description: |
+      Splits path immediately following the final path separator, separating it into a directory and file name component.
+
+      The function returns an array with two values, the first being the diretory, and the second the file.
+
+      A wrapper for Go's [`filepath.Split`](https://golang.org/pkg/path/filepath/#Split) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ $p := filepath.Split "/tmp/foo" }}{{ $dir := index $p 0 }}{{ $file := index $p 1 }}dir is {{$dir}}, file is {{$file}}'
+        dir is /tmp/, file is foo
+        C:\> gomplate.exe -i '{{ $p := filepath.Split `C:\tmp\foo` }}{{ $dir := index $p 0 }}{{ $file := index $p 1 }}dir is {{$dir}}, file is {{$file}}'
+        dir is C:\tmp\, file is foo
+  - name: filepath.ToSlash
+    description: |
+      Returns the result of replacing each separator character in path with a slash (`/`) character.
+
+      A wrapper for Go's [`filepath.ToSlash`](https://golang.org/pkg/path/filepath/#ToSlash) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ filepath.ToSlash "/foo/bar" }}'
+        /foo/bar
+        C:\> gomplate.exe -i '{{ filepath.ToSlash `foo\bar\baz` }}'
+        foo/bar/baz
+  - name: filepath.VolumeName
+    description: |
+      Returns the leading volume name. Given `C:\foo\bar` it returns `C:` on Windows. Given a UNC like `\\host\share\foo` it returns `\\host\share`. On other platforms it returns an empty string.
+
+      A wrapper for Go's [`filepath.VolumeName`](https://golang.org/pkg/path/filepath/#VolumeName) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        C:\> gomplate.exe -i 'volume is {{ filepath.VolumeName "C:/foo/bar" }}'
+        volume is C:
+        $ gomplate -i 'volume is {{ filepath.VolumeName "/foo/bar" }}'
+        volume is

--- a/docs-src/content/functions/func_doc.md.tmpl
+++ b/docs-src/content/functions/func_doc.md.tmpl
@@ -1,0 +1,46 @@
+{{ $data := ds "data" -}}
+---
+title: {{ $data.ns }} functions
+menu:
+  main:
+    parent: functions
+---
+
+{{ $data.preamble -}}
+
+{{ range $_, $f := $data.funcs }}
+## `{{ $f.name }}`
+{{ if has $f "alias" }}
+**Alias:** `{{$f.alias}}`
+{{ end }}
+
+{{- if has $f "description" }}
+{{ $f.description }}
+{{ end -}}
+
+{{ if has $f "arguments" -}}
+### Usage
+```go
+{{ $f.name }} {{ range $f.arguments -}} {{ if not .required }}[{{ .name }}]{{else}}{{ .name }}{{end}} {{end}}
+```
+{{ if has $f "pipeline" }}{{ if $f.pipeline }}
+```go
+{{ $last := (sub (len $f.arguments) 1) -}}
+{{ (index $f.arguments $last).name }} | {{ $f.name }} {{ range $i, $a := $f.arguments -}} {{if not (eq $i $last)}}{{ if not $a.required }}[{{ .name }}]{{else}}{{ .name }}{{end}}{{end}} {{end}}
+```
+{{ end }}{{ end }}
+### Arguments
+
+| name | description |
+|------|-------------|
+{{ range $f.arguments }}| `{{.name}}` | _({{if .required}}required{{else}}optional{{end}})_ {{.description}} |
+{{ end }}
+{{- end -}}
+{{if has $f "examples" }}
+### Examples
+
+{{ range $f.examples -}}
+```console
+{{ . | strings.TrimSpace }}
+```
+{{ end }}{{ end }}{{ end -}}

--- a/docs-src/content/functions/math.yml
+++ b/docs-src/content/functions/math.yml
@@ -1,0 +1,273 @@
+ns: math
+preamble: |
+  A set of basic math functions to be able to perform simple arithmetic operations with `gomplate`.
+
+  ### Supported input
+
+  In general, any input will be converted to the correct input type by the various functions in this package, and an appropriately-typed value will be returned type. Special cases are documented.
+
+  In addition to regular base-10 numbers, integers can be
+  [specified](https://golang.org/ref/spec#Integer_literals) as octal (prefix with
+  `0`) or hexadecimal (prefix with `0x`).
+
+  Decimal/floating-point numbers can be [specified](https://golang.org/ref/spec#Floating-point_literals)
+  with optional exponents.
+
+  Some examples demonstrating this:
+
+  ```console
+  $ NUM=50 gomplate -i '{{ div (getenv "NUM") 10 }}'
+  5
+  $ gomplate -i '{{ add "0x2" "02" "2.0" "2e0" }}'
+  8
+  $ gomplate -i '{{ add 2.5 2.5 }}'
+  5.0
+  ```
+funcs:
+  - name: math.Abs
+    description: |
+      Returns the absolute value of a given number. When the input is an integer, the result will be an `int64`, otherwise it will be a `float64`.
+    arguments:
+      - name: num
+        required: true
+        description: The input number
+    examples:
+      - |
+        $ gomplate -i '{{ math.Abs -3.5 }} {{ math.Abs 3.5 }} {{ math.Abs -42 }}'
+        3.5 3.5 42
+  - name: math.Add
+    alias: add
+    description: |
+      Adds all given operators. When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
+    arguments:
+      - name: n...
+        required: true
+        description: The numbers to add together
+    examples:
+      - |
+        $ gomplate -i '{{ math.Add 1 2 3 4 }} {{ math.Add 1.5 2 3 }}'
+        10 6.5
+  - name: math.Ceil
+    description: |
+      Returns the least integer value greater than or equal to a given floating-point number. This wraps Go's [`math.Ceil`](https://golang.org/pkg/math/#Ceil).
+
+      **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
+    arguments:
+      - name: num
+        required: true
+        description: The input number. Will be converted to a `float64`, or `0` if not convertable
+    examples:
+      - |
+        $ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}ceil {{ printf "%#v" . }} = {{ math.Ceil . }}{{"\n"}}{{ end }}'
+        ceil 5.1 = 6
+        ceil 42 = 42
+        ceil "3.14" = 4
+        ceil "0xFF" = 255
+        ceil "NaN" = NaN
+        ceil "Inf" = +Inf
+        ceil "-0" = 0
+  - name: math.Div
+    alias: div
+    description: |
+      Divide the first number by the second. Division by zero is disallowed. The result will be a `float64`.
+    pipeline: true
+    arguments:
+      - name: a
+        required: true
+        description: The divisor
+      - name: b
+        required: true
+        description: The dividend
+    examples:
+      - |
+        $ gomplate -i '{{ math.Div 8 2 }} {{ math.Div 3 2 }}'
+        4 1.5
+  - name: math.Floor
+    description: |
+      Returns the greatest integer value less than or equal to a given floating-point number. This wraps Go's [`math.Floor`](https://golang.org/pkg/math/#Floor).
+
+      **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
+    arguments:
+      - name: num
+        required: true
+        description: The input number. Will be converted to a `float64`, or `0` if not convertable
+    examples:
+      - |
+        $ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}floor {{ printf "%#v" . }} = {{ math.Floor . }}{{"\n"}}{{ end }}'
+        floor 5.1 = 4
+        floor 42 = 42
+        floor "3.14" = 3
+        floor "0xFF" = 255
+        floor "NaN" = NaN
+        floor "Inf" = +Inf
+        floor "-0" = 0
+  - name: math.IsFloat
+    description: |
+      Returns whether or not the given number can be interpreted as a floating-point literal, as defined by the [Go language reference](https://golang.org/ref/spec#Floating-point_literals).
+
+      **Note:** If a decimal point is part of the input number, it will be considered a floating-point number, even if the decimal is `0`.
+    arguments:
+      - name: num
+        required: true
+        description: The value to test
+    examples:
+      - |
+        $ gomplate -i '{{ range (slice 1.0 "-1.0" 5.1 42 "3.14" "foo" "0xFF" "NaN" "Inf" "-0") }}{{ if (math.IsFloat .) }}{{.}} is a float{{"\n"}}{{ end }}{{end}}'
+        1 is a float
+        -1.0 is a float
+        5.1 is a float
+        3.14 is a float
+        NaN is a float
+        Inf is a float
+  - name: math.IsInt
+    description: |
+      Returns whether or not the given number is an integer.
+    arguments:
+      - name: num
+        required: true
+        description: The value to test
+    examples:
+      - |
+        $ gomplate -i '{{ range (slice 1.0 "-1.0" 5.1 42 "3.14" "foo" "0xFF" "NaN" "Inf" "-0") }}{{ if (math.IsInt .) }}{{.}} is an integer{{"\n"}}{{ end }}{{end}}'
+        42 is an integer
+        0xFF is an integer
+        -0 is an integer
+  - name: math.IsNum
+    description: |
+      Returns whether the given input is a number. Useful for `if` conditions.
+    arguments:
+      - name: in
+        required: true
+        description: The value to test
+    examples:
+      - |
+        $ gomplate -i '{{ math.IsNum "foo" }} {{ math.IsNum 0xDeadBeef }}'
+        false true
+  - name: math.Max
+    description: |
+      Returns the largest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Max`](https://golang.org/pkg/math/#Max) are followed.
+    arguments:
+      - name: nums...
+        required: true
+        description: One or more numbers to compare
+    examples:
+      - |
+        $ gomplate -i '{{ math.Max 0 8.0 4.5 "-1.5e-11" }}'
+        8
+  - name: math.Min
+    description: |
+      Returns the smallest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Min`](https://golang.org/pkg/math/#Min) are followed.
+    arguments:
+      - name: nums...
+        required: true
+        description: One or more numbers to compare
+    examples:
+      - |
+        $ gomplate -i '{{ math.Min 0 8 4.5 "-1.5e-11" }}'
+        -1.5e-11
+  - name: math.Mul
+    alias: mul
+    description: |
+      Multiply all given operators together.
+    arguments:
+      - name: n...
+        required: true
+        description: The numbers to multiply
+    examples:
+      - |
+        $ gomplate -i '{{ math.Mul 8 8 2 }}'
+        128
+  - name: math.Pow
+    alias: pow
+    description: |
+      Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://golang.org/pkg/math/#Pow). If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned.
+    arguments:
+      - name: b
+        required: true
+        description: The base
+      - name: 'n'
+        required: true
+        description: The exponent
+    examples:
+      - |
+        $ gomplate -i '{{ math.Pow 10 2 }}'
+        100
+        $ gomplate -i '{{ math.Pow 2 32 }}'
+        4294967296
+        $ gomplate -i '{{ math.Pow 1.5 2 }}'
+        2.2
+  - name: math.Rem
+    alias: rem
+    description: |
+      Return the remainder from an integer division operation.
+    pipeline: true
+    arguments:
+      - name: a
+        required: true
+        description: The divisor
+      - name: b
+        required: true
+        description: The dividend
+    examples:
+      - |
+        $ gomplate -i '{{ math.Rem 5 3 }}'
+        2
+        $ gomplate -i '{{ math.Rem -5 3 }}'
+        -2
+  - name: math.Round
+    description: |
+      Returns the nearest integer, rounding half away from zero.
+
+      **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
+    arguments:
+      - name: num
+        required: true
+        description: The input number. Will be converted to a `float64`, or `0` if not convertable
+    examples:
+      - |
+        $ gomplate -i '{{ range (slice -6.5 5.1 42.9 "3.5" 6.5) }}round {{ printf "%#v" . }} = {{ math.Round . }}{{"\n"}}{{ end }}'
+        round -6.5 = -7
+        round 5.1 = 5
+        round 42.9 = 43
+        round "3.5" = 4
+        round 6.5 = 7
+  - name: math.Seq
+    alias: seq
+    description: |
+      Return a sequence from `start` to `end`, in steps of `step`. Can handle counting
+      down as well as up, including with negative numbers.
+
+      Note that the sequence _may_ not end at `end`, if `end` is not divisible by `step`.
+    arguments:
+      - name: start
+        required: false
+        description: The first number in the sequence (defaults to `1`)
+      - name: end
+        required: true
+        description: The last number in the sequence
+      - name: step
+        required: false
+        description: The amount to increment between each number (defaults to `1`)
+    examples:
+      - |
+        $ gomplate -i '{{ range (math.Seq 5) }}{{.}} {{end}}'
+        1 2 3 4 5
+      - |
+        $ gomplate -i '{{ conv.Join (math.Seq 10 -3 2) ", " }}'
+        10, 8, 6, 4, 2, 0, -2
+  - name: math.Sub
+    alias: sub
+    description: |
+      Subtract the second from the first of the given operators.  When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
+    pipeline: true
+    arguments:
+      - name: a
+        required: true
+        description: The minuend (the number to subtract from)
+      - name: b
+        required: true
+        description: The subtrahend (the number being subtracted)
+    examples:
+      - |
+        $ gomplate -i '{{ math.Sub 3 1 }}'
+        2

--- a/docs-src/content/functions/path.yml
+++ b/docs-src/content/functions/path.yml
@@ -1,0 +1,127 @@
+ns: path
+preamble: |
+  gomplate's path functions are split into 2 namespaces:
+  - `path`, which is useful for manipulating slash-based (`/`) paths, such as in URLs
+  - `filepath`, which should be used for local filesystem paths, especially when Windows paths may be involved.
+
+  This page documents the `path` namespace - see also the [`filepath`](../filepath) documentation.
+
+  These functions are wrappers for Go's [`path`](https://golang.org/pkg/path/) and [`path/filepath`](https://golang.org/pkg/path/filepath/) packages.
+funcs:
+  - name: path.Base
+    description: |
+      Returns the last element of path. Trailing slashes are removed before extracting the last element. If the path is empty, Base returns `.`. If the path consists entirely of slashes, Base returns `/`.
+
+      A wrapper for Go's [`path.Base`](https://golang.org/pkg/path/#Base) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ path.Base "/tmp/foo" }}'
+        foo
+  - name: path.Clean
+    description: |
+      Clean returns the shortest path name equivalent to path by purely lexical processing.
+
+      A wrapper for Go's [`path.Clean`](https://golang.org/pkg/path/#Clean) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ path.Clean "/tmp//foo/../" }}'
+        /tmp
+  - name: path.Dir
+    description: |
+      Returns all but the last element of path, typically the path's directory.
+
+      A wrapper for Go's [`path.Dir`](https://golang.org/pkg/path/#Dir) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ path.Dir "/tmp/foo" }}'
+        /tmp
+  - name: path.Ext
+    description: |
+      Returns the file name extension used by path.
+
+      A wrapper for Go's [`path.Ext`](https://golang.org/pkg/path/#Ext) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ path.Ext "/tmp/foo.csv" }}'
+        .csv
+  - name: path.IsAbs
+    description: |
+      Reports whether the path is absolute.
+
+      A wrapper for Go's [`path.IsAbs`](https://golang.org/pkg/path/#IsAbs) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i 'the path is {{ if (path.IsAbs "/tmp/foo.csv") }}absolute{{else}}relative{{end}}'
+        the path is absolute
+        $ gomplate -i 'the path is {{ if (path.IsAbs "../foo.csv") }}absolute{{else}}relative{{end}}'
+        the path is relative
+  - name: path.Join
+    description: |
+      Joins any number of path elements into a single path, adding a separating slash if necessary.
+
+      A wrapper for Go's [`path.Join`](https://golang.org/pkg/path/#Join) function.
+    arguments:
+      - name: elem...
+        required: true
+        description: The path elements to join (0 or more)
+    examples:
+      - |
+        $ gomplate -i '{{ path.Join "/tmp" "foo" "bar" }}'
+        /tmp/foo/bar
+  - name: path.Match
+    description: |
+      Reports whether name matches the shell file name pattern.
+
+      A wrapper for Go's [`path.Match`](https://golang.org/pkg/path/#Match) function.
+    arguments:
+      - name: pattern
+        required: true
+        description: The pattern to match on
+      - name: path
+        required: true
+        description: The path to match
+    examples:
+      - |
+        $ gomplate -i '{{ path.Match "*.csv" "foo.csv" }}'
+        true
+  - name: path.Split
+    description: |
+      Splits path immediately following the final slash, separating it into a directory and file name component.
+
+      The function returns an array with two values, the first being the diretory, and the second the file.
+
+      A wrapper for Go's [`path.Split`](https://golang.org/pkg/path/#Split) function.
+    pipeline: true
+    arguments:
+      - name: path
+        required: true
+        description: The input path
+    examples:
+      - |
+        $ gomplate -i '{{ $p := path.Split "/tmp/foo" }}{{ $dir := index $p 0 }}{{ $file := index $p 1 }}dir is {{$dir}}, file is {{$file}}'
+        dir is /tmp/, file is foo

--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -1,0 +1,16 @@
+ns: strings
+preamble: ''
+funcs:
+  - name: strings.Sort
+    alias: sort
+    description: |
+      Returns an alphanumerically-sorted copy of a given string list.
+    pipeline: true
+    arguments:
+      - name: list
+        required: true
+        description: The list to sort
+    examples:
+      - |
+        $ gomplate -i '{{ (slice "foo" "bar" "baz") | sort }}'
+        [bar baz foo]

--- a/docs-src/content/functions/test.yml
+++ b/docs-src/content/functions/test.yml
@@ -1,0 +1,39 @@
+ns: test
+preamble: |
+  The `test` namespace contains some simple functions to help validate
+  assumptions and can cause template generation to fail in specific cases.
+funcs:
+  - name: test.Assert
+    alias: assert
+    description: |
+      Asserts that the given expression or value is `true`. If it is not, causes
+      template generation to fail immediately with an optional message.
+    pipeline: true
+    arguments:
+      - name: message
+        required: false
+        description: The optional message to provide in the case of failure
+      - name: value
+        required: true
+        description: The value to test
+    examples:
+      - |
+        $ gomplate -i '{{ assert (eq "foo" "bar") }}'
+        template: <arg>:1:3: executing "<arg>" at <assert (eq "foo" "ba...>: error calling assert: assertion failed
+        $ gomplate -i '{{ assert "something horrible happened" false }}'
+        template: <arg>:1:3: executing "<arg>" at <assert "something ho...>: error calling assert: assertion failed: something horrible happened
+  - name: test.Fail
+    alias: fail
+    description: |
+      Cause template generation to fail immediately, with an optional message.
+    pipeline: true
+    arguments:
+      - name: message
+        required: false
+        description: The optional message to provide
+    examples:
+      - |
+        $ gomplate -i '{{ fail }}'
+        template: <arg>:1:3: executing "<arg>" at <fail>: error calling fail: template generation failed
+        $ gomplate -i '{{ test.Fail "something is wrong!" }}'
+        template: <arg>:1:7: executing "<arg>" at <test.Fail>: error calling Fail: template generation failed: something is wrong!

--- a/docs/content/functions/filepath.md
+++ b/docs/content/functions/filepath.md
@@ -15,11 +15,9 @@ These functions are wrappers for Go's [`path/filepath`](https://golang.org/pkg/p
 
 ## `filepath.Base`
 
-
 Returns the last element of path. Trailing path separators are removed before extracting the last element. If the path is empty, Base returns `.`. If the path consists entirely of separators, Base returns a single separator.
 
 A wrapper for Go's [`filepath.Base`](https://golang.org/pkg/path/filepath/#Base) function.
-
 
 ### Usage
 ```go
@@ -30,13 +28,11 @@ filepath.Base path
 path | filepath.Base  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -47,11 +43,9 @@ foo
 
 ## `filepath.Clean`
 
-
 Clean returns the shortest path name equivalent to path by purely lexical processing.
 
 A wrapper for Go's [`filepath.Clean`](https://golang.org/pkg/path/filepath/#Clean) function.
-
 
 ### Usage
 ```go
@@ -62,13 +56,11 @@ filepath.Clean path
 path | filepath.Clean  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -79,11 +71,9 @@ $ gomplate -i '{{ filepath.Clean "/tmp//foo/../" }}'
 
 ## `filepath.Dir`
 
-
 Returns all but the last element of path, typically the path's directory.
 
 A wrapper for Go's [`filepath.Dir`](https://golang.org/pkg/path/filepath/#Dir) function.
-
 
 ### Usage
 ```go
@@ -94,13 +84,11 @@ filepath.Dir path
 path | filepath.Dir  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -111,11 +99,9 @@ $ gomplate -i '{{ filepath.Dir "/tmp/foo" }}'
 
 ## `filepath.Ext`
 
-
 Returns the file name extension used by path.
 
 A wrapper for Go's [`filepath.Ext`](https://golang.org/pkg/path/filepath/#Ext) function.
-
 
 ### Usage
 ```go
@@ -126,13 +112,11 @@ filepath.Ext path
 path | filepath.Ext  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -143,11 +127,9 @@ $ gomplate -i '{{ filepath.Ext "/tmp/foo.csv" }}'
 
 ## `filepath.FromSlash`
 
-
 Returns the result of replacing each slash (`/`) character in the path with the platform's separator character.
 
 A wrapper for Go's [`filepath.FromSlash`](https://golang.org/pkg/path/filepath/#FromSlash) function.
-
 
 ### Usage
 ```go
@@ -158,13 +140,11 @@ filepath.FromSlash path
 path | filepath.FromSlash  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -177,11 +157,9 @@ C:\foo\bar
 
 ## `filepath.IsAbs`
 
-
 Reports whether the path is absolute.
 
 A wrapper for Go's [`filepath.IsAbs`](https://golang.org/pkg/path/filepath/#IsAbs) function.
-
 
 ### Usage
 ```go
@@ -192,13 +170,11 @@ filepath.IsAbs path
 path | filepath.IsAbs  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -211,24 +187,20 @@ the path is relative
 
 ## `filepath.Join`
 
-
 Joins any number of path elements into a single path, adding a separator if necessary.
 
 A wrapper for Go's [`filepath.Join`](https://golang.org/pkg/path/filepath/#Join) function.
-
 
 ### Usage
 ```go
 filepath.Join elem... 
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `elem...` | _(required)_ The path elements to join (0 or more) |
-
 
 ### Examples
 
@@ -241,17 +213,14 @@ C:\tmp\foo\bar
 
 ## `filepath.Match`
 
-
 Reports whether name matches the shell file name pattern.
 
 A wrapper for Go's [`filepath.Match`](https://golang.org/pkg/path/filepath/#Match) function.
-
 
 ### Usage
 ```go
 filepath.Match pattern path 
 ```
-
 
 ### Arguments
 
@@ -259,7 +228,6 @@ filepath.Match pattern path
 |------|-------------|
 | `pattern` | _(required)_ The pattern to match on |
 | `path` | _(required)_ The path to match |
-
 
 ### Examples
 
@@ -270,25 +238,21 @@ true
 
 ## `filepath.Rel`
 
-
 Returns a relative path that is lexically equivalent to targetpath when joined to basepath with an intervening separator.
 
 A wrapper for Go's [`filepath.Rel`](https://golang.org/pkg/path/filepath/#Rel) function.
-
 
 ### Usage
 ```go
 filepath.Rel basepath targetpath 
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
-| `basepath` | _(required)_ The |
-| `targetpath` | _(required)_ The |
-
+| `basepath` | _(required)_ The base path |
+| `targetpath` | _(required)_ The target path |
 
 ### Examples
 
@@ -299,13 +263,11 @@ b/c
 
 ## `filepath.Split`
 
-
 Splits path immediately following the final path separator, separating it into a directory and file name component.
 
 The function returns an array with two values, the first being the diretory, and the second the file.
 
 A wrapper for Go's [`filepath.Split`](https://golang.org/pkg/path/filepath/#Split) function.
-
 
 ### Usage
 ```go
@@ -316,13 +278,11 @@ filepath.Split path
 path | filepath.Split  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -335,11 +295,9 @@ dir is C:\tmp\, file is foo
 
 ## `filepath.ToSlash`
 
-
 Returns the result of replacing each separator character in path with a slash (`/`) character.
 
 A wrapper for Go's [`filepath.ToSlash`](https://golang.org/pkg/path/filepath/#ToSlash) function.
-
 
 ### Usage
 ```go
@@ -350,13 +308,11 @@ filepath.ToSlash path
 path | filepath.ToSlash  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -369,11 +325,9 @@ foo/bar/baz
 
 ## `filepath.VolumeName`
 
-
 Returns the leading volume name. Given `C:\foo\bar` it returns `C:` on Windows. Given a UNC like `\\host\share\foo` it returns `\\host\share`. On other platforms it returns an empty string.
 
 A wrapper for Go's [`filepath.VolumeName`](https://golang.org/pkg/path/filepath/#VolumeName) function.
-
 
 ### Usage
 ```go
@@ -384,13 +338,11 @@ filepath.VolumeName path
 path | filepath.VolumeName  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 

--- a/docs/content/functions/math.md
+++ b/docs/content/functions/math.md
@@ -31,18 +31,18 @@ $ gomplate -i '{{ add 2.5 2.5 }}'
 
 ## `math.Abs`
 
-Returns the absolute value of a given number. When the input is an integer, , the result will be an `int64`, otherwise it will be an `float64`.
+Returns the absolute value of a given number. When the input is an integer, the result will be an `int64`, otherwise it will be a `float64`.
 
 ### Usage
 ```go
-math.Abs num
+math.Abs num 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `num`  | _(required)_ The input number |
+| name | description |
+|------|-------------|
+| `num` | _(required)_ The input number |
 
 ### Examples
 
@@ -59,13 +59,16 @@ Adds all given operators. When one of the inputs is a floating-point number, the
 
 ### Usage
 ```go
-math.Add n...
-```
-```go
-x | math.Add.Add n...
+math.Add n... 
 ```
 
-### Example
+### Arguments
+
+| name | description |
+|------|-------------|
+| `n...` | _(required)_ The numbers to add together |
+
+### Examples
 
 ```console
 $ gomplate -i '{{ math.Add 1 2 3 4 }} {{ math.Add 1.5 2 3 }}'
@@ -80,19 +83,19 @@ Returns the least integer value greater than or equal to a given floating-point 
 
 ### Usage
 ```go
-math.Ceil num
+math.Ceil num 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
 
 ### Examples
 
 ```console
-$ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}ceil {{ printf "%#v" . }} = {{ math.Ceil . }}{{"\n"}}{{ end }}' 
+$ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}ceil {{ printf "%#v" . }} = {{ math.Ceil . }}{{"\n"}}{{ end }}'
 ceil 5.1 = 6
 ceil 42 = 42
 ceil "3.14" = 4
@@ -110,13 +113,21 @@ Divide the first number by the second. Division by zero is disallowed. The resul
 
 ### Usage
 ```go
-math.Div a b
-```
-```go
-b | math.Div a
+math.Div a b 
 ```
 
-### Example
+```go
+b | math.Div a  
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `a` | _(required)_ The divisor |
+| `b` | _(required)_ The dividend |
+
+### Examples
 
 ```console
 $ gomplate -i '{{ math.Div 8 2 }} {{ math.Div 3 2 }}'
@@ -131,13 +142,13 @@ Returns the greatest integer value less than or equal to a given floating-point 
 
 ### Usage
 ```go
-math.Floor num
+math.Floor num 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
 
 ### Examples
@@ -161,13 +172,13 @@ Returns whether or not the given number can be interpreted as a floating-point l
 
 ### Usage
 ```go
-math.IsFloat num
+math.IsFloat num 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `num` | _(required)_ The value to test |
 
 ### Examples
@@ -185,17 +196,16 @@ Inf is a float
 ## `math.IsInt`
 
 Returns whether or not the given number is an integer.
-Returns whether or not the given number can be interpreted as a floating-point literal, as defined by the [Go language reference](https://golang.org/ref/spec#Integer_literals).
 
 ### Usage
 ```go
-math.IsInt num
+math.IsInt num 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `num` | _(required)_ The value to test |
 
 ### Examples
@@ -213,13 +223,13 @@ Returns whether the given input is a number. Useful for `if` conditions.
 
 ### Usage
 ```go
-math.IsNum in
+math.IsNum in 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `in` | _(required)_ The value to test |
 
 ### Examples
@@ -235,14 +245,14 @@ Returns the largest number provided. If any values are floating-point numbers, a
 
 ### Usage
 ```go
-math.Max nums...
+math.Max nums... 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `nums` | _(required)_ One or more numbers to compare |
+| name | description |
+|------|-------------|
+| `nums...` | _(required)_ One or more numbers to compare |
 
 ### Examples
 
@@ -257,14 +267,14 @@ Returns the smallest number provided. If any values are floating-point numbers, 
 
 ### Usage
 ```go
-math.Min nums...
+math.Min nums... 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `nums` | _(required)_ One or more numbers to compare |
+| name | description |
+|------|-------------|
+| `nums...` | _(required)_ One or more numbers to compare |
 
 ### Examples
 
@@ -281,13 +291,16 @@ Multiply all given operators together.
 
 ### Usage
 ```go
-math.Mul n...
-```
-```go
-x | math.Mul n...
+math.Mul n... 
 ```
 
-### Example
+### Arguments
+
+| name | description |
+|------|-------------|
+| `n...` | _(required)_ The numbers to multiply |
+
+### Examples
 
 ```console
 $ gomplate -i '{{ math.Mul 8 8 2 }}'
@@ -302,13 +315,17 @@ Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://go
 
 ### Usage
 ```go
-math.Pow b n
-```
-```go
-n | math.Pow b
+math.Pow b n 
 ```
 
-### Example
+### Arguments
+
+| name | description |
+|------|-------------|
+| `b` | _(required)_ The base |
+| `n` | _(required)_ The exponent |
+
+### Examples
 
 ```console
 $ gomplate -i '{{ math.Pow 10 2 }}'
@@ -327,13 +344,21 @@ Return the remainder from an integer division operation.
 
 ### Usage
 ```go
-math.Rem a b
-```
-```go
-b | math.Rem b
+math.Rem a b 
 ```
 
-### Example
+```go
+b | math.Rem a  
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `a` | _(required)_ The divisor |
+| `b` | _(required)_ The dividend |
+
+### Examples
 
 ```console
 $ gomplate -i '{{ math.Rem 5 3 }}'
@@ -350,13 +375,13 @@ Returns the nearest integer, rounding half away from zero.
 
 ### Usage
 ```go
-math.Round num
+math.Round num 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
 
 ### Examples
@@ -381,13 +406,13 @@ Note that the sequence _may_ not end at `end`, if `end` is not divisible by `ste
 
 ### Usage
 ```go
-math.Seq [start] end [step]
+math.Seq [start] end [step] 
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `start` | _(optional)_ The first number in the sequence (defaults to `1`) |
 | `end` | _(required)_ The last number in the sequence |
 | `step` | _(optional)_ The amount to increment between each number (defaults to `1`) |
@@ -396,9 +421,8 @@ math.Seq [start] end [step]
 
 ```console
 $ gomplate -i '{{ range (math.Seq 5) }}{{.}} {{end}}'
-1 2 3 4 5 
+1 2 3 4 5
 ```
-
 ```console
 $ gomplate -i '{{ conv.Join (math.Seq 10 -3 2) ", " }}'
 10, 8, 6, 4, 2, 0, -2
@@ -412,13 +436,21 @@ Subtract the second from the first of the given operators.  When one of the inpu
 
 ### Usage
 ```go
-math.Sub a b
-```
-```go
-b | math.Sub a
+math.Sub a b 
 ```
 
-### Example
+```go
+b | math.Sub a  
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `a` | _(required)_ The minuend (the number to subtract from) |
+| `b` | _(required)_ The subtrahend (the number being subtracted) |
+
+### Examples
 
 ```console
 $ gomplate -i '{{ math.Sub 3 1 }}'

--- a/docs/content/functions/path.md
+++ b/docs/content/functions/path.md
@@ -5,9 +5,9 @@ menu:
     parent: functions
 ---
 
-The path functions are split into 2 namespaces: 
+gomplate's path functions are split into 2 namespaces:
 - `path`, which is useful for manipulating slash-based (`/`) paths, such as in URLs
-- `filepath`, which should be used for local filesystem paths, especially when Windows paths may be involved
+- `filepath`, which should be used for local filesystem paths, especially when Windows paths may be involved.
 
 This page documents the `path` namespace - see also the [`filepath`](../filepath) documentation.
 
@@ -15,11 +15,9 @@ These functions are wrappers for Go's [`path`](https://golang.org/pkg/path/) and
 
 ## `path.Base`
 
-
 Returns the last element of path. Trailing slashes are removed before extracting the last element. If the path is empty, Base returns `.`. If the path consists entirely of slashes, Base returns `/`.
 
 A wrapper for Go's [`path.Base`](https://golang.org/pkg/path/#Base) function.
-
 
 ### Usage
 ```go
@@ -30,13 +28,11 @@ path.Base path
 path | path.Base  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -47,11 +43,9 @@ foo
 
 ## `path.Clean`
 
-
 Clean returns the shortest path name equivalent to path by purely lexical processing.
 
 A wrapper for Go's [`path.Clean`](https://golang.org/pkg/path/#Clean) function.
-
 
 ### Usage
 ```go
@@ -62,13 +56,11 @@ path.Clean path
 path | path.Clean  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -79,11 +71,9 @@ $ gomplate -i '{{ path.Clean "/tmp//foo/../" }}'
 
 ## `path.Dir`
 
-
 Returns all but the last element of path, typically the path's directory.
 
 A wrapper for Go's [`path.Dir`](https://golang.org/pkg/path/#Dir) function.
-
 
 ### Usage
 ```go
@@ -94,13 +84,11 @@ path.Dir path
 path | path.Dir  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -111,11 +99,9 @@ $ gomplate -i '{{ path.Dir "/tmp/foo" }}'
 
 ## `path.Ext`
 
-
 Returns the file name extension used by path.
 
 A wrapper for Go's [`path.Ext`](https://golang.org/pkg/path/#Ext) function.
-
 
 ### Usage
 ```go
@@ -126,13 +112,11 @@ path.Ext path
 path | path.Ext  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -143,11 +127,9 @@ $ gomplate -i '{{ path.Ext "/tmp/foo.csv" }}'
 
 ## `path.IsAbs`
 
-
 Reports whether the path is absolute.
 
 A wrapper for Go's [`path.IsAbs`](https://golang.org/pkg/path/#IsAbs) function.
-
 
 ### Usage
 ```go
@@ -158,13 +140,11 @@ path.IsAbs path
 path | path.IsAbs  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 
@@ -177,24 +157,20 @@ the path is relative
 
 ## `path.Join`
 
-
 Joins any number of path elements into a single path, adding a separating slash if necessary.
 
 A wrapper for Go's [`path.Join`](https://golang.org/pkg/path/#Join) function.
-
 
 ### Usage
 ```go
 path.Join elem... 
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `elem...` | _(required)_ The path elements to join (0 or more) |
-
 
 ### Examples
 
@@ -205,17 +181,14 @@ $ gomplate -i '{{ path.Join "/tmp" "foo" "bar" }}'
 
 ## `path.Match`
 
-
 Reports whether name matches the shell file name pattern.
 
 A wrapper for Go's [`path.Match`](https://golang.org/pkg/path/#Match) function.
-
 
 ### Usage
 ```go
 path.Match pattern path 
 ```
-
 
 ### Arguments
 
@@ -223,7 +196,6 @@ path.Match pattern path
 |------|-------------|
 | `pattern` | _(required)_ The pattern to match on |
 | `path` | _(required)_ The path to match |
-
 
 ### Examples
 
@@ -234,13 +206,11 @@ true
 
 ## `path.Split`
 
-
 Splits path immediately following the final slash, separating it into a directory and file name component.
 
 The function returns an array with two values, the first being the diretory, and the second the file.
 
 A wrapper for Go's [`path.Split`](https://golang.org/pkg/path/#Split) function.
-
 
 ### Usage
 ```go
@@ -251,13 +221,11 @@ path.Split path
 path | path.Split  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `path` | _(required)_ The input path |
-
 
 ### Examples
 

--- a/docs/content/functions/test.md
+++ b/docs/content/functions/test.md
@@ -10,13 +10,10 @@ assumptions and can cause template generation to fail in specific cases.
 
 ## `test.Assert`
 
-
 **Alias:** `assert`
-
 
 Asserts that the given expression or value is `true`. If it is not, causes
 template generation to fail immediately with an optional message.
-
 
 ### Usage
 ```go
@@ -27,14 +24,12 @@ test.Assert [message] value
 value | test.Assert [message]  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `message` | _(optional)_ The optional message to provide in the case of failure |
 | `value` | _(required)_ The value to test |
-
 
 ### Examples
 
@@ -47,12 +42,9 @@ template: <arg>:1:3: executing "<arg>" at <assert "something ho...>: error calli
 
 ## `test.Fail`
 
-
 **Alias:** `fail`
 
-
 Cause template generation to fail immediately, with an optional message.
-
 
 ### Usage
 ```go
@@ -63,13 +55,11 @@ test.Fail [message]
 message | test.Fail  
 ```
 
-
 ### Arguments
 
 | name | description |
 |------|-------------|
 | `message` | _(optional)_ The optional message to provide |
-
 
 ### Examples
 


### PR DESCRIPTION
This is _the beginning_ of an idea to generate the doc markdown in a more uniform way.

I have a vague awareness that Hugo (which I use for generating the doc site) may support something similar, but I don't know how it works, and I think I may be able to eventually generate other formats of docs (such as some man pages, as in #151?) from this...

At the very least, it'll help clean up the differences in formatting, and will probably give me a kick in the pants to better-document some of the older functions.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>