### PR TITLE
Return error instead of using log.Fatal

### DIFF
--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -24,15 +24,15 @@ func TestTag_MissingKey(t *testing.T) {
 		},
 	}
 	e := &Ec2Info{
-		describer: func() InstanceDescriber {
-			return client
+		describer: func() (InstanceDescriber, error) {
+			return client, nil
 		},
 		metaClient: ec2meta,
 		cache:      make(map[string]interface{}),
 	}
 
-	assert.Empty(t, e.Tag("missing"))
-	assert.Equal(t, "default", e.Tag("missing", "default"))
+	assert.Empty(t, must(e.Tag("missing")))
+	assert.Equal(t, "default", must(e.Tag("missing", "default")))
 }
 
 func TestTag_ValidKey(t *testing.T) {
@@ -51,15 +51,15 @@ func TestTag_ValidKey(t *testing.T) {
 		},
 	}
 	e := &Ec2Info{
-		describer: func() InstanceDescriber {
-			return client
+		describer: func() (InstanceDescriber, error) {
+			return client, nil
 		},
 		metaClient: ec2meta,
 		cache:      make(map[string]interface{}),
 	}
 
-	assert.Equal(t, "bar", e.Tag("foo"))
-	assert.Equal(t, "bar", e.Tag("foo", "default"))
+	assert.Equal(t, "bar", must(e.Tag("foo")))
+	assert.Equal(t, "bar", must(e.Tag("foo", "default")))
 }
 
 func TestTag_NonEC2(t *testing.T) {
@@ -68,15 +68,15 @@ func TestTag_NonEC2(t *testing.T) {
 	defer server.Close()
 	client := DummyInstanceDescriber{}
 	e := &Ec2Info{
-		describer: func() InstanceDescriber {
-			return client
+		describer: func() (InstanceDescriber, error) {
+			return client, nil
 		},
 		metaClient: ec2meta,
 		cache:      make(map[string]interface{}),
 	}
 
-	assert.Equal(t, "", e.Tag("foo"))
-	assert.Equal(t, "default", e.Tag("foo", "default"))
+	assert.Equal(t, "", must(e.Tag("foo")))
+	assert.Equal(t, "default", must(e.Tag("foo", "default")))
 }
 
 func TestNewEc2Info(t *testing.T) {
@@ -95,11 +95,11 @@ func TestNewEc2Info(t *testing.T) {
 		},
 	}
 	e := NewEc2Info(ClientOptions{})
-	e.describer = func() InstanceDescriber {
-		return client
+	e.describer = func() (InstanceDescriber, error) {
+		return client, nil
 	}
 	e.metaClient = ec2meta
 
-	assert.Equal(t, "bar", e.Tag("foo"))
-	assert.Equal(t, "bar", e.Tag("foo", "default"))
+	assert.Equal(t, "bar", must(e.Tag("foo")))
+	assert.Equal(t, "bar", must(e.Tag("foo", "default")))
 }

--- a/aws/ec2meta.go
+++ b/aws/ec2meta.go
@@ -3,10 +3,11 @@ package aws
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/hairyhenderson/gomplate/env"
 )
@@ -50,13 +51,15 @@ func unreachable(err error) bool {
 	return false
 }
 
-func (e *Ec2Meta) retrieveMetadata(url string, def ...string) string {
+// retrieve EC2 metadata, defaulting if we're not in EC2 or if there's a non-OK
+// response. If there is an OK response, but we can't parse it, this errors
+func (e *Ec2Meta) retrieveMetadata(url string, def ...string) (string, error) {
 	if value, ok := e.cache[url]; ok {
-		return value
+		return value, nil
 	}
 
 	if e.nonAWS {
-		return returnDefault(def)
+		return returnDefault(def), nil
 	}
 
 	if e.Client == nil {
@@ -71,27 +74,27 @@ func (e *Ec2Meta) retrieveMetadata(url string, def ...string) string {
 		if unreachable(err) {
 			e.nonAWS = true
 		}
-		return returnDefault(def)
+		return returnDefault(def), nil
 	}
 
 	// nolint: errcheck
 	defer resp.Body.Close()
 	if resp.StatusCode > 399 {
-		return returnDefault(def)
+		return returnDefault(def), nil
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("Failed to read response body from %s: %v", url, err)
+		return "", errors.Wrapf(err, "Failed to read response body from %s", url)
 	}
 	value := strings.TrimSpace(string(body))
 	e.cache[url] = value
 
-	return value
+	return value, nil
 }
 
 // Meta -
-func (e *Ec2Meta) Meta(key string, def ...string) string {
+func (e *Ec2Meta) Meta(key string, def ...string) (string, error) {
 	if e.Endpoint == "" {
 		e.Endpoint = DefaultEndpoint
 	}
@@ -101,7 +104,7 @@ func (e *Ec2Meta) Meta(key string, def ...string) string {
 }
 
 // Dynamic -
-func (e *Ec2Meta) Dynamic(key string, def ...string) string {
+func (e *Ec2Meta) Dynamic(key string, def ...string) (string, error) {
 	if e.Endpoint == "" {
 		e.Endpoint = DefaultEndpoint
 	}
@@ -111,21 +114,24 @@ func (e *Ec2Meta) Dynamic(key string, def ...string) string {
 }
 
 // Region -
-func (e *Ec2Meta) Region(def ...string) string {
+func (e *Ec2Meta) Region(def ...string) (string, error) {
 	defaultRegion := returnDefault(def)
 	if defaultRegion == "" {
-		defaultRegion = "unknown"
+		defaultRegion = unknown
 	}
 
-	doc := e.Dynamic("instance-identity/document", `{"region":"`+defaultRegion+`"}`)
+	doc, err := e.Dynamic("instance-identity/document", `{"region":"`+defaultRegion+`"}`)
+	if err != nil {
+		return "", err
+	}
 	obj := &InstanceDocument{
 		Region: defaultRegion,
 	}
-	err := json.Unmarshal([]byte(doc), &obj)
+	err = json.Unmarshal([]byte(doc), &obj)
 	if err != nil {
-		log.Fatalf("Unable to unmarshal JSON object %s: %v", doc, err)
+		return "", errors.Wrapf(err, "Unable to unmarshal JSON object %s", doc)
 	}
-	return obj.Region
+	return obj.Region, nil
 }
 
 // InstanceDocument -

--- a/aws/ec2meta_test.go
+++ b/aws/ec2meta_test.go
@@ -7,57 +7,64 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func must(r interface{}, err error) interface{} {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
 func TestMeta_MissingKey(t *testing.T) {
 	server, ec2meta := MockServer(404, "")
 	defer server.Close()
 
-	assert.Empty(t, ec2meta.Meta("foo"))
-	assert.Equal(t, "default", ec2meta.Meta("foo", "default"))
+	assert.Empty(t, must(ec2meta.Meta("foo")))
+	assert.Equal(t, "default", must(ec2meta.Meta("foo", "default")))
 }
 
 func TestMeta_ValidKey(t *testing.T) {
 	server, ec2meta := MockServer(200, "i-1234")
 	defer server.Close()
 
-	assert.Equal(t, "i-1234", ec2meta.Meta("instance-id"))
-	assert.Equal(t, "i-1234", ec2meta.Meta("instance-id", "unused default"))
+	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id")))
+	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id", "unused default")))
 }
 
 func TestDynamic_MissingKey(t *testing.T) {
 	server, ec2meta := MockServer(404, "")
 	defer server.Close()
 
-	assert.Empty(t, ec2meta.Dynamic("foo"))
-	assert.Equal(t, "default", ec2meta.Dynamic("foo", "default"))
+	assert.Empty(t, must(ec2meta.Dynamic("foo")))
+	assert.Equal(t, "default", must(ec2meta.Dynamic("foo", "default")))
 }
 
 func TestDynamic_ValidKey(t *testing.T) {
 	server, ec2meta := MockServer(200, "i-1234")
 	defer server.Close()
 
-	assert.Equal(t, "i-1234", ec2meta.Dynamic("instance-id"))
-	assert.Equal(t, "i-1234", ec2meta.Dynamic("instance-id", "unused default"))
+	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id")))
+	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id", "unused default")))
 }
 
 func TestRegion_NoRegion(t *testing.T) {
 	server, ec2meta := MockServer(200, "{}")
 	defer server.Close()
 
-	assert.Equal(t, "unknown", ec2meta.Region())
+	assert.Equal(t, "unknown", must(ec2meta.Region()))
 }
 
 func TestRegion_NoRegionWithDefault(t *testing.T) {
 	server, ec2meta := MockServer(200, "{}")
 	defer server.Close()
 
-	assert.Equal(t, "foo", ec2meta.Region("foo"))
+	assert.Equal(t, "foo", must(ec2meta.Region("foo")))
 }
 
 func TestRegion_KnownRegion(t *testing.T) {
 	server, ec2meta := MockServer(200, `{"region":"us-east-1"}`)
 	defer server.Close()
 
-	assert.Equal(t, "us-east-1", ec2meta.Region())
+	assert.Equal(t, "us-east-1", must(ec2meta.Region()))
 }
 
 func TestUnreachable(t *testing.T) {
@@ -71,5 +78,5 @@ func TestRetrieveMetadata_NonEC2(t *testing.T) {
 	ec2meta := NewEc2Meta(ClientOptions{})
 	ec2meta.nonAWS = true
 
-	assert.Equal(t, "foo", ec2meta.retrieveMetadata("", "foo"))
+	assert.Equal(t, "foo", must(ec2meta.retrieveMetadata("", "foo")))
 }

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -32,7 +32,7 @@ func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
 func NewDummyEc2Info(metaClient *Ec2Meta) *Ec2Info {
 	i := &Ec2Info{
 		metaClient: metaClient,
-		describer:  func() InstanceDescriber { return DummyInstanceDescriber{} },
+		describer:  func() (InstanceDescriber, error) { return DummyInstanceDescriber{}, nil },
 	}
 	return i
 }

--- a/base64/base64.go
+++ b/base64/base64.go
@@ -2,24 +2,23 @@ package base64
 
 import (
 	b64 "encoding/base64"
-	"log"
 )
 
 // Encode - Encode data in base64 format
-func Encode(in []byte) string {
-	return b64.StdEncoding.EncodeToString(in)
+func Encode(in []byte) (string, error) {
+	return b64.StdEncoding.EncodeToString(in), nil
 }
 
 // Decode - Decode a base64-encoded string
-func Decode(in string) []byte {
+func Decode(in string) ([]byte, error) {
 	o, err := b64.StdEncoding.DecodeString(in)
 	if err != nil {
 		// maybe it's in the URL variant?
 		o, err = b64.URLEncoding.DecodeString(in)
 		if err != nil {
 			// ok, just give up...
-			log.Fatal(err)
+			return nil, err
 		}
 	}
-	return o
+	return o, nil
 }

--- a/base64/base64_test.go
+++ b/base64/base64_test.go
@@ -6,22 +6,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func must(r interface{}, err error) interface{} {
+	if err != nil {
+		return err
+	}
+	return r
+}
+
 func TestEncode(t *testing.T) {
-	assert.Equal(t, "", Encode([]byte("")))
-	assert.Equal(t, "Zg==", Encode([]byte("f")))
-	assert.Equal(t, "Zm8=", Encode([]byte("fo")))
-	assert.Equal(t, "Zm9v", Encode([]byte("foo")))
-	assert.Equal(t, "Zm9vYg==", Encode([]byte("foob")))
-	assert.Equal(t, "Zm9vYmE=", Encode([]byte("fooba")))
-	assert.Equal(t, "Zm9vYmFy", Encode([]byte("foobar")))
+	assert.Equal(t, "", must(Encode([]byte(""))))
+	assert.Equal(t, "Zg==", must(Encode([]byte("f"))))
+	assert.Equal(t, "Zm8=", must(Encode([]byte("fo"))))
+	assert.Equal(t, "Zm9v", must(Encode([]byte("foo"))))
+	assert.Equal(t, "Zm9vYg==", must(Encode([]byte("foob"))))
+	assert.Equal(t, "Zm9vYmE=", must(Encode([]byte("fooba"))))
+	assert.Equal(t, "Zm9vYmFy", must(Encode([]byte("foobar"))))
+	assert.Equal(t, "A+B/", must(Encode([]byte{0x03, 0xe0, 0x7f})))
 }
 
 func TestDecode(t *testing.T) {
-	assert.Equal(t, []byte(""), Decode(""))
-	assert.Equal(t, []byte("f"), Decode("Zg=="))
-	assert.Equal(t, []byte("fo"), Decode("Zm8="))
-	assert.Equal(t, []byte("foo"), Decode("Zm9v"))
-	assert.Equal(t, []byte("foob"), Decode("Zm9vYg=="))
-	assert.Equal(t, []byte("fooba"), Decode("Zm9vYmE="))
-	assert.Equal(t, []byte("foobar"), Decode("Zm9vYmFy"))
+	assert.Equal(t, []byte(""), must(Decode("")))
+	assert.Equal(t, []byte("f"), must(Decode("Zg==")))
+	assert.Equal(t, []byte("fo"), must(Decode("Zm8=")))
+	assert.Equal(t, []byte("foo"), must(Decode("Zm9v")))
+	assert.Equal(t, []byte("foob"), must(Decode("Zm9vYg==")))
+	assert.Equal(t, []byte("fooba"), must(Decode("Zm9vYmE=")))
+	assert.Equal(t, []byte("foobar"), must(Decode("Zm9vYmFy")))
+	assert.Equal(t, []byte{0x03, 0xe0, 0x7f}, must(Decode("A+B/")))
+	assert.Equal(t, []byte{0x03, 0xe0, 0x7f}, must(Decode("A-B_")))
+
+	_, err := Decode("b.o.g.u.s")
+	assert.Error(t, err)
 }

--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -1,3 +1,7 @@
+/*
+The gomplate command
+
+*/
 package main
 
 import (

--- a/crypto/pbkdf2.go
+++ b/crypto/pbkdf2.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha1" //nolint: gosec
 	"crypto/sha256"
 	"crypto/sha512"
-	"fmt"
 	"hash"
+
+	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -42,7 +43,7 @@ func StrToHash(hash string) (crypto.Hash, error) {
 	case "SHA512_256", "SHA512/256", "SHA-512_256", "SHA-512/256":
 		return crypto.SHA512_256, nil
 	}
-	return 0, fmt.Errorf("no such hash %s", hash)
+	return 0, errors.Errorf("no such hash %s", hash)
 }
 
 // PBKDF2 - Run the Password-Based Key Derivation Function #2 as defined in
@@ -50,7 +51,7 @@ func StrToHash(hash string) (crypto.Hash, error) {
 func PBKDF2(password, salt []byte, iter, keylen int, hashFunc crypto.Hash) ([]byte, error) {
 	h, ok := hashFuncs[hashFunc]
 	if !ok {
-		return nil, fmt.Errorf("hashFunc not supported: %v", hashFunc)
+		return nil, errors.Errorf("hashFunc not supported: %v", hashFunc)
 	}
 	return pbkdf2.Key(password, salt, iter, keylen, h), nil
 }

--- a/data/data.go
+++ b/data/data.go
@@ -4,68 +4,68 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
-	"log"
 	"strings"
 
 	// XXX: replace once https://github.com/BurntSushi/toml/pull/179 is merged
 	"github.com/hairyhenderson/toml"
+	"github.com/pkg/errors"
 	"github.com/ugorji/go/codec"
 	yaml "gopkg.in/yaml.v2"
 )
 
-func unmarshalObj(obj map[string]interface{}, in string, f func([]byte, interface{}) error) map[string]interface{} {
+func unmarshalObj(obj map[string]interface{}, in string, f func([]byte, interface{}) error) (map[string]interface{}, error) {
 	err := f([]byte(in), &obj)
 	if err != nil {
-		log.Fatalf("Unable to unmarshal object %s: %v", in, err)
+		return nil, errors.Wrapf(err, "Unable to unmarshal object %s", in)
 	}
-	return obj
+	return obj, nil
 }
 
-func unmarshalArray(obj []interface{}, in string, f func([]byte, interface{}) error) []interface{} {
+func unmarshalArray(obj []interface{}, in string, f func([]byte, interface{}) error) ([]interface{}, error) {
 	err := f([]byte(in), &obj)
 	if err != nil {
-		log.Fatalf("Unable to unmarshal array %s: %v", in, err)
+		return nil, errors.Wrapf(err, "Unable to unmarshal array %s", in)
 	}
-	return obj
+	return obj, nil
 }
 
 // JSON - Unmarshal a JSON Object
-func JSON(in string) map[string]interface{} {
+func JSON(in string) (map[string]interface{}, error) {
 	obj := make(map[string]interface{})
 	return unmarshalObj(obj, in, yaml.Unmarshal)
 }
 
 // JSONArray - Unmarshal a JSON Array
-func JSONArray(in string) []interface{} {
+func JSONArray(in string) ([]interface{}, error) {
 	obj := make([]interface{}, 1)
 	return unmarshalArray(obj, in, yaml.Unmarshal)
 }
 
 // YAML - Unmarshal a YAML Object
-func YAML(in string) map[string]interface{} {
+func YAML(in string) (map[string]interface{}, error) {
 	obj := make(map[string]interface{})
 	return unmarshalObj(obj, in, yaml.Unmarshal)
 }
 
 // YAMLArray - Unmarshal a YAML Array
-func YAMLArray(in string) []interface{} {
+func YAMLArray(in string) ([]interface{}, error) {
 	obj := make([]interface{}, 1)
 	return unmarshalArray(obj, in, yaml.Unmarshal)
 }
 
 // TOML - Unmarshal a TOML Object
-func TOML(in string) interface{} {
+func TOML(in string) (interface{}, error) {
 	obj := make(map[string]interface{})
 	return unmarshalObj(obj, in, toml.Unmarshal)
 }
 
-func parseCSV(args ...string) ([][]string, []string) {
+func parseCSV(args ...string) ([][]string, []string, error) {
 	in, delim, hdr := csvParseArgs(args...)
 	c := csv.NewReader(strings.NewReader(in))
 	c.Comma = rune(delim[0])
 	records, err := c.ReadAll()
 	if err != nil {
-		log.Fatal(err)
+		return nil, nil, err
 	}
 	if len(records) > 0 {
 		if hdr == nil {
@@ -78,7 +78,7 @@ func parseCSV(args ...string) ([][]string, []string) {
 			}
 		}
 	}
-	return records, hdr
+	return records, hdr, nil
 }
 
 func csvParseArgs(args ...string) (in, delim string, hdr []string) {
@@ -119,12 +119,15 @@ func autoIndex(i int) string {
 //     in - the CSV-format string to parse
 // returns:
 //  an array of rows, which are arrays of cells (strings)
-func CSV(args ...string) [][]string {
-	records, hdr := parseCSV(args...)
+func CSV(args ...string) ([][]string, error) {
+	records, hdr, err := parseCSV(args...)
+	if err != nil {
+		return nil, err
+	}
 	records = append(records, nil)
 	copy(records[1:], records)
 	records[0] = hdr
-	return records
+	return records, nil
 }
 
 // CSVByRow - Unmarshal CSV in a row-oriented form
@@ -136,8 +139,11 @@ func CSV(args ...string) [][]string {
 //     in - the CSV-format string to parse
 // returns:
 //  an array of rows, indexed by the header name
-func CSVByRow(args ...string) (rows []map[string]string) {
-	records, hdr := parseCSV(args...)
+func CSVByRow(args ...string) (rows []map[string]string, err error) {
+	records, hdr, err := parseCSV(args...)
+	if err != nil {
+		return nil, err
+	}
 	for _, record := range records {
 		m := make(map[string]string)
 		for i, v := range record {
@@ -145,7 +151,7 @@ func CSVByRow(args ...string) (rows []map[string]string) {
 		}
 		rows = append(rows, m)
 	}
-	return rows
+	return rows, nil
 }
 
 // CSVByColumn - Unmarshal CSV in a Columnar form
@@ -157,38 +163,37 @@ func CSVByRow(args ...string) (rows []map[string]string) {
 //     in - the CSV-format string to parse
 // returns:
 //  a map of columns, indexed by the header name. values are arrays of strings
-func CSVByColumn(args ...string) (cols map[string][]string) {
-	records, hdr := parseCSV(args...)
+func CSVByColumn(args ...string) (cols map[string][]string, err error) {
+	records, hdr, err := parseCSV(args...)
+	if err != nil {
+		return nil, err
+	}
 	cols = make(map[string][]string)
 	for _, record := range records {
 		for i, v := range record {
 			cols[hdr[i]] = append(cols[hdr[i]], v)
 		}
 	}
-	return cols
+	return cols, nil
 }
 
 // ToCSV -
-func ToCSV(args ...interface{}) string {
+func ToCSV(args ...interface{}) (string, error) {
 	delim := ","
 	var in [][]string
 	if len(args) == 2 {
-		d, ok := args[0].(string)
-		if ok {
-			delim = d
-		} else {
-			log.Fatalf("Can't parse ToCSV delimiter (%v) - must be string (is a %T)", args[0], args[0])
-		}
-		in, ok = args[1].([][]string)
+		var ok bool
+		delim, ok = args[0].(string)
 		if !ok {
-			log.Fatal("Can't parse ToCSV input - must be of type [][]string")
+			return "", errors.Errorf("Can't parse ToCSV delimiter (%v) - must be string (is a %T)", args[0], args[0])
 		}
+		args = args[1:]
 	}
 	if len(args) == 1 {
 		var ok bool
 		in, ok = args[0].([][]string)
 		if !ok {
-			log.Fatal("Can't parse ToCSV input - must be of type [][]string")
+			return "", errors.Errorf("Can't parse ToCSV input - must be of type [][]string")
 		}
 	}
 	b := &bytes.Buffer{}
@@ -198,59 +203,66 @@ func ToCSV(args ...interface{}) string {
 	c.UseCRLF = true
 	err := c.WriteAll(in)
 	if err != nil {
-		log.Fatal(err)
+		return "", err
 	}
-	return b.String()
+	return b.String(), nil
 }
 
-func marshalObj(obj interface{}, f func(interface{}) ([]byte, error)) string {
+func marshalObj(obj interface{}, f func(interface{}) ([]byte, error)) (string, error) {
 	b, err := f(obj)
 	if err != nil {
-		log.Fatalf("Unable to marshal object %s: %v", obj, err)
+		return "", errors.Wrapf(err, "Unable to marshal object %s", obj)
 	}
 
-	return string(b)
+	return string(b), nil
 }
 
-func toJSONBytes(in interface{}) []byte {
+func toJSONBytes(in interface{}) ([]byte, error) {
 	h := &codec.JsonHandle{}
 	h.Canonical = true
 	buf := new(bytes.Buffer)
 	err := codec.NewEncoder(buf, h).Encode(in)
 	if err != nil {
-		log.Fatalf("Unable to marshal %s: %v", in, err)
+		return nil, errors.Wrapf(err, "Unable to marshal %s", in)
 	}
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 // ToJSON - Stringify a struct as JSON
-func ToJSON(in interface{}) string {
-	return string(toJSONBytes(in))
+func ToJSON(in interface{}) (string, error) {
+	s, err := toJSONBytes(in)
+	if err != nil {
+		return "", err
+	}
+	return string(s), nil
 }
 
 // ToJSONPretty - Stringify a struct as JSON (indented)
-func ToJSONPretty(indent string, in interface{}) string {
+func ToJSONPretty(indent string, in interface{}) (string, error) {
 	out := new(bytes.Buffer)
-	b := toJSONBytes(in)
-	err := json.Indent(out, b, "", indent)
+	b, err := toJSONBytes(in)
 	if err != nil {
-		log.Fatalf("Unable to indent JSON %s: %v", b, err)
+		return "", err
+	}
+	err = json.Indent(out, b, "", indent)
+	if err != nil {
+		return "", errors.Wrapf(err, "Unable to indent JSON %s", b)
 	}
 
-	return out.String()
+	return out.String(), nil
 }
 
 // ToYAML - Stringify a struct as YAML
-func ToYAML(in interface{}) string {
+func ToYAML(in interface{}) (string, error) {
 	return marshalObj(in, yaml.Marshal)
 }
 
 // ToTOML - Stringify a struct as TOML
-func ToTOML(in interface{}) string {
+func ToTOML(in interface{}) (string, error) {
 	buf := new(bytes.Buffer)
 	err := toml.NewEncoder(buf).Encode(in)
 	if err != nil {
-		log.Fatalf("Unable to marshal %s: %v", in, err)
+		return "", errors.Wrapf(err, "Unable to marshal %s", in)
 	}
-	return buf.String()
+	return buf.String(), nil
 }

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ugorji/go/codec"
+
+	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +18,8 @@ func TestUnmarshalObj(t *testing.T) {
 		"true": true,
 	}
 
-	test := func(actual map[string]interface{}) {
+	test := func(actual map[string]interface{}, err error) {
+		assert.NoError(t, err)
 		assert.Equal(t, expected["foo"], actual["foo"])
 		assert.Equal(t, expected["one"], actual["one"])
 		assert.Equal(t, expected["true"], actual["true"])
@@ -25,13 +30,20 @@ func TestUnmarshalObj(t *testing.T) {
 one: 1.0
 true: true
 `))
+
+	obj := make(map[string]interface{})
+	_, err := unmarshalObj(obj, "SOMETHING", func(in []byte, out interface{}) error {
+		return errors.New("fail")
+	})
+	assert.EqualError(t, err, "Unable to unmarshal object SOMETHING: fail")
 }
 
 func TestUnmarshalArray(t *testing.T) {
 
 	expected := []string{"foo", "bar"}
 
-	test := func(actual []interface{}) {
+	test := func(actual []interface{}, err error) {
+		assert.NoError(t, err)
 		assert.Equal(t, expected[0], actual[0])
 		assert.Equal(t, expected[1], actual[1])
 	}
@@ -40,6 +52,46 @@ func TestUnmarshalArray(t *testing.T) {
 - foo
 - bar
 `))
+
+	obj := make([]interface{}, 1)
+	_, err := unmarshalArray(obj, "SOMETHING", func(in []byte, out interface{}) error {
+		return errors.New("fail")
+	})
+	assert.EqualError(t, err, "Unable to unmarshal array SOMETHING: fail")
+}
+
+func TestMarshalObj(t *testing.T) {
+	expected := "foo"
+	actual, err := marshalObj(nil, func(in interface{}) ([]byte, error) {
+		return []byte("foo"), nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+	_, err = marshalObj(nil, func(in interface{}) ([]byte, error) {
+		return nil, errors.New("fail")
+	})
+	assert.Error(t, err)
+}
+
+func TestToJSONBytes(t *testing.T) {
+	expected := []byte("null")
+	actual, err := toJSONBytes(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+
+	_, err = toJSONBytes(&badObject{})
+	assert.Error(t, err)
+}
+
+type badObject struct {
+}
+
+func (b *badObject) CodecEncodeSelf(e *codec.Encoder) {
+	panic("boom")
+}
+
+func (b *badObject) CodecDecodeSelf(e *codec.Decoder) {
+
 }
 
 func TestToJSON(t *testing.T) {
@@ -56,7 +108,12 @@ func TestToJSON(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, ToJSON(in))
+	out, err := ToJSON(in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+
+	_, err = ToJSON(&badObject{})
+	assert.Error(t, err)
 }
 
 func TestToJSONPretty(t *testing.T) {
@@ -84,7 +141,12 @@ func TestToJSONPretty(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, ToJSONPretty("  ", in))
+	out, err := ToJSONPretty("  ", in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+
+	_, err = ToJSONPretty("  ", &badObject{})
+	assert.Error(t, err)
 }
 
 func TestToYAML(t *testing.T) {
@@ -110,29 +172,33 @@ key`: map[string]interface{}{
 		},
 		"d": time.Date(2006, time.January, 2, 15, 4, 5, 999999999, mst),
 	}
-	assert.Equal(t, expected, ToYAML(in))
+	out, err := ToYAML(in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 }
 
 func TestCSV(t *testing.T) {
-	in := "first,second,third\n1,2,3\n4,5,6"
 	expected := [][]string{
 		{"first", "second", "third"},
 		{"1", "2", "3"},
 		{"4", "5", "6"},
 	}
-	assert.Equal(t, expected, CSV(in))
+	testdata := []struct {
+		args []string
+		out  [][]string
+	}{
+		{[]string{"first,second,third\n1,2,3\n4,5,6"}, expected},
+		{[]string{";", "first;second;third\r\n1;2;3\r\n4;5;6\r\n"}, expected},
 
-	in = "first;second;third\r\n1;2;3\r\n4;5;6\r\n"
-	assert.Equal(t, expected, CSV(";", in))
-
-	in = ""
-	assert.Equal(t, [][]string{nil}, CSV(in))
-
-	in = "\n"
-	assert.Equal(t, [][]string{nil}, CSV(in))
-
-	in = "foo"
-	assert.Equal(t, [][]string{{"foo"}}, CSV(in))
+		{[]string{""}, [][]string{nil}},
+		{[]string{"\n"}, [][]string{nil}},
+		{[]string{"foo"}, [][]string{{"foo"}}},
+	}
+	for _, d := range testdata {
+		out, err := CSV(d.args...)
+		assert.NoError(t, err)
+		assert.Equal(t, d.out, out)
+	}
 }
 
 func TestCSVByRow(t *testing.T) {
@@ -149,59 +215,55 @@ func TestCSVByRow(t *testing.T) {
 			"third":  "6",
 		},
 	}
-	assert.Equal(t, expected, CSVByRow(in))
-
-	in = "1,2,3\n4,5,6"
-	assert.Equal(t, expected, CSVByRow("first,second,third", in))
-
-	in = "1;2;3\n4;5;6"
-	assert.Equal(t, expected, CSVByRow(";", "first;second;third", in))
-
-	in = "first;second;third\r\n1;2;3\r\n4;5;6"
-	assert.Equal(t, expected, CSVByRow(";", in))
-
-	expected = []map[string]string{
-		{"A": "1", "B": "2", "C": "3"},
-		{"A": "4", "B": "5", "C": "6"},
+	testdata := []struct {
+		args []string
+		out  []map[string]string
+	}{
+		{[]string{in}, expected},
+		{[]string{"first,second,third", "1,2,3\n4,5,6"}, expected},
+		{[]string{";", "first;second;third", "1;2;3\n4;5;6"}, expected},
+		{[]string{";", "first;second;third\r\n1;2;3\r\n4;5;6"}, expected},
+		{[]string{"", "1,2,3\n4,5,6"}, []map[string]string{
+			{"A": "1", "B": "2", "C": "3"},
+			{"A": "4", "B": "5", "C": "6"},
+		}},
+		{[]string{"", "1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"}, []map[string]string{
+			{"A": "1", "B": "1", "C": "1", "D": "1", "E": "1", "F": "1", "G": "1", "H": "1", "I": "1", "J": "1", "K": "1", "L": "1", "M": "1", "N": "1", "O": "1", "P": "1", "Q": "1", "R": "1", "S": "1", "T": "1", "U": "1", "V": "1", "W": "1", "X": "1", "Y": "1", "Z": "1", "AA": "1", "BB": "1", "CC": "1", "DD": "1"},
+		}},
 	}
-
-	in = "1,2,3\n4,5,6"
-	assert.Equal(t, expected, CSVByRow("", in))
-
-	expected = []map[string]string{
-		{"A": "1", "B": "1", "C": "1", "D": "1", "E": "1", "F": "1", "G": "1", "H": "1", "I": "1", "J": "1", "K": "1", "L": "1", "M": "1", "N": "1", "O": "1", "P": "1", "Q": "1", "R": "1", "S": "1", "T": "1", "U": "1", "V": "1", "W": "1", "X": "1", "Y": "1", "Z": "1", "AA": "1", "BB": "1", "CC": "1", "DD": "1"},
+	for _, d := range testdata {
+		out, err := CSVByRow(d.args...)
+		assert.NoError(t, err)
+		assert.Equal(t, d.out, out)
 	}
-
-	in = "1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
-	assert.Equal(t, expected, CSVByRow("", in))
 }
 
 func TestCSVByColumn(t *testing.T) {
-	in := "first,second,third\n1,2,3\n4,5,6"
 	expected := map[string][]string{
 		"first":  {"1", "4"},
 		"second": {"2", "5"},
 		"third":  {"3", "6"},
 	}
-	assert.Equal(t, expected, CSVByColumn(in))
 
-	in = "1,2,3\n4,5,6"
-	assert.Equal(t, expected, CSVByColumn("first,second,third", in))
-
-	in = "1;2;3\n4;5;6"
-	assert.Equal(t, expected, CSVByColumn(";", "first;second;third", in))
-
-	in = "first;second;third\r\n1;2;3\r\n4;5;6"
-	assert.Equal(t, expected, CSVByColumn(";", in))
-
-	expected = map[string][]string{
-		"A": {"1", "4"},
-		"B": {"2", "5"},
-		"C": {"3", "6"},
+	testdata := []struct {
+		args []string
+		out  map[string][]string
+	}{
+		{[]string{"first,second,third\n1,2,3\n4,5,6"}, expected},
+		{[]string{"first,second,third", "1,2,3\n4,5,6"}, expected},
+		{[]string{";", "first;second;third", "1;2;3\n4;5;6"}, expected},
+		{[]string{";", "first;second;third\r\n1;2;3\r\n4;5;6"}, expected},
+		{[]string{"", "1,2,3\n4,5,6"}, map[string][]string{
+			"A": {"1", "4"},
+			"B": {"2", "5"},
+			"C": {"3", "6"},
+		}},
 	}
-
-	in = "1,2,3\n4,5,6"
-	assert.Equal(t, expected, CSVByColumn("", in))
+	for _, d := range testdata {
+		out, err := CSVByColumn(d.args...)
+		assert.NoError(t, err)
+		assert.Equal(t, d.out, out)
+	}
 }
 
 func TestAutoIndex(t *testing.T) {
@@ -222,11 +284,21 @@ func TestToCSV(t *testing.T) {
 	}
 	expected := "first,second,third\r\n1,2,3\r\n4,5,6\r\n"
 
-	assert.Equal(t, expected, ToCSV(in))
+	out, err := ToCSV(in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 
 	expected = "first;second;third\r\n1;2;3\r\n4;5;6\r\n"
 
-	assert.Equal(t, expected, ToCSV(";", in))
+	out, err = ToCSV(";", in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+
+	_, err = ToCSV(42, [][]int{{1, 2}})
+	assert.Error(t, err)
+
+	_, err = ToCSV([][]int{{1, 2}})
+	assert.Error(t, err)
 }
 
 func TestTOML(t *testing.T) {
@@ -299,7 +371,9 @@ hosts = [
 		},
 	}
 
-	assert.Equal(t, expected, TOML(in))
+	out, err := TOML(in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 }
 
 func TestToTOML(t *testing.T) {
@@ -324,5 +398,7 @@ true = true
 			},
 		},
 	}
-	assert.Equal(t, expected, ToTOML(in))
+	out, err := ToTOML(in)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 }

--- a/data/datasource_awssmp.go
+++ b/data/datasource_awssmp.go
@@ -55,6 +55,6 @@ func readAWSSMPParam(source *Source, paramPath string) ([]byte, error) {
 
 	result := *response.Parameter
 
-	output := ToJSON(result)
-	return []byte(output), nil
+	output, err := ToJSON(result)
+	return []byte(output), err
 }

--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -148,6 +148,13 @@ func TestDatasourceExists(t *testing.T) {
 	assert.False(t, data.DatasourceExists("bar"))
 }
 
+func must(r interface{}, err error) interface{} {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
 func setupHTTP(code int, mimetype string, body string) (*httptest.Server, *http.Client) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -155,7 +162,7 @@ func setupHTTP(code int, mimetype string, body string) (*httptest.Server, *http.
 		w.WriteHeader(code)
 		if body == "" {
 			// mirror back the headers
-			fmt.Fprintln(w, marshalObj(r.Header, json.Marshal))
+			fmt.Fprintln(w, must(marshalObj(r.Header, json.Marshal)))
 		} else {
 			fmt.Fprintln(w, body)
 		}
@@ -196,11 +203,11 @@ func TestHTTPFile(t *testing.T) {
 
 	actual, err := data.Datasource("foo")
 	assert.NoError(t, err)
-	assert.Equal(t, marshalObj(expected, json.Marshal), marshalObj(actual, json.Marshal))
+	assert.Equal(t, must(marshalObj(expected, json.Marshal)), must(marshalObj(actual, json.Marshal)))
 
 	actual, err = data.Datasource(server.URL)
 	assert.NoError(t, err)
-	assert.Equal(t, marshalObj(expected, json.Marshal), marshalObj(actual, json.Marshal))
+	assert.Equal(t, must(marshalObj(expected, json.Marshal)), must(marshalObj(actual, json.Marshal)))
 }
 
 func TestHTTPFileWithHeaders(t *testing.T) {
@@ -232,7 +239,7 @@ func TestHTTPFileWithHeaders(t *testing.T) {
 	}
 	actual, err := data.Datasource("foo")
 	assert.NoError(t, err)
-	assert.Equal(t, marshalObj(expected, json.Marshal), marshalObj(actual, json.Marshal))
+	assert.Equal(t, must(marshalObj(expected, json.Marshal)), must(marshalObj(actual, json.Marshal)))
 
 	expected = http.Header{
 		"Accept-Encoding": {"test"},
@@ -245,7 +252,7 @@ func TestHTTPFileWithHeaders(t *testing.T) {
 	}
 	actual, err = data.Datasource(server.URL)
 	assert.NoError(t, err)
-	assert.Equal(t, marshalObj(expected, json.Marshal), marshalObj(actual, json.Marshal))
+	assert.Equal(t, must(marshalObj(expected, json.Marshal)), must(marshalObj(actual, json.Marshal)))
 }
 
 func TestParseHeaderArgs(t *testing.T) {

--- a/data/datasource_vault.go
+++ b/data/datasource_vault.go
@@ -33,18 +33,22 @@ func parseVaultParams(sourceURL *url.URL, args []string) (params map[string]inte
 	return params, p, nil
 }
 
-func readVault(source *Source, args ...string) ([]byte, error) {
+func readVault(source *Source, args ...string) (data []byte, err error) {
 	if source.vc == nil {
-		source.vc = vault.New(source.URL)
-		source.vc.Login()
+		source.vc, err = vault.New(source.URL)
+		if err != nil {
+			return nil, err
+		}
+		err = source.vc.Login()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	params, p, err := parseVaultParams(source.URL, args)
 	if err != nil {
 		return nil, err
 	}
-
-	var data []byte
 
 	source.mediaType = jsonMimetype
 	if len(params) > 0 {

--- a/file/file.go
+++ b/file/file.go
@@ -1,10 +1,10 @@
 package file
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/pkg/errors"
 
 	"github.com/spf13/afero"
 )
@@ -16,13 +16,13 @@ var fs = afero.NewOsFs()
 func Read(filename string) (string, error) {
 	inFile, err := fs.OpenFile(filename, os.O_RDONLY, 0)
 	if err != nil {
-		return "", fmt.Errorf("failed to open %s\n%v", filename, err)
+		return "", errors.Wrapf(err, "failed to open %s", filename)
 	}
 	// nolint: errcheck
 	defer inFile.Close()
 	bytes, err := ioutil.ReadAll(inFile)
 	if err != nil {
-		err = fmt.Errorf("read failed for %s\n%v", filename, err)
+		err = errors.Wrapf(err, "read failed for %s", filename)
 		return "", err
 	}
 	return string(bytes), nil

--- a/funcs/aws.go
+++ b/funcs/aws.go
@@ -42,25 +42,25 @@ type Funcs struct {
 }
 
 // EC2Region -
-func (a *Funcs) EC2Region(def ...string) string {
+func (a *Funcs) EC2Region(def ...string) (string, error) {
 	a.metaInit.Do(a.initMeta)
 	return a.meta.Region(def...)
 }
 
 // EC2Meta -
-func (a *Funcs) EC2Meta(key string, def ...string) string {
+func (a *Funcs) EC2Meta(key string, def ...string) (string, error) {
 	a.metaInit.Do(a.initMeta)
 	return a.meta.Meta(key, def...)
 }
 
 // EC2Dynamic -
-func (a *Funcs) EC2Dynamic(key string, def ...string) string {
+func (a *Funcs) EC2Dynamic(key string, def ...string) (string, error) {
 	a.metaInit.Do(a.initMeta)
 	return a.meta.Dynamic(key, def...)
 }
 
 // EC2Tag -
-func (a *Funcs) EC2Tag(tag string, def ...string) string {
+func (a *Funcs) EC2Tag(tag string, def ...string) (string, error) {
 	a.infoInit.Do(a.initInfo)
 	return a.info.Tag(tag, def...)
 }

--- a/funcs/aws_test.go
+++ b/funcs/aws_test.go
@@ -12,12 +12,20 @@ func TestNSIsIdempotent(t *testing.T) {
 	right := AWSNS()
 	assert.True(t, left == right)
 }
+
 func TestAWSFuncs(t *testing.T) {
 	m := aws.NewDummyEc2Meta()
 	i := aws.NewDummyEc2Info(m)
 	af := &Funcs{meta: m, info: i}
-	assert.Equal(t, "unknown", af.EC2Region())
-	assert.Equal(t, "", af.EC2Meta("foo"))
-	assert.Equal(t, "", af.EC2Tag("foo"))
-	assert.Equal(t, "unknown", af.EC2Region())
+	assert.Equal(t, "unknown", must(af.EC2Region()))
+	assert.Equal(t, "", must(af.EC2Meta("foo")))
+	assert.Equal(t, "", must(af.EC2Tag("foo")))
+	assert.Equal(t, "unknown", must(af.EC2Region()))
+}
+
+func must(r interface{}, err error) interface{} {
+	if err != nil {
+		panic(err)
+	}
+	return r
 }

--- a/funcs/base64.go
+++ b/funcs/base64.go
@@ -27,14 +27,15 @@ func AddBase64Funcs(f map[string]interface{}) {
 type Base64Funcs struct{}
 
 // Encode -
-func (f *Base64Funcs) Encode(in interface{}) string {
+func (f *Base64Funcs) Encode(in interface{}) (string, error) {
 	b := toBytes(in)
 	return base64.Encode(b)
 }
 
 // Decode -
-func (f *Base64Funcs) Decode(in interface{}) string {
-	return string(base64.Decode(conv.ToString(in)))
+func (f *Base64Funcs) Decode(in interface{}) (string, error) {
+	out, err := base64.Decode(conv.ToString(in))
+	return string(out), err
 }
 
 type byter interface {

--- a/funcs/base64_test.go
+++ b/funcs/base64_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestBase64Encode(t *testing.T) {
 	bf := &Base64Funcs{}
-	assert.Equal(t, "Zm9vYmFy", bf.Encode("foobar"))
+	assert.Equal(t, "Zm9vYmFy", must(bf.Encode("foobar")))
 }
 
 func TestBase64Decode(t *testing.T) {
 	bf := &Base64Funcs{}
-	assert.Equal(t, "foobar", bf.Decode("Zm9vYmFy"))
+	assert.Equal(t, "foobar", must(bf.Decode("Zm9vYmFy")))
 	// assert.Equal(t, "", bf.Decode(nil))
 }
 
@@ -27,4 +27,5 @@ func TestToBytes(t *testing.T) {
 
 	assert.Equal(t, []byte{}, toBytes(nil))
 
+	assert.Equal(t, []byte("42"), toBytes(42))
 }

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -56,7 +56,7 @@ func (f *ConvFuncs) Slice(args ...interface{}) []interface{} {
 }
 
 // Join -
-func (f *ConvFuncs) Join(in interface{}, sep string) string {
+func (f *ConvFuncs) Join(in interface{}, sep string) (string, error) {
 	return conv.Join(in, sep)
 }
 

--- a/funcs/data.go
+++ b/funcs/data.go
@@ -48,66 +48,66 @@ func AddDataFuncs(f map[string]interface{}, d *data.Data) {
 type DataFuncs struct{}
 
 // JSON -
-func (f *DataFuncs) JSON(in interface{}) map[string]interface{} {
+func (f *DataFuncs) JSON(in interface{}) (map[string]interface{}, error) {
 	return data.JSON(conv.ToString(in))
 }
 
 // JSONArray -
-func (f *DataFuncs) JSONArray(in interface{}) []interface{} {
+func (f *DataFuncs) JSONArray(in interface{}) ([]interface{}, error) {
 	return data.JSONArray(conv.ToString(in))
 }
 
 // YAML -
-func (f *DataFuncs) YAML(in interface{}) map[string]interface{} {
+func (f *DataFuncs) YAML(in interface{}) (map[string]interface{}, error) {
 	return data.YAML(conv.ToString(in))
 }
 
 // YAMLArray -
-func (f *DataFuncs) YAMLArray(in interface{}) []interface{} {
+func (f *DataFuncs) YAMLArray(in interface{}) ([]interface{}, error) {
 	return data.YAMLArray(conv.ToString(in))
 }
 
 // TOML -
-func (f *DataFuncs) TOML(in interface{}) interface{} {
+func (f *DataFuncs) TOML(in interface{}) (interface{}, error) {
 	return data.TOML(conv.ToString(in))
 }
 
 // CSV -
-func (f *DataFuncs) CSV(args ...string) [][]string {
+func (f *DataFuncs) CSV(args ...string) ([][]string, error) {
 	return data.CSV(args...)
 }
 
 // CSVByRow -
-func (f *DataFuncs) CSVByRow(args ...string) (rows []map[string]string) {
+func (f *DataFuncs) CSVByRow(args ...string) (rows []map[string]string, err error) {
 	return data.CSVByRow(args...)
 }
 
 // CSVByColumn -
-func (f *DataFuncs) CSVByColumn(args ...string) (cols map[string][]string) {
+func (f *DataFuncs) CSVByColumn(args ...string) (cols map[string][]string, err error) {
 	return data.CSVByColumn(args...)
 }
 
 // ToCSV -
-func (f *DataFuncs) ToCSV(args ...interface{}) string {
+func (f *DataFuncs) ToCSV(args ...interface{}) (string, error) {
 	return data.ToCSV(args...)
 }
 
 // ToJSON -
-func (f *DataFuncs) ToJSON(in interface{}) string {
+func (f *DataFuncs) ToJSON(in interface{}) (string, error) {
 	return data.ToJSON(in)
 }
 
 // ToJSONPretty -
-func (f *DataFuncs) ToJSONPretty(indent string, in interface{}) string {
+func (f *DataFuncs) ToJSONPretty(indent string, in interface{}) (string, error) {
 	return data.ToJSONPretty(indent, in)
 }
 
 // ToYAML -
-func (f *DataFuncs) ToYAML(in interface{}) string {
+func (f *DataFuncs) ToYAML(in interface{}) (string, error) {
 	return data.ToYAML(in)
 }
 
 // ToTOML -
-func (f *DataFuncs) ToTOML(in interface{}) string {
+func (f *DataFuncs) ToTOML(in interface{}) (string, error) {
 	return data.ToTOML(in)
 }

--- a/funcs/doc.go
+++ b/funcs/doc.go
@@ -1,0 +1,14 @@
+/*
+Package funcs provides gomplate namespaces and functions to be used in 'text/template' templates.
+
+The different namespaces can be added individually:
+
+	f := template.FuncMap{}
+	funcs.AddMathFuncs(f)
+	funcs.AddNetFuncs(f)
+
+Even though the functions are exported, these are not intended to be called programmatically
+by external consumers, but instead only to be used as template functions.
+
+*/
+package funcs

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -29,31 +29,31 @@ func AddNetFuncs(f map[string]interface{}) {
 type NetFuncs struct{}
 
 // LookupIP -
-func (f *NetFuncs) LookupIP(name interface{}) string {
+func (f *NetFuncs) LookupIP(name interface{}) (string, error) {
 	return net.LookupIP(conv.ToString(name))
 }
 
 // LookupIPs -
-func (f *NetFuncs) LookupIPs(name interface{}) []string {
+func (f *NetFuncs) LookupIPs(name interface{}) ([]string, error) {
 	return net.LookupIPs(conv.ToString(name))
 }
 
 // LookupCNAME -
-func (f *NetFuncs) LookupCNAME(name interface{}) string {
+func (f *NetFuncs) LookupCNAME(name interface{}) (string, error) {
 	return net.LookupCNAME(conv.ToString(name))
 }
 
 // LookupSRV -
-func (f *NetFuncs) LookupSRV(name interface{}) *stdnet.SRV {
+func (f *NetFuncs) LookupSRV(name interface{}) (*stdnet.SRV, error) {
 	return net.LookupSRV(conv.ToString(name))
 }
 
 // LookupSRVs -
-func (f *NetFuncs) LookupSRVs(name interface{}) []*stdnet.SRV {
+func (f *NetFuncs) LookupSRVs(name interface{}) ([]*stdnet.SRV, error) {
 	return net.LookupSRVs(conv.ToString(name))
 }
 
 // LookupTXT -
-func (f *NetFuncs) LookupTXT(name interface{}) []string {
+func (f *NetFuncs) LookupTXT(name interface{}) ([]string, error) {
 	return net.LookupTXT(conv.ToString(name))
 }

--- a/funcs/net_test.go
+++ b/funcs/net_test.go
@@ -8,5 +8,5 @@ import (
 
 func TestNetLookupIP(t *testing.T) {
 	n := &NetFuncs{}
-	assert.Equal(t, "127.0.0.1", n.LookupIP("localhost"))
+	assert.Equal(t, "127.0.0.1", must(n.LookupIP("localhost")))
 }

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -6,7 +6,6 @@ package funcs
 // in templates easier.
 
 import (
-	"log"
 	"sync"
 
 	"github.com/Masterminds/goutils"
@@ -177,7 +176,7 @@ func (f *StringFuncs) Trunc(length int, s interface{}) string {
 }
 
 // Indent -
-func (f *StringFuncs) Indent(args ...interface{}) string {
+func (f *StringFuncs) Indent(args ...interface{}) (string, error) {
 	input := conv.ToString(args[len(args)-1])
 	indent := " "
 	width := 1
@@ -188,21 +187,21 @@ func (f *StringFuncs) Indent(args ...interface{}) string {
 		if !ok {
 			width, ok = args[0].(int)
 			if !ok {
-				log.Fatal("Indent: invalid arguments")
+				return "", errors.New("Indent: invalid arguments")
 			}
 			indent = " "
 		}
 	case 3:
 		width, ok = args[0].(int)
 		if !ok {
-			log.Fatal("Indent: invalid arguments")
+			return "", errors.New("Indent: invalid arguments")
 		}
 		indent, ok = args[1].(string)
 		if !ok {
-			log.Fatal("Indent: invalid arguments")
+			return "", errors.New("Indent: invalid arguments")
 		}
 	}
-	return gompstrings.Indent(width, indent, input)
+	return gompstrings.Indent(width, indent, input), nil
 }
 
 // Slug -

--- a/funcs/strings_test.go
+++ b/funcs/strings_test.go
@@ -17,10 +17,22 @@ func TestReplaceAll(t *testing.T) {
 
 func TestIndent(t *testing.T) {
 	sf := &StringFuncs{}
-	assert.Equal(t, " foo\n bar\n baz", sf.Indent("foo\nbar\nbaz"))
-	assert.Equal(t, "  foo\n  bar\n  baz", sf.Indent("  ", "foo\nbar\nbaz"))
-	assert.Equal(t, "---foo\n---bar\n---baz", sf.Indent(3, "-", "foo\nbar\nbaz"))
-	assert.Equal(t, "   foo\n   bar\n   baz", sf.Indent(3, "foo\nbar\nbaz"))
+
+	testdata := []struct {
+		args []interface{}
+		out  string
+	}{
+		{[]interface{}{"foo\nbar\nbaz"}, " foo\n bar\n baz"},
+		{[]interface{}{"  ", "foo\nbar\nbaz"}, "  foo\n  bar\n  baz"},
+		{[]interface{}{3, "-", "foo\nbar\nbaz"}, "---foo\n---bar\n---baz"},
+		{[]interface{}{3, "foo\nbar\nbaz"}, "   foo\n   bar\n   baz"},
+	}
+
+	for _, d := range testdata {
+		out, err := sf.Indent(d.args...)
+		assert.NoError(t, err)
+		assert.Equal(t, d.out, out)
+	}
 }
 
 func TestTrimPrefix(t *testing.T) {
@@ -86,9 +98,6 @@ func TestSlug(t *testing.T) {
 	assert.Equal(t, "100", s)
 }
 
-func must(in interface{}, err error) interface{} {
-	return in
-}
 func TestSort(t *testing.T) {
 	sf := &StringFuncs{}
 	in := []string{"foo", "bar", "baz"}

--- a/libkv/boltdb.go
+++ b/libkv/boltdb.go
@@ -9,23 +9,27 @@ import (
 	"github.com/docker/libkv/store/boltdb"
 	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/env"
+	"github.com/pkg/errors"
 )
 
 // NewBoltDB - initialize a new BoltDB datasource handler
-func NewBoltDB(u *url.URL) *LibKV {
+func NewBoltDB(u *url.URL) (*LibKV, error) {
 	boltdb.Register()
 
-	config := setupBoltDB(u.Fragment)
+	config, err := setupBoltDB(u.Fragment)
+	if err != nil {
+		return nil, err
+	}
 	kv, err := libkv.NewStore(store.BOLTDB, []string{u.Path}, config)
 	if err != nil {
-		logFatal("BoltDB store creation failed", err)
+		return nil, errors.Wrapf(err, "BoltDB store creation failed")
 	}
-	return &LibKV{kv}
+	return &LibKV{kv}, nil
 }
 
-func setupBoltDB(bucket string) *store.Config {
+func setupBoltDB(bucket string) (*store.Config, error) {
 	if bucket == "" {
-		logFatal("missing bucket - must specify BoltDB bucket in URL fragment")
+		return nil, errors.New("missing bucket - must specify BoltDB bucket in URL fragment")
 	}
 
 	t := conv.MustParseInt(env.Getenv("BOLTDB_TIMEOUT"), 10, 16)
@@ -33,5 +37,5 @@ func setupBoltDB(bucket string) *store.Config {
 		Bucket:            bucket,
 		ConnectionTimeout: time.Duration(t) * time.Second,
 		PersistConnection: conv.Bool(env.Getenv("BOLTDB_PERSIST")),
-	}
+	}, nil
 }

--- a/libkv/boltdb_test.go
+++ b/libkv/boltdb_test.go
@@ -1,7 +1,6 @@
 package libkv
 
 import (
-	"log"
 	"net/url"
 	"os"
 	"testing"
@@ -11,31 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var spyLogFatalMsg string
-
-func restoreLogFatal() {
-	logFatal = log.Fatal
-}
-
-func mockLogFatal(args ...interface{}) {
-	spyLogFatalMsg = (args[0]).(string)
-	panic(spyLogFatalMsg)
-}
-
-func setupMockLogFatal() {
-	logFatal = mockLogFatal
-	spyLogFatalMsg = ""
-}
-
 func TestSetupBoltDB(t *testing.T) {
-	defer restoreLogFatal()
-	setupMockLogFatal()
-	assert.Panics(t, func() {
-		setupBoltDB("")
-	})
+	_, err := setupBoltDB("")
+	assert.Error(t, err)
 
 	expectedConfig := &store.Config{Bucket: "foo"}
-	actualConfig := setupBoltDB("foo")
+	actualConfig, err := setupBoltDB("foo")
+	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, actualConfig)
 
 	expectedConfig = &store.Config{
@@ -44,7 +25,8 @@ func TestSetupBoltDB(t *testing.T) {
 	}
 	os.Setenv("BOLTDB_TIMEOUT", "42")
 	defer os.Unsetenv("BOLTDB_TIMEOUT")
-	actualConfig = setupBoltDB("bar")
+	actualConfig, err = setupBoltDB("bar")
+	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, actualConfig)
 
 	expectedConfig = &store.Config{
@@ -54,15 +36,13 @@ func TestSetupBoltDB(t *testing.T) {
 	}
 	os.Setenv("BOLTDB_PERSIST", "true")
 	defer os.Unsetenv("BOLTDB_PERSIST")
-	actualConfig = setupBoltDB("bar")
+	actualConfig, err = setupBoltDB("bar")
+	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, actualConfig)
 }
 
 func TestNewBoltDB(t *testing.T) {
 	u, _ := url.Parse("boltdb:///bolt.db")
-	defer restoreLogFatal()
-	setupMockLogFatal()
-	assert.Panics(t, func() {
-		NewBoltDB(u)
-	})
+	_, err := NewBoltDB(u)
+	assert.Error(t, err)
 }

--- a/libkv/consul.go
+++ b/libkv/consul.go
@@ -25,36 +25,45 @@ const (
 )
 
 // NewConsul - instantiate a new Consul datasource handler
-func NewConsul(u *url.URL) *LibKV {
+func NewConsul(u *url.URL) (*LibKV, error) {
 	consul.Register()
 	c, err := consulURL(u)
 	if err != nil {
-		logFatal(err)
+		return nil, err
 	}
-	config := consulConfig(c.Scheme == https)
+	config, err := consulConfig(c.Scheme == https)
+	if err != nil {
+		return nil, err
+	}
 	if role := env.Getenv("CONSUL_VAULT_ROLE", ""); role != "" {
 		mount := env.Getenv("CONSUL_VAULT_MOUNT", "consul")
 
-		client := vault.New(nil)
-		client.Login()
+		var client *vault.Vault
+		client, err = vault.New(nil)
+		if err != nil {
+			return nil, err
+		}
+		err = client.Login()
+		defer client.Logout()
+		if err != nil {
+			return nil, err
+		}
 
 		path := fmt.Sprintf("%s/creds/%s", mount, role)
 
 		var data []byte
 		data, err = client.Read(path)
 		if err != nil {
-			logFatal("vault consul auth failed", err)
+			return nil, errors.Wrapf(err, "vault consul auth failed")
 		}
 
 		decoded := make(map[string]interface{})
 		err = yaml.Unmarshal(data, &decoded)
 		if err != nil {
-			logFatal("Unable to unmarshal object", err)
+			return nil, errors.Wrapf(err, "Unable to unmarshal object")
 		}
 
 		token := decoded["token"].(string)
-
-		client.Logout()
 
 		// nolint: gosec
 		_ = os.Setenv("CONSUL_HTTP_TOKEN", token)
@@ -62,9 +71,9 @@ func NewConsul(u *url.URL) *LibKV {
 	var kv store.Store
 	kv, err = libkv.NewStore(store.CONSUL, []string{c.String()}, config)
 	if err != nil {
-		logFatal("Consul setup failed", err)
+		return nil, errors.Wrapf(err, "Consul setup failed")
 	}
-	return &LibKV{kv}
+	return &LibKV{kv}, nil
 }
 
 // -- converts a gomplate datasource URL into a usable Consul URL
@@ -99,7 +108,7 @@ func consulURL(u *url.URL) (*url.URL, error) {
 	return c, nil
 }
 
-func consulConfig(useTLS bool) *store.Config {
+func consulConfig(useTLS bool) (*store.Config, error) {
 	t := conv.MustAtoi(env.Getenv("CONSUL_TIMEOUT"))
 	config := &store.Config{
 		ConnectionTimeout: time.Duration(t) * time.Second,
@@ -109,10 +118,10 @@ func consulConfig(useTLS bool) *store.Config {
 		var err error
 		config.TLS, err = consulapi.SetupTLSConfig(tconf)
 		if err != nil {
-			logFatal("TLS Config setup failed", err)
+			return nil, errors.Wrapf(err, "TLS Config setup failed")
 		}
 	}
-	return config
+	return config, nil
 }
 
 func setupTLS(prefix string) *consulapi.TLSConfig {

--- a/libkv/consul_test.go
+++ b/libkv/consul_test.go
@@ -91,7 +91,9 @@ func TestSetupTLS(t *testing.T) {
 func TestConsulConfig(t *testing.T) {
 	expectedConfig := &store.Config{}
 
-	actualConfig := consulConfig(false)
+	actualConfig, err := consulConfig(false)
+	assert.NoError(t, err)
+
 	assert.Equal(t, expectedConfig, actualConfig)
 
 	defer os.Unsetenv("CONSUL_TIMEOUT")
@@ -100,7 +102,8 @@ func TestConsulConfig(t *testing.T) {
 		ConnectionTimeout: 10 * time.Second,
 	}
 
-	actualConfig = consulConfig(false)
+	actualConfig, err = consulConfig(false)
+	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, actualConfig)
 
 	os.Unsetenv("CONSUL_TIMEOUT")
@@ -108,7 +111,8 @@ func TestConsulConfig(t *testing.T) {
 		TLS: &tls.Config{},
 	}
 
-	actualConfig = consulConfig(true)
+	actualConfig, err = consulConfig(true)
+	assert.NoError(t, err)
 	assert.NotNil(t, actualConfig.TLS)
 	actualConfig.TLS = &tls.Config{}
 	assert.Equal(t, expectedConfig, actualConfig)

--- a/libkv/libkv.go
+++ b/libkv/libkv.go
@@ -1,13 +1,8 @@
 package libkv
 
 import (
-	"log"
-
 	"github.com/docker/libkv/store"
 )
-
-// logFatal is defined so log.Fatal calls can be overridden for testing
-var logFatal = log.Fatal
 
 // LibKV -
 type LibKV struct {

--- a/libkv/libkv_test.go
+++ b/libkv/libkv_test.go
@@ -1,0 +1,85 @@
+package libkv
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/docker/libkv/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRead(t *testing.T) {
+	s := &FakeStore{data: []*store.KVPair{
+		{Key: "foo", Value: []byte("bar")},
+	}}
+	kv := &LibKV{s}
+	_, err := kv.Read("foo")
+
+	assert.NoError(t, err)
+
+	s = &FakeStore{err: errors.New("fail")}
+	kv = &LibKV{s}
+	_, err = kv.Read("foo")
+
+	assert.Error(t, err)
+}
+
+type FakeStore struct {
+	data []*store.KVPair
+	err  error
+}
+
+func (s *FakeStore) Put(key string, value []byte, options *store.WriteOptions) error {
+	return nil
+}
+
+func (s *FakeStore) Get(key string) (*store.KVPair, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	for _, v := range s.data {
+		if v.Key == key {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *FakeStore) Delete(key string) error {
+	return nil
+}
+
+func (s *FakeStore) Exists(key string) (bool, error) {
+	return false, nil
+}
+
+func (s *FakeStore) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	return nil, nil
+}
+
+func (s *FakeStore) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	return nil, nil
+}
+
+func (s *FakeStore) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
+	return nil, nil
+}
+
+func (s *FakeStore) List(directory string) ([]*store.KVPair, error) {
+	return nil, nil
+}
+
+func (s *FakeStore) DeleteTree(directory string) error {
+	return nil
+}
+
+func (s *FakeStore) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
+	return false, nil, nil
+}
+
+func (s *FakeStore) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	return false, nil
+}
+
+func (s *FakeStore) Close() {}

--- a/net/net.go
+++ b/net/net.go
@@ -1,62 +1,69 @@
 package net
 
 import (
-	"log"
 	"net"
 )
 
 // LookupIP -
-func LookupIP(name string) string {
-	i := LookupIPs(name)
-	if len(i) == 0 {
-		return ""
+func LookupIP(name string) (string, error) {
+	i, err := LookupIPs(name)
+	if err != nil {
+		return "", err
 	}
-	return i[0]
+	if len(i) == 0 {
+		return "", nil
+	}
+	return i[0], nil
 }
 
 // LookupIPs -
-func LookupIPs(name string) []string {
+func LookupIPs(name string) ([]string, error) {
 	srcIPs, err := net.LookupIP(name)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	var ips []string
 	for _, v := range srcIPs {
-		if v.To4() != nil {
+		if v.To4() != nil && !contains(ips, v.String()) {
 			ips = append(ips, v.String())
 		}
 	}
-	return ips
+	return ips, nil
+}
+
+func contains(a []string, s string) bool {
+	for _, v := range a {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }
 
 // LookupCNAME -
-func LookupCNAME(name string) string {
-	cname, err := net.LookupCNAME(name)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return cname
+func LookupCNAME(name string) (string, error) {
+	return net.LookupCNAME(name)
 }
 
 // LookupTXT -
-func LookupTXT(name string) []string {
-	records, err := net.LookupTXT(name)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return records
+func LookupTXT(name string) ([]string, error) {
+	return net.LookupTXT(name)
 }
 
 // LookupSRV -
-func LookupSRV(name string) *net.SRV {
-	return LookupSRVs(name)[0]
+func LookupSRV(name string) (*net.SRV, error) {
+	srvs, err := LookupSRVs(name)
+	if err != nil {
+		return nil, err
+	}
+	return srvs[0], nil
 }
 
 // LookupSRVs -
-func LookupSRVs(name string) []*net.SRV {
+func LookupSRVs(name string) ([]*net.SRV, error) {
 	_, addrs, err := net.LookupSRV("", "", name)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-	return addrs
+	return addrs, nil
 }

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -6,27 +6,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func must(r interface{}, err error) interface{} {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
 func TestLookupIP(t *testing.T) {
-	assert.Equal(t, "127.0.0.1", LookupIP("localhost"))
-	assert.Equal(t, "169.254.255.254", LookupIP("hostlocal.io"))
-	assert.Equal(t, "93.184.216.34", LookupIP("example.com"))
-
+	assert.Equal(t, "127.0.0.1", must(LookupIP("localhost")))
+	assert.Equal(t, "169.254.255.254", must(LookupIP("hostlocal.io")))
+	assert.Equal(t, "93.184.216.34", must(LookupIP("example.com")))
 }
 
 func TestLookupIPs(t *testing.T) {
-	assert.Equal(t, "127.0.0.1", LookupIPs("localhost")[0])
-	assert.Equal(t, []string{"169.254.255.254"}, LookupIPs("hostlocal.io"))
-	assert.Equal(t, []string{"93.184.216.34"}, LookupIPs("example.com"))
+	assert.Equal(t, []string{"127.0.0.1"}, must(LookupIPs("localhost")))
+	assert.Equal(t, []string{"169.254.255.254"}, must(LookupIPs("hostlocal.io")))
+	assert.Equal(t, []string{"93.184.216.34"}, must(LookupIPs("example.com")))
 }
 
 func TestLookupTXT(t *testing.T) {
-	assert.NotEmpty(t, LookupTXT("example.com"))
+	assert.NotEmpty(t, must(LookupTXT("example.com")))
 }
 
 func TestLookupCNAME(t *testing.T) {
-	assert.Equal(t, "hairyhenderson.ca.", LookupCNAME("www.hairyhenderson.ca."))
+	assert.Equal(t, "hairyhenderson.ca.", must(LookupCNAME("www.hairyhenderson.ca.")))
 }
 
 func TestLookupSRV(t *testing.T) {
-	assert.Equal(t, uint16(5060), LookupSRV("_sip._udp.sip.voice.google.com").Port)
+	srv, err := LookupSRV("_sip._udp.sip.voice.google.com")
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(5060), srv.Port)
 }

--- a/tests/integration/test_ec2_utils.go
+++ b/tests/integration/test_ec2_utils.go
@@ -1,3 +1,5 @@
+//+build integration
+
 package integration
 
 import (

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -12,42 +12,35 @@ import (
 	"github.com/hairyhenderson/gomplate/aws"
 	"github.com/hairyhenderson/gomplate/conv"
 	"github.com/hairyhenderson/gomplate/env"
+	"github.com/pkg/errors"
 )
 
 // GetToken -
-func (v *Vault) GetToken() string {
-	if token := v.AppRoleLogin(); token != "" {
-		return token
+func (v *Vault) GetToken() (string, error) {
+	// sorted in order of precedence
+	authFuncs := []func() (string, error){
+		v.AppRoleLogin,
+		v.AppIDLogin,
+		v.GitHubLogin,
+		v.UserPassLogin,
+		v.TokenLogin,
+		v.EC2Login,
 	}
-	if token := v.AppIDLogin(); token != "" {
-		return token
+	for _, f := range authFuncs {
+		if token, err := f(); token != "" || err != nil {
+			return token, err
+		}
 	}
-	if token := v.GitHubLogin(); token != "" {
-		return token
-	}
-	if token := v.UserPassLogin(); token != "" {
-		return token
-	}
-	if token := v.TokenLogin(); token != "" {
-		return token
-	}
-	if token := v.EC2Login(); token != "" {
-		return token
-	}
-	logFatal("All vault auth failed")
-	return ""
+	return "", errors.New("No vault auth methods succeeded")
 }
 
 // AppIDLogin - app-id auth backend
-func (v *Vault) AppIDLogin() string {
+func (v *Vault) AppIDLogin() (string, error) {
 	appID := env.Getenv("VAULT_APP_ID")
 	userID := env.Getenv("VAULT_USER_ID")
 
-	if appID == "" {
-		return ""
-	}
-	if userID == "" {
-		return ""
+	if appID == "" || userID == "" {
+		return "", nil
 	}
 
 	mount := env.Getenv("VAULT_AUTH_APP_ID_MOUNT", "app-id")
@@ -59,25 +52,22 @@ func (v *Vault) AppIDLogin() string {
 	path := fmt.Sprintf("auth/%s/login/%s", mount, appID)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		logFatal("AppID logon failed", err)
+		return "", errors.Wrapf(err, "AppID logon failed")
 	}
 	if secret == nil {
-		logFatal("Empty response from AppID logon")
+		return "", errors.New("Empty response from AppID logon")
 	}
 
-	return secret.Auth.ClientToken
+	return secret.Auth.ClientToken, nil
 }
 
 // AppRoleLogin - approle auth backend
-func (v *Vault) AppRoleLogin() string {
+func (v *Vault) AppRoleLogin() (string, error) {
 	roleID := env.Getenv("VAULT_ROLE_ID")
 	secretID := env.Getenv("VAULT_SECRET_ID")
 
-	if roleID == "" {
-		return ""
-	}
-	if secretID == "" {
-		return ""
+	if roleID == "" || secretID == "" {
+		return "", nil
 	}
 
 	mount := env.Getenv("VAULT_AUTH_APPROLE_MOUNT", "approle")
@@ -90,21 +80,21 @@ func (v *Vault) AppRoleLogin() string {
 	path := fmt.Sprintf("auth/%s/login", mount)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		logFatal("AppRole logon failed", err)
+		return "", errors.Wrap(err, "AppRole logon failed")
 	}
 	if secret == nil {
-		logFatal("Empty response from AppRole logon")
+		return "", errors.New("Empty response from AppRole logon")
 	}
 
-	return secret.Auth.ClientToken
+	return secret.Auth.ClientToken, nil
 }
 
 // GitHubLogin - github auth backend
-func (v *Vault) GitHubLogin() string {
+func (v *Vault) GitHubLogin() (string, error) {
 	githubToken := env.Getenv("VAULT_AUTH_GITHUB_TOKEN")
 
 	if githubToken == "" {
-		return ""
+		return "", nil
 	}
 
 	mount := env.Getenv("VAULT_AUTH_GITHUB_MOUNT", "github")
@@ -116,25 +106,22 @@ func (v *Vault) GitHubLogin() string {
 	path := fmt.Sprintf("auth/%s/login", mount)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		logFatal("AppRole logon failed", err)
+		return "", errors.Wrap(err, "AppRole logon failed")
 	}
 	if secret == nil {
-		logFatal("Empty response from AppRole logon")
+		return "", errors.New("Empty response from AppRole logon")
 	}
 
-	return secret.Auth.ClientToken
+	return secret.Auth.ClientToken, nil
 }
 
 // UserPassLogin - userpass auth backend
-func (v *Vault) UserPassLogin() string {
+func (v *Vault) UserPassLogin() (string, error) {
 	username := env.Getenv("VAULT_AUTH_USERNAME")
 	password := env.Getenv("VAULT_AUTH_PASSWORD")
 
-	if username == "" {
-		return ""
-	}
-	if password == "" {
-		return ""
+	if username == "" || password == "" {
+		return "", nil
 	}
 
 	mount := env.Getenv("VAULT_AUTH_USERPASS_MOUNT", "userpass")
@@ -146,34 +133,37 @@ func (v *Vault) UserPassLogin() string {
 	path := fmt.Sprintf("auth/%s/login/%s", mount, username)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		logFatal("UserPass logon failed", err)
+		return "", errors.Wrap(err, "UserPass logon failed")
 	}
 	if secret == nil {
-		logFatal("Empty response from UserPass logon")
+		return "", errors.New("Empty response from UserPass logon")
 	}
 
-	return secret.Auth.ClientToken
+	return secret.Auth.ClientToken, nil
 }
 
 // EC2Login - AWS EC2 auth backend
-func (v *Vault) EC2Login() string {
+func (v *Vault) EC2Login() (string, error) {
 	mount := env.Getenv("VAULT_AUTH_AWS_MOUNT", "aws")
 	output := env.Getenv("VAULT_AUTH_AWS_NONCE_OUTPUT")
 
 	nonce := env.Getenv("VAULT_AUTH_AWS_NONCE")
 
-	vars := createEc2LoginVars(nonce)
+	vars, err := createEc2LoginVars(nonce)
+	if err != nil {
+		return "", err
+	}
 	if vars["pkcs7"] == "" {
-		return ""
+		return "", nil
 	}
 
 	path := fmt.Sprintf("auth/%s/login", mount)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		logFatal("AWS EC2 logon failed", err)
+		return "", errors.Wrapf(err, "AWS EC2 logon failed")
 	}
 	if secret == nil {
-		logFatal("Empty response from AWS EC2 logon")
+		return "", errors.New("Empty response from AWS EC2 logon")
 	}
 
 	if output != "" {
@@ -183,21 +173,21 @@ func (v *Vault) EC2Login() string {
 		fs := vfs.OS()
 		f, err := fs.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.FileMode(0600))
 		if err != nil {
-			logFatal("Error opening nonce output file")
+			return "", errors.Wrapf(err, "Error opening nonce output file")
 		}
 		n, err := f.Write([]byte(nonce + "\n"))
 		if err != nil {
-			logFatal("Error writing nonce output file")
+			return "", errors.Wrapf(err, "Error writing nonce output file")
 		}
 		if n == 0 {
-			logFatal("No bytes written to nonce output file")
+			return "", errors.Wrapf(err, "No bytes written to nonce output file")
 		}
 	}
 
-	return secret.Auth.ClientToken
+	return secret.Auth.ClientToken, nil
 }
 
-func createEc2LoginVars(nonce string) map[string]interface{} {
+func createEc2LoginVars(nonce string) (map[string]interface{}, error) {
 	role := env.Getenv("VAULT_AUTH_AWS_ROLE")
 
 	vars := map[string]interface{}{}
@@ -216,35 +206,41 @@ func createEc2LoginVars(nonce string) map[string]interface{} {
 
 	meta := aws.NewEc2Meta(opts)
 
-	vars["pkcs7"] = strings.Replace(strings.TrimSpace(meta.Dynamic("instance-identity/pkcs7")), "\n", "", -1)
-	return vars
+	doc, err := meta.Dynamic("instance-identity/pkcs7")
+	if err != nil {
+		return nil, err
+	}
+	vars["pkcs7"] = strings.Replace(strings.TrimSpace(doc), "\n", "", -1)
+	return vars, nil
 }
 
 // TokenLogin -
-func (v *Vault) TokenLogin() string {
+func (v *Vault) TokenLogin() (string, error) {
 	if token := env.Getenv("VAULT_TOKEN"); token != "" {
-		return token
+		return token, nil
 	}
 	fs := vfs.OS()
-	f, err := fs.OpenFile(path.Join(v.homeDir(), ".vault-token"), os.O_RDONLY, 0)
+	homeDir, err := homeDir()
 	if err != nil {
-		return ""
+		return "", err
+	}
+	f, err := fs.OpenFile(path.Join(homeDir, ".vault-token"), os.O_RDONLY, 0)
+	if err != nil {
+		return "", nil
 	}
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return string(b)
+	return string(b), nil
 }
 
-func (v *Vault) homeDir() string {
+func homeDir() (string, error) {
 	if home := os.Getenv("HOME"); home != "" {
-		return home
+		return home, nil
 	}
 	if home := os.Getenv("USERPROFILE"); home != "" {
-		return home
+		return home, nil
 	}
-	logFatal(`Neither HOME nor USERPROFILE environment variables are set!
-		I can't figure out where the current user's home directory is!`)
-	return ""
+	return "", errors.New("neither HOME nor USERPROFILE environment variables are set! I can't figure out where the current user's home directory is")
 }

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -22,6 +22,7 @@ func TestTokenLogin(t *testing.T) {
 	os.Setenv("VAULT_TOKEN", "foo")
 	defer os.Unsetenv("VAULT_TOKEN")
 
-	token := v.TokenLogin()
+	token, err := v.TokenLogin()
+	assert.NoError(t, err)
 	assert.Equal(t, "foo", token)
 }

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -10,25 +10,30 @@ import (
 
 func TestNew(t *testing.T) {
 	os.Unsetenv("VAULT_ADDR")
-	v := New(nil)
+	v, err := New(nil)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://127.0.0.1:8200", v.client.Address())
 
 	os.Setenv("VAULT_ADDR", "http://example.com:1234")
 	defer os.Unsetenv("VAULT_ADDR")
-	v = New(nil)
+	v, err = New(nil)
+	assert.NoError(t, err)
 	assert.Equal(t, "http://example.com:1234", v.client.Address())
 	os.Unsetenv("VAULT_ADDR")
 
 	u, _ := url.Parse("vault://vault.rocks:8200/secret/foo/bar")
-	v = New(u)
+	v, err = New(u)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://vault.rocks:8200", v.client.Address())
 
 	u, _ = url.Parse("vault+https://vault.rocks:8200/secret/foo/bar")
-	v = New(u)
+	v, err = New(u)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://vault.rocks:8200", v.client.Address())
 
 	u, _ = url.Parse("vault+http://vault.rocks:8200/secret/foo/bar")
-	v = New(u)
+	v, err = New(u)
+	assert.NoError(t, err)
 	assert.Equal(t, "http://vault.rocks:8200", v.client.Address())
 }
 


### PR DESCRIPTION
I took a detour when working on #379, because this has become a pretty major issue and I just want to get it fixed once and for all.

Turns out using `log.Fatal` from template functions was a terrible idea. Makes it much harder to properly handle/display/track errors, and `text/template` handles them decently anyway.

The basic goal here is to remove all uses of `log.Fatal` or `log.Fatalf`, and instead change function signatures to return errors instead.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>