### PR TITLE
New --context flag for pre-loading datasources into context

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -113,6 +113,8 @@ func initFlags(command *cobra.Command) {
 	command.Flags().StringArrayVarP(&opts.DataSources, "datasource", "d", nil, "`datasource` in alias=URL form. Specify multiple times to add multiple sources.")
 	command.Flags().StringArrayVarP(&opts.DataSourceHeaders, "datasource-header", "H", nil, "HTTP `header` field in 'alias=Name: value' form to be provided on HTTP-based data sources. Multiples can be set.")
 
+	command.Flags().StringArrayVarP(&opts.Contexts, "context", "c", nil, "pre-load a `datasource` into the context, in alias=URL form. Use the special alias `.` to set the root context.")
+
 	command.Flags().StringArrayVarP(&opts.InputFiles, "file", "f", []string{"-"}, "Template `file` to process. Omit to use standard input, or use --in or --input-dir")
 	command.Flags().StringVarP(&opts.Input, "in", "i", "", "Template `string` to process (alternative to --file and --input-dir)")
 	command.Flags().StringVar(&opts.InputDir, "input-dir", "", "`directory` which is examined recursively for templates (alternative to --file and --in)")

--- a/context.go
+++ b/context.go
@@ -3,11 +3,12 @@ package gomplate
 import (
 	"os"
 	"strings"
+
+	"github.com/hairyhenderson/gomplate/data"
 )
 
 // context for templates
-type context struct {
-}
+type context map[string]interface{}
 
 // Env - Map environment variables for use in a template
 func (c *context) Env() map[string]string {
@@ -17,4 +18,30 @@ func (c *context) Env() map[string]string {
 		env[i[0:sep]] = i[sep+1:]
 	}
 	return env
+}
+
+func createContext(contexts []string, d *data.Data) (interface{}, error) {
+	var err error
+	ctx := &context{}
+	for _, context := range contexts {
+		a := parseAlias(context)
+		if a == "." {
+			return d.Datasource(a)
+		}
+		(*ctx)[a], err = d.Datasource(a)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ctx, nil
+}
+
+func parseAlias(arg string) string {
+	parts := strings.SplitN(arg, "=", 2)
+	switch len(parts) {
+	case 1:
+		return strings.SplitN(parts[0], ".", 2)[0]
+	default:
+		return parts[0]
+	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,8 +1,11 @@
 package gomplate
 
 import (
+	"net/url"
 	"os"
 	"testing"
+
+	"github.com/hairyhenderson/gomplate/data"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,4 +21,50 @@ func TestEnvGetsUpdatedEnvironment(t *testing.T) {
 	assert.Empty(t, c.Env()["FOO"])
 	assert.NoError(t, os.Setenv("FOO", "foo"))
 	assert.Equal(t, c.Env()["FOO"], "foo")
+}
+
+func TestCreateContext(t *testing.T) {
+	c, err := createContext(nil, nil)
+	assert.NoError(t, err)
+	assert.Empty(t, c)
+
+	fooURL := "env:///foo?type=application/yaml"
+	barURL := "env:///bar?type=application/yaml"
+	uf, _ := url.Parse(fooURL)
+	ub, _ := url.Parse(barURL)
+	d := &data.Data{
+		Sources: map[string]*data.Source{
+			"foo": {URL: uf},
+			".":   {URL: ub},
+		},
+	}
+	os.Setenv("foo", "foo: bar")
+	defer os.Unsetenv("foo")
+	c, err = createContext([]string{"foo=" + fooURL}, d)
+	assert.NoError(t, err)
+	assert.IsType(t, &context{}, c)
+	ctx := c.(*context)
+	ds := ((*ctx)["foo"]).(map[string]interface{})
+	assert.Equal(t, "bar", ds["foo"])
+
+	os.Setenv("bar", "bar: baz")
+	defer os.Unsetenv("bar")
+	c, err = createContext([]string{".=" + barURL}, d)
+	assert.NoError(t, err)
+	assert.IsType(t, map[string]interface{}{}, c)
+	ds = c.(map[string]interface{})
+	assert.Equal(t, "baz", ds["bar"])
+}
+
+func TestParseAlias(t *testing.T) {
+	testdata := map[string]string{
+		"":        "",
+		"foo":     "foo",
+		"foo.bar": "foo",
+		"a=b":     "a",
+		".=foo":   ".",
+	}
+	for k, v := range testdata {
+		assert.Equal(t, v, parseAlias(k))
+	}
 }

--- a/data/datasource.go
+++ b/data/datasource.go
@@ -267,6 +267,9 @@ func (d *Data) lookupSource(alias string) (*Source, error) {
 		}
 		d.Sources[alias] = source
 	}
+	if source.Alias == "" {
+		source.Alias = alias
+	}
 	return source, nil
 }
 

--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -6,9 +6,9 @@ menu: main
 
 Datasources are an optional, but central concept in gomplate. While the basic flow of template rendering is taking an input template and rendering it into an output, there often is need to include data from one or more sources external to the template itself.
 
-Some common use-cases include injecting sensitive material like passwords (which should not be stored in source-control with the templates), or providing simplified configuration formats that can be fed to a template to provide a much more complex output.
+Some common use-cases include injecting sensitive material like passwords (which should not be stored unencrypted in source-control with the templates), or providing simplified configuration formats that can be fed to a template to provide a much more complex output.
 
-Datasources can be defined with the [`--datasource`/`-d`][] command-line flag or the [`defineDatasource`][] function, and referenced via an _alias_ inside the template, using a function such as [`datasource`][] or [`include`][].
+Datasources can be defined with the [`--datasource`/`-d`][] command-line flag or the [`defineDatasource`][] function, and referenced via an _alias_ inside the template, using a function such as [`datasource`][] or [`include`][]. Datasources can additionally be loaded into the [context][] with the [`--context`/`-c`][] command-line flag.
 
 Since datasources are defined separately from the template, the same templates can be used with different datasources and even different datasource types. For example, gomplate could be run on a developer machine with a `file` datasource pointing to a JSON file containing test data, where the same template could be used in a production environment using a `consul` datasource with the real production data.
 
@@ -432,6 +432,8 @@ $ gomplate -d vault=vault:///secret/foo -i '{{ (ds "vault").value }}'
 The file `/tmp/vault-aws-nonce` will be created if it didn't already exist, and further executions of `gomplate` can re-authenticate securely.
 
 [`--datasource`/`-d`]: ../usage/#datasource-d
+[`--context`/`-c`]: ../usage/#context-c
+[context]: ../syntax/#the-context
 [`--datasource-header`/`-H`]: ../usage/#datasource-header-h
 [`defineDatasource`]: ../functions/data/#definedatasource
 [`datasource`]: ../functions/data/#datasource

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -133,9 +133,10 @@ $ gomplate -i '{{ with "foo" }}The context is {{ . }}{{ end }}'
 The context is foo
 ```
 
-Templates rendered by gomplate always have a _default_ context. In future, gomplate's
-context may expand (_watch this space!_), but currently, it contains one item: the
-system's environment variables, available as [`.Env`](#env).
+Templates rendered by gomplate always have a _default_ context. You can populate
+the default context from data sources with the [`--context`/`c`](../usage/#context-c)
+flag. The special context item [`.Env`](#env) is available for referencing the
+system's environment variables.
 
 ## Nested templates
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -77,6 +77,12 @@ A few different forms are valid:
 - `mydata.json`
   - This form infers the name from the file name (without extension). Only valid for files in the current directory.
 
+### `--context`/`c`
+
+Add a data source in `name=URL` form, and make it available in the [default context][] as `.<name>`. The special name `.` (period) can be used to override the entire default context.
+
+All other rules for the [`--datasource`/`-d`](#datasource-d) flag apply.
+
 ### Overriding the template delimiters
 
 Sometimes it's necessary to override the default template delimiters (`{{`/`}}`).

--- a/tests/integration/datasources_file_test.go
+++ b/tests/integration/datasources_file_test.go
@@ -62,6 +62,18 @@ func (s *FileDatasourcesSuite) TestFileDatasources(c *C) {
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar"})
 
 	result = icmd.RunCommand(GomplateBin,
+		"-c", "config="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{ .config.foo}}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar"})
+
+	result = icmd.RunCommand(GomplateBin,
+		"-c", ".="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{ .foo}} {{ (ds ".").foo }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar bar"})
+
+	result = icmd.RunCommand(GomplateBin,
 		"-d", "config="+s.tmpDir.Join("config2.yml"),
 		"-i", `{{ if (datasourceReachable "bogus") }}bogus!{{ end -}}
 {{ if (datasourceReachable "config") -}}


### PR DESCRIPTION
Fixes #404 

Adds a new `--context`/`-c` commandline flag to allow pre-loading a datasource into the template's context.

This allows this sort of usage:

```console
$ gomplate -c foo=https://example.com/foo.json -c bar.yml -i '{{ .foo.value }}, {{ .bar.value }}'
foo's value, bar's value
$ gomplate -c .=baz.yml -i '{{ .value }}'
baz's value
```

Caveats:

- all context datasources are loaded first - this can introduce latency
- setting the root (with alias of `.`) makes `.Env` unavailable
- sub-paths can't be given to context datasources in the template (i.e. `{{ datasource "foo" "subpath" }}`)
- inline datasources can't be added to the context at runtime

Other:

- context datasources are still available by name as regular datasources:
    ```console
    $ gomplate -c .=baz.yml -i '{{ .value }} - {{ (ds ".").value }}'
    baz's value - baz's value
    ```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>