### PR TITLE
New test.Ternary function

### DIFF
--- a/docs-src/content/functions/test.yml
+++ b/docs-src/content/functions/test.yml
@@ -76,3 +76,32 @@ funcs:
         template: <arg>:1:25: executing "<arg>" at <required "The `confi...>: error calling required: The `config` datasource must have a value defined for `empty`
         $ gomplate -d config=config.yaml -i '{{ (ds "config").bogus | required "The `config` datasource must have a value defined for `bogus`" }}'
         template: <arg>:1:7: executing "<arg>" at <"config">: map has no entry for key "bogus"
+  - name: test.Ternary
+    alias: ternary
+    description: |
+      Returns one of two values depending on whether the third is true. Note that the third value does not have to be a boolean - it is converted first by the [`conv.ToBool`](../conv/#conv-tobool) function (values like `true`, `1`, `"true"`, `"Yes"`, etc... are considered true).
+
+      This is effectively a short-form of the following template:
+
+      ```
+      {{ if conv.ToBool $condition }}{{ $truevalue }}{{ else }}{{ $falsevalue }}{{ end }}
+      ```
+
+      Keep in mind that using an explicit `if`/`else` block is often easier to understand than ternary expressions!
+    pipeline: true
+    arguments:
+      - name: truevalue
+        required: true
+        description: the value to return if `condition` is true
+      - name: falsevalue
+        required: true
+        description: the value to return if `condition` is false
+      - name: condition
+        required: true
+        description: the value to evaluate for truthiness
+    examples:
+      - |
+        $ gomplate -i '{{ ternary "FOO" "BAR" false }}'
+        BAR
+        $ gomplate -i '{{ ternary "FOO" "BAR" "yes" }}'
+        FOO

--- a/docs/content/functions/test.md
+++ b/docs/content/functions/test.md
@@ -122,3 +122,43 @@ template: <arg>:1:25: executing "<arg>" at <required "The `confi...>: error call
 $ gomplate -d config=config.yaml -i '{{ (ds "config").bogus | required "The `config` datasource must have a value defined for `bogus`" }}'
 template: <arg>:1:7: executing "<arg>" at <"config">: map has no entry for key "bogus"
 ```
+
+## `test.Ternary`
+
+**Alias:** `ternary`
+
+Returns one of two values depending on whether the third is true. Note that the third value does not have to be a boolean - it is converted first by the [`conv.ToBool`](../conv/#conv-tobool) function (values like `true`, `1`, `"true"`, `"Yes"`, etc... are considered true).
+
+This is effectively a short-form of the following template:
+
+```
+{{ if conv.ToBool $condition }}{{ $truevalue }}{{ else }}{{ $falsevalue }}{{ end }}
+```
+
+Keep in mind that using an explicit `if`/`else` block is often easier to understand than ternary expressions!
+
+### Usage
+```go
+test.Ternary truevalue falsevalue condition 
+```
+
+```go
+condition | test.Ternary truevalue falsevalue  
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `truevalue` | _(required)_ the value to return if `condition` is true |
+| `falsevalue` | _(required)_ the value to return if `condition` is false |
+| `condition` | _(required)_ the value to evaluate for truthiness |
+
+### Examples
+
+```console
+$ gomplate -i '{{ ternary "FOO" "BAR" false }}'
+BAR
+$ gomplate -i '{{ ternary "FOO" "BAR" "yes" }}'
+FOO
+```

--- a/funcs/test.go
+++ b/funcs/test.go
@@ -27,6 +27,7 @@ func AddTestFuncs(f map[string]interface{}) {
 	f["assert"] = TestNS().Assert
 	f["fail"] = TestNS().Fail
 	f["required"] = TestNS().Required
+	f["ternary"] = TestNS().Ternary
 }
 
 // TestFuncs -
@@ -75,4 +76,12 @@ func (f *TestFuncs) Required(args ...interface{}) (interface{}, error) {
 	default:
 		return nil, errors.Errorf("wrong number of args: want 1 or 2, got %d", len(args))
 	}
+}
+
+// Ternary -
+func (f *TestFuncs) Ternary(tval, fval, b interface{}) interface{} {
+	if conv.ToBool(b) {
+		return tval
+	}
+	return fval
 }

--- a/funcs/test_test.go
+++ b/funcs/test_test.go
@@ -63,3 +63,18 @@ func TestRequired(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, v, "foo")
 }
+
+func TestTernary(t *testing.T) {
+	f := TestNS()
+	testdata := []struct {
+		tval, fval, b interface{}
+		expected      interface{}
+	}{
+		{"foo", 42, false, 42},
+		{"foo", 42, "yes", "foo"},
+		{false, true, true, false},
+	}
+	for _, d := range testdata {
+		assert.Equal(t, d.expected, f.Ternary(d.tval, d.fval, d.b))
+	}
+}


### PR DESCRIPTION
Fixes #428 

Note that this differs slightly from the sprig version - the third arg is not required to be a `bool`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>