### PR TITLE
AWS region detection for SSM param store datasources

### DIFF
--- a/aws/ec2meta.go
+++ b/aws/ec2meta.go
@@ -15,6 +15,11 @@ import (
 // DefaultEndpoint -
 var DefaultEndpoint = "http://169.254.169.254"
 
+const (
+	// the default region
+	unknown = "unknown"
+)
+
 // Ec2Meta -
 type Ec2Meta struct {
 	Endpoint string


### PR DESCRIPTION
Fixes #458 by always looking up the region when creating a new `SDKSession`

Signed-off-by: Dave Henderson <dhenderson@gmail.com>