### PR TITLE
new arg --templates for parsing additional templates

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -116,6 +116,7 @@ func initFlags(command *cobra.Command) {
 	command.Flags().StringArrayVar(&opts.ExcludeGlob, "exclude", []string{}, "glob of files to not parse")
 
 	command.Flags().StringArrayVarP(&opts.OutputFiles, "out", "o", []string{"-"}, "output `file` name. Omit to use standard output.")
+	command.Flags().StringArrayVar(&opts.AdditionalTemplates, "templates", []string{}, "Additional template files (globs)")
 	command.Flags().StringVar(&opts.OutputDir, "output-dir", ".", "`directory` to store the processed templates. Only used for --input-dir")
 	command.Flags().StringVar(&opts.OutMode, "chmod", "", "set the mode for output file(s). Omit to inherit from input file(s)")
 

--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -116,7 +116,7 @@ func initFlags(command *cobra.Command) {
 	command.Flags().StringArrayVar(&opts.ExcludeGlob, "exclude", []string{}, "glob of files to not parse")
 
 	command.Flags().StringArrayVarP(&opts.OutputFiles, "out", "o", []string{"-"}, "output `file` name. Omit to use standard output.")
-	command.Flags().StringArrayVar(&opts.AdditionalTemplates, "templates", []string{}, "Additional template files (globs)")
+	command.Flags().StringArrayVar(&opts.AdditionalTemplates, "template", []string{}, "Additional template file(s)")
 	command.Flags().StringVar(&opts.OutputDir, "output-dir", ".", "`directory` to store the processed templates. Only used for --input-dir")
 	command.Flags().StringVar(&opts.OutMode, "chmod", "", "set the mode for output file(s). Omit to inherit from input file(s)")
 

--- a/gomplate.go
+++ b/gomplate.go
@@ -27,6 +27,8 @@ type Config struct {
 
 	LDelim string
 	RDelim string
+
+	AdditionalTemplates []string
 }
 
 // parse an os.FileMode out of the string, and let us know if it's an override or not...

--- a/template.go
+++ b/template.go
@@ -40,6 +40,7 @@ func (t *tplate) toGoTemplate(g *gomplate) (*template.Template, error) {
 		return tp, err
 	}
 	for alias, path := range t.additionalTemplates {
+		// nolint: gosec
 		b, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, err

--- a/template_test.go
+++ b/template_test.go
@@ -95,7 +95,7 @@ func TestWalkDir(t *testing.T) {
 	defer func() { fs = origfs }()
 	fs = afero.NewMemMapFs()
 
-	_, err := walkDir("/indir", "/outdir", nil, 0, false)
+	_, err := walkDir("/indir", "/outdir", nil, 0, false, []string{})
 	assert.Error(t, err)
 
 	_ = fs.MkdirAll("/indir/one", 0777)
@@ -104,7 +104,7 @@ func TestWalkDir(t *testing.T) {
 	afero.WriteFile(fs, "/indir/one/bar", []byte("bar"), 0644)
 	afero.WriteFile(fs, "/indir/two/baz", []byte("baz"), 0644)
 
-	templates, err := walkDir("/indir", "/outdir", []string{"/*/two"}, 0, false)
+	templates, err := walkDir("/indir", "/outdir", []string{"/*/two"}, 0, false, []string{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(templates))

--- a/template_test.go
+++ b/template_test.go
@@ -95,7 +95,7 @@ func TestWalkDir(t *testing.T) {
 	defer func() { fs = origfs }()
 	fs = afero.NewMemMapFs()
 
-	_, err := walkDir("/indir", "/outdir", nil, 0, false, []string{})
+	_, err := walkDir("/indir", "/outdir", nil, 0, false, templateAliases{})
 	assert.Error(t, err)
 
 	_ = fs.MkdirAll("/indir/one", 0777)
@@ -104,7 +104,7 @@ func TestWalkDir(t *testing.T) {
 	afero.WriteFile(fs, "/indir/one/bar", []byte("bar"), 0644)
 	afero.WriteFile(fs, "/indir/two/baz", []byte("baz"), 0644)
 
-	templates, err := walkDir("/indir", "/outdir", []string{"/*/two"}, 0, false, []string{})
+	templates, err := walkDir("/indir", "/outdir", []string{"/*/two"}, 0, false, templateAliases{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(templates))


### PR DESCRIPTION
Does this seem like a good approach for loading additional templates like `{{ template "otherfile.tpl" }}`?

I think couldn't think what to call the CLI arg - maybe `--additional-templates` is better, but here's a straw man.

Cheers, great project, just this one thing missing IMO :+1: :100: :heart: 