### PR TITLE
Adding option to suppress empty output files

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -139,3 +139,14 @@ add the command to the command-line after a `--` argument:
 $ gomplate -i 'hello world' -o out.txt -- cat out.txt
 hello world
 ```
+
+## Suppressing empty output
+
+Sometimes it can be desirable to suppress empty output (i.e. output consisting of only whitespace). To do so, set `GOMPLATE_SUPPRESS_EMPTY=true` in your environment:
+
+```console
+$ export GOMPLATE_SUPPRESS_EMPTY=true
+$ gomplate -i '{{ print "   \n" }}' -o out
+$ cat out
+cat: out: No such file or directory
+```

--- a/template_test.go
+++ b/template_test.go
@@ -295,3 +295,60 @@ func TestProcessTemplates(t *testing.T) {
 		fs.Remove("out")
 	}
 }
+
+func TestAllWhitespace(t *testing.T) {
+	testdata := []struct {
+		in       []byte
+		expected bool
+	}{
+		{[]byte(" "), true},
+		{[]byte("foo"), false},
+		{[]byte("   \t\n\n\v\r\n"), true},
+		{[]byte("   foo   "), false},
+	}
+
+	for _, d := range testdata {
+		assert.Equal(t, d.expected, allWhitespace(d.in))
+	}
+}
+
+func TestEmptySkipper(t *testing.T) {
+	testdata := []struct {
+		in    []byte
+		empty bool
+	}{
+		{[]byte(" "), true},
+		{[]byte("foo"), false},
+		{[]byte("   \t\n\n\v\r\n"), true},
+		{[]byte("   foo   "), false},
+	}
+
+	for _, d := range testdata {
+		w := &bufferCloser{&bytes.Buffer{}}
+		opened := false
+		f := newEmptySkipper(func() (io.WriteCloser, error) {
+			t.Logf("I got called %#v", w)
+			opened = true
+			return w, nil
+		})
+		n, err := f.Write(d.in)
+		assert.NoError(t, err)
+		assert.Equal(t, len(d.in), n)
+		if d.empty {
+			assert.Nil(t, f.w)
+			assert.False(t, opened)
+		} else {
+			assert.NotNil(t, f.w)
+			assert.True(t, opened)
+			assert.EqualValues(t, d.in, w.Bytes())
+		}
+	}
+}
+
+type bufferCloser struct {
+	*bytes.Buffer
+}
+
+func (b *bufferCloser) Close() error {
+	return nil
+}

--- a/tests/integration/basic_test.go
+++ b/tests/integration/basic_test.go
@@ -233,3 +233,19 @@ func (s *BasicSuite) TestExecCommand(c *C) {
 		Out:      "hello world",
 	})
 }
+
+func (s *BasicSuite) TestEmptyOutputSuppression(c *C) {
+	out := s.tmpDir.Join("out")
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"-i",
+		`{{print "\t  \n\n\r\n\t\t     \v\n"}}`,
+		"-o", out),
+		func(cmd *icmd.Cmd) {
+			cmd.Env = []string{
+				"GOMPLATE_SUPPRESS_EMPTY=true",
+			}
+		})
+	result.Assert(c, icmd.Expected{ExitCode: 0})
+	_, err := os.Stat(out)
+	assert.Equal(c, true, os.IsNotExist(err))
+}


### PR DESCRIPTION
Fixes #430 

This adds a new environment variable `GOMPLATE_SUPPRESS_EMPTY` which, if set to `true`, will cause output files to not be created if the template only outputs whitespace.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>