### PR TITLE
Document suppressing newlines.

### DIFF
--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -51,7 +51,7 @@ Hello,  baz!
 
 This might not be desirable.
 
-You can suppress leading newlines (i.e. newlines that come before the action) by placing a minus sign in front of the first set of delimiters (`{{`). Putting the minus sign behind the trailing set of delimiters (`}}`) will suppress the newline _after_ the action. You can do both to suppress newlines entirely on that line.
+You can use [Golang template syntax](https://golang.org/pkg/text/template/#hdr-Text_and_spaces) to fix this. Leading newlines (i.e. newlines that come before the action) can be suppressed by placing a minus sign in front of the first set of delimiters (`{{`). Putting the minus sign behind the trailing set of delimiters (`}}`) will suppress the newline _after_ the action. You can do both to suppress newlines entirely on that line.
 
 Placing the minus sign within the context (i.e. inside of `{{.}}`) has no effect.
 

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -60,7 +60,7 @@ Here are a few examples.
 ### Suppressing leading newlines
 
 ```
-{{- range ( "Foo, bar, baz" | strings.Split "," ) }}
+{{- range slice "Foo" "bar" "baz" }}
 Hello, {{ . }}!
 {{- end }}
 ```
@@ -79,7 +79,7 @@ Hello,  baz!
 This code:
 
 ```
-{{ range ( "Foo, bar, baz" | strings.Split "," ) -}}
+{{ range slice "Foo" "bar" "baz" -}}
 Hello, {{ . }}!
 {{ end -}}
 ```
@@ -97,7 +97,7 @@ Hello,  baz!
 This code:
 
 ```
-{{- range ( "Foo, bar, baz" | strings.Split "," ) -}}
+{{- range slice "Foo" "bar" "baz" -}}
 Hello, {{ . }}!
 {{- end -}}
 ```

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -27,6 +27,88 @@ _real life_, but this conveys the basics, which is that _actions_ are  delimited
 by `{{` and `}}`, and are replaced with their output (if any) when the template
 is rendered.
 
+## Multi-line templates
+
+By default, every line containing an action will render a newline. For example, the action block below:
+
+```
+{{ range ( "Foo, bar, baz" | strings.Split "," ) }}
+Hello, {{ . }}!
+{{ end }}
+```
+
+will produce the output below:
+
+```
+
+Hello, Foo!
+
+Hello,  bar!
+
+Hello,  baz!
+
+```
+
+This might not be desirable.
+
+You can suppress leading newlines (i.e. newlines that come before the action) by placing a minus sign in front of the first set of delimiters (`{{`). Putting the minus sign behind the trailing set of delimiters (`}}`) will suppress the newline _after_ the action. You can do both to suppress newlines entirely on that line.
+
+Placing the minus sign within the context (i.e. inside of `{{.}}`) has no effect.
+
+Here are a few examples.
+
+### Suppressing leading newlines
+
+```
+{{- range ( "Foo, bar, baz" | strings.Split "," ) }}
+Hello, {{ . }}!
+{{- end }}
+```
+
+will produce this:
+
+```
+
+Hello, Foo!
+Hello,  bar!
+Hello,  baz!
+```
+
+### Suppressing trailling newlines
+
+This code:
+
+```
+{{ range ( "Foo, bar, baz" | strings.Split "," ) -}}
+Hello, {{ . }}!
+{{ end -}}
+```
+
+yields this:
+
+```
+Hello, Foo!
+Hello,  bar!
+Hello,  baz!
+```
+
+### Suppressing newlines altogether
+
+This code:
+
+```
+{{- range ( "Foo, bar, baz" | strings.Split "," ) -}}
+Hello, {{ . }}!
+{{- end -}}
+```
+
+Produces:
+
+```
+Hello, Foo!Hello,  bar!Hello,  baz!
+```
+
+
 ## Variables
 
 The result of an action can be assigned to a _variable_, which is denoted by a

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -32,7 +32,7 @@ is rendered.
 By default, every line containing an action will render a newline. For example, the action block below:
 
 ```
-{{ range ( "Foo, bar, baz" | strings.Split "," ) }}
+{{ range slice "Foo" "bar" "baz" }}
 Hello, {{ . }}!
 {{ end }}
 ```


### PR DESCRIPTION
I found myself writing multi-line action blocks to improve readability but could not understand why each action left a newline behind. Because I was running this in Docker Compose, I didn't want to alter the `ENTRYPOINT` to your image to do some data munging with `bash` to workaround it.

I saw that some example code in your documentation had leading and trailing minus signs after and before the action delimiters. I figured this was worth something, so I used it in my code and discovered that this is how you suppress newlines.

While this is well-known for those that use Go templates, it wasn't clear to this not-yet-a-Golang dev. I added some documentation to explain this better for folks like me.

I love this tool! Thank you for making it!