### PR TITLE
Fixing MIME type precedence

### DIFF
--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -92,7 +92,7 @@ These are the supported types:
 
 ### Overriding MIME Types
 
-On occasion it's necessary to override the detected MIME type. To accomplish this, gomplate supports a `type` query string parameter on datasource URLs. This can contain the same value as a standard [HTTP Content-Type][] header.
+On occasion it's necessary to override the detected (via file extension or `Contrent-Type` header) MIME type. To accomplish this, gomplate supports a `type` query string parameter on datasource URLs. This can contain the same value as a standard [HTTP Content-Type][] header.
 
 For example, to force a file named `data.txt` to be parsed as a JSON document:
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -49,6 +49,13 @@ func mirrorHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
+func typeHandler(t, body string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", t)
+		w.Write([]byte(body))
+	}
+}
+
 // freeport - find a free TCP port for immediate use. No guarantees!
 func freeport() (port int, addr string) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})


### PR DESCRIPTION
Fixes #370, closes #373 

This defers the mime type calculation until it's actually necessary. I've also severely simplified (and eliminated uses of) `NewSource`. It can be deprecated/removed later. Also I've noticed that `Ext` and `Params` aren't used at all, and contain info that can be easily calculated from the URL. And most (all?) of the properties of the `Source` struct should be unexported. But those things can (will!) happen in a followup PR.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>