### PR TITLE
Fixing install instructions for go get

### DIFF
--- a/docs/content/installing.md
+++ b/docs/content/installing.md
@@ -95,7 +95,7 @@ $ gomplate --help
 If you're a Go user already, sometimes it's faster to just use `go get` to install `gomplate`:
 
 ```console
-$ go get github.com/hairyhenderson/gomplate
+$ go get github.com/hairyhenderson/gomplate/cmd/gomplate
 $ gomplate --help
 ...
 ```


### PR DESCRIPTION
Fixes #386

Tested this out in a clean `golang:1.11` container:

```console
$ docker run -it --rm golang:1.11 sh -c 'go get github.com/hairyhenderson/gomplate/cmd/gomplate && gomplate -h'
Process text files with Go templates

Usage:
  gomplate [flags]

Flags:
...
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>