### PR TITLE
New functions conv.Keys and conv.Values

### DIFF
--- a/conv/conv.go
+++ b/conv/conv.go
@@ -3,6 +3,7 @@ package conv
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -327,4 +328,48 @@ func Dict(v ...interface{}) (map[string]interface{}, error) {
 		dict[key] = v[i+1]
 	}
 	return dict, nil
+}
+
+// Keys returns the list of keys in one or more maps. The returned list of keys
+// is ordered by map, each in sorted key order.
+func Keys(in ...map[string]interface{}) ([]string, error) {
+	if len(in) == 0 {
+		return nil, fmt.Errorf("conv.Keys needs at least one argument")
+	}
+	keys := []string{}
+	for _, m := range in {
+		k, _ := splitMap(m)
+		keys = append(keys, k...)
+	}
+	return keys, nil
+}
+
+func splitMap(m map[string]interface{}) ([]string, []interface{}) {
+	keys := make([]string, len(m))
+	values := make([]interface{}, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		values[i] = m[k]
+	}
+	return keys, values
+}
+
+// Values returns the list of values in one or more maps. The returned list of values
+// is ordered by map, each in sorted key order. If the Keys function is called with
+// the same arguments, the key/value mappings will be maintained.
+func Values(in ...map[string]interface{}) ([]interface{}, error) {
+	if len(in) == 0 {
+		return nil, fmt.Errorf("conv.Values needs at least one argument")
+	}
+	values := []interface{}{}
+	for _, m := range in {
+		_, v := splitMap(m)
+		values = append(values, v...)
+	}
+	return values, nil
 }

--- a/conv/conv_test.go
+++ b/conv/conv_test.go
@@ -326,3 +326,71 @@ func TestDict(t *testing.T) {
 		assert.Equal(t, d.expected, actual)
 	}
 }
+
+func TestKeys(t *testing.T) {
+	_, err := Keys()
+	assert.Error(t, err)
+
+	in := map[string]interface{}{
+		"foo": 1,
+		"bar": 2,
+	}
+	expected := []string{"bar", "foo"}
+	keys, err := Keys(in)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, keys)
+
+	in2 := map[string]interface{}{
+		"baz": 3,
+		"qux": 4,
+	}
+	expected = []string{"bar", "foo", "baz", "qux"}
+	keys, err = Keys(in, in2)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, keys)
+
+	in3 := map[string]interface{}{
+		"Foo": 5,
+		"Bar": 6,
+		"foo": 7,
+		"bar": 8,
+	}
+	expected = []string{"bar", "foo", "baz", "qux", "Bar", "Foo", "bar", "foo"}
+	keys, err = Keys(in, in2, in3)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, keys)
+}
+
+func TestValues(t *testing.T) {
+	_, err := Values()
+	assert.Error(t, err)
+
+	in := map[string]interface{}{
+		"foo": 1,
+		"bar": 2,
+	}
+	expected := []interface{}{2, 1}
+	values, err := Values(in)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, values)
+
+	in2 := map[string]interface{}{
+		"baz": 3,
+		"qux": 4,
+	}
+	expected = []interface{}{2, 1, 3, 4}
+	values, err = Values(in, in2)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, values)
+
+	in3 := map[string]interface{}{
+		"Foo": 5,
+		"Bar": 6,
+		"foo": 7,
+		"bar": 8,
+	}
+	expected = []interface{}{2, 1, 3, 4, 6, 5, 8, 7}
+	values, err = Values(in, in2, in3)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, values)
+}

--- a/docs-src/content/functions/conv.yml
+++ b/docs-src/content/functions/conv.yml
@@ -404,3 +404,47 @@ funcs:
       - |
         $ gomplate -i '{{ conv.ToStrings nil 42 true 0xF (slice 1 2 3) }}'
         [nil 42 true 15 [1 2 3]]
+  - name: conv.Keys
+    alias: keys
+    description: |
+      Return a list of keys in one or more maps.
+
+      The keys will be ordered first by map position (if multiple maps are given),
+      then alphabetically.
+
+      See also [`conv.Values`](#conv-values).
+    arguments:
+      - name: in...
+        required: true
+        description: the maps
+    examples:
+      - |
+        $ gomplate -i '{{ $map := json `{"foo": 1, "bar": 2}` -}}
+          {{ conv.Keys $map }}'
+        [bar foo]
+        $ gomplate -i '{{ $map1 := json `{"foo": 1, "bar": 2}` -}}
+          {{ $map2 := json `{"baz": 3, "qux": 4}` -}}
+          {{ conv.Keys $map1 $map2 }}'
+        [bar foo baz qux]
+  - name: conv.Values
+    alias: values
+    description: |
+      Return a list of values in one or more maps.
+
+      The values will be ordered first by map position (if multiple maps are given),
+      then alphabetically by key.
+
+      See also [`conv.Keys`](#conv-keys).
+    arguments:
+      - name: in...
+        required: true
+        description: the maps
+    examples:
+      - |
+        $ gomplate -i '{{ $map := json `{"foo": 1, "bar": 2}` -}}
+          {{ conv.Values $map }}'
+        [2 1]
+        $ gomplate -i '{{ $map1 := json `{"foo": 1, "bar": 2}` -}}
+          {{ $map2 := json `{"baz": 3, "qux": 4}` -}}
+          {{ conv.Values $map1 $map2 }}'
+        [2 1 3 4]

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -620,3 +620,71 @@ conv.ToStrings in...
 $ gomplate -i '{{ conv.ToStrings nil 42 true 0xF (slice 1 2 3) }}'
 [nil 42 true 15 [1 2 3]]
 ```
+
+## `conv.Keys`
+
+**Alias:** `keys`
+
+Return a list of keys in one or more maps.
+
+The keys will be ordered first by map position (if multiple maps are given),
+then alphabetically.
+
+See also [`conv.Values`](#conv-values).
+
+### Usage
+```go
+conv.Keys in... 
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in...` | _(required)_ the maps |
+
+### Examples
+
+```console
+$ gomplate -i '{{ $map := json `{"foo": 1, "bar": 2}` -}}
+  {{ conv.Keys $map }}'
+[bar foo]
+$ gomplate -i '{{ $map1 := json `{"foo": 1, "bar": 2}` -}}
+  {{ $map2 := json `{"baz": 3, "qux": 4}` -}}
+  {{ conv.Keys $map1 $map2 }}'
+[bar foo baz qux]
+```
+
+## `conv.Values`
+
+**Alias:** `values`
+
+Return a list of values in one or more maps.
+
+The values will be ordered first by map position (if multiple maps are given),
+then alphabetically by key.
+
+See also [`conv.Keys`](#conv-keys).
+
+### Usage
+```go
+conv.Values in... 
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in...` | _(required)_ the maps |
+
+### Examples
+
+```console
+$ gomplate -i '{{ $map := json `{"foo": 1, "bar": 2}` -}}
+  {{ conv.Values $map }}'
+[2 1]
+$ gomplate -i '{{ $map1 := json `{"foo": 1, "bar": 2}` -}}
+  {{ $map2 := json `{"baz": 3, "qux": 4}` -}}
+  {{ conv.Values $map1 $map2 }}'
+[2 1 3 4]
+```

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -30,6 +30,8 @@ func AddConvFuncs(f map[string]interface{}) {
 	f["join"] = ConvNS().Join
 	f["default"] = ConvNS().Default
 	f["dict"] = ConvNS().Dict
+	f["keys"] = ConvNS().Keys
+	f["values"] = ConvNS().Values
 }
 
 // ConvFuncs -
@@ -141,4 +143,14 @@ func (f *ConvFuncs) Default(def, in interface{}) interface{} {
 // Dict -
 func (f *ConvFuncs) Dict(in ...interface{}) (map[string]interface{}, error) {
 	return conv.Dict(in...)
+}
+
+// Keys -
+func (f *ConvFuncs) Keys(in ...map[string]interface{}) ([]string, error) {
+	return conv.Keys(in...)
+}
+
+// Values -
+func (f *ConvFuncs) Values(in ...map[string]interface{}) ([]interface{}, error) {
+	return conv.Values(in...)
 }


### PR DESCRIPTION
Related to #467 

Adding two new functions `conv.Keys` and `conv.Values`, also aliased as `keys` and `values`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>