### PR TITLE
New merge datasource, for merging multiple datasources

### DIFF
--- a/data/datasource_env.go
+++ b/data/datasource_env.go
@@ -6,10 +6,6 @@ import (
 	"github.com/hairyhenderson/gomplate/env"
 )
 
-func init() {
-	addSourceReader("env", readEnv)
-}
-
 func readEnv(source *Source, args ...string) (b []byte, err error) {
 	n := source.URL.Path
 	n = strings.TrimPrefix(n, "/")

--- a/data/datasource_merge.go
+++ b/data/datasource_merge.go
@@ -1,0 +1,96 @@
+package data
+
+import (
+	"strings"
+
+	"github.com/imdario/mergo"
+
+	"github.com/pkg/errors"
+)
+
+// readMerge demultiplexes a `merge:` datasource. The 'args' parameter currently
+// has no meaning for this source.
+//
+// URI format is 'merge:<source 1>|<source 2>[|<source n>...]' where `<source #>`
+// is a supported URI or a pre-defined alias name.
+//
+// Query strings and fragments are interpreted relative to the merged data, not
+// the source data. To merge datasources with query strings or fragments, define
+// separate sources first and specify the alias names. HTTP headers are also not
+// supported directly.
+func (d *Data) readMerge(source *Source, args ...string) ([]byte, error) {
+	opaque := source.URL.Opaque
+	parts := strings.Split(opaque, "|")
+	if len(parts) < 2 {
+		return nil, errors.New("need at least 2 datasources to merge")
+	}
+	data := make([]map[string]interface{}, len(parts))
+	for i, part := range parts {
+		// supports either URIs or aliases
+		subSource, err := d.lookupSource(part)
+		if err != nil {
+			// maybe it's a relative filename?
+			subSource, err = parseSource(part + "=" + part)
+			if err != nil {
+				return nil, err
+			}
+		}
+		subSource.inherit(source)
+
+		b, err := d.readSource(subSource)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Couldn't read datasource '%s'", part)
+		}
+
+		mimeType, err := subSource.mimeType()
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read datasource %s", subSource.URL)
+		}
+
+		data[i], err = parseMap(mimeType, string(b))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Merge the data together
+	b, err := mergeData(data)
+	if err != nil {
+		return nil, err
+	}
+
+	source.mediaType = yamlMimetype
+	return b, nil
+}
+
+func mergeData(data []map[string]interface{}) ([]byte, error) {
+	dst := data[0]
+	data = data[1:]
+	for _, datum := range data {
+		err := mergo.Merge(&dst, datum)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to merge datasources")
+		}
+	}
+
+	s, err := ToYAML(dst)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(s), nil
+}
+
+func parseMap(mimeType, data string) (map[string]interface{}, error) {
+	datum, err := parseData(mimeType, data)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	switch datum := datum.(type) {
+	case map[string]interface{}:
+		m = datum
+	default:
+		return nil, errors.Errorf("unexpected data type '%T' for datasource (type %s); merge: can only merge maps", datum, mimeType)
+	}
+	return m, nil
+}

--- a/data/datasource_merge_test.go
+++ b/data/datasource_merge_test.go
@@ -1,0 +1,75 @@
+//+build !windows
+
+package data
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/blang/vfs"
+	"github.com/blang/vfs/memfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadMerge(t *testing.T) {
+	jsonContent := []byte(`{"hello": "world"}`)
+	yamlContent := []byte("hello: earth\ngoodnight: moon\n")
+	arrayContent := []byte(`["hello", "world"]`)
+
+	mergedContent := []byte("goodnight: moon\nhello: world\n")
+
+	fs := memfs.Create()
+
+	_ = fs.Mkdir("/tmp", 0777)
+	f, _ := vfs.Create(fs, "/tmp/jsonfile.json")
+	_, _ = f.Write(jsonContent)
+	f, _ = vfs.Create(fs, "/tmp/array.json")
+	_, _ = f.Write(arrayContent)
+	f, _ = vfs.Create(fs, "/tmp/yamlfile.yaml")
+	_, _ = f.Write(yamlContent)
+	f, _ = vfs.Create(fs, "/tmp/textfile.txt")
+	_, _ = f.Write([]byte(`plain text...`))
+
+	source := &Source{Alias: "foo", URL: mustParseURL("merge:file:///tmp/jsonfile.json|file:///tmp/yamlfile.yaml")}
+	source.fs = fs
+	d := &Data{
+		Sources: map[string]*Source{
+			"foo":       source,
+			"bar":       {Alias: "bar", URL: mustParseURL("file:///tmp/jsonfile.json")},
+			"baz":       {Alias: "baz", URL: mustParseURL("file:///tmp/yamlfile.yaml")},
+			"text":      {Alias: "text", URL: mustParseURL("file:///tmp/textfile.txt")},
+			"badscheme": {Alias: "badscheme", URL: mustParseURL("bad:///scheme.json")},
+			"badtype":   {Alias: "badtype", URL: mustParseURL("file:///tmp/textfile.txt?type=foo/bar")},
+			"array":     {Alias: "array", URL: mustParseURL("file:///tmp/array.json?type=" + url.QueryEscape(jsonArrayMimetype))},
+		},
+	}
+
+	actual, err := d.readMerge(source)
+	assert.NoError(t, err)
+	assert.Equal(t, mergedContent, actual)
+
+	source.URL = mustParseURL("merge:bar|baz")
+	actual, err = d.readMerge(source)
+	assert.NoError(t, err)
+	assert.Equal(t, mergedContent, actual)
+
+	source.URL = mustParseURL("merge:file:///tmp/jsonfile.json")
+	_, err = d.readMerge(source)
+	assert.Error(t, err)
+
+	source.URL = mustParseURL("merge:bogusalias|file:///tmp/jsonfile.json")
+	_, err = d.readMerge(source)
+	assert.Error(t, err)
+
+	source.URL = mustParseURL("merge:file:///tmp/jsonfile.json|badscheme")
+	_, err = d.readMerge(source)
+	assert.Error(t, err)
+
+	source.URL = mustParseURL("merge:file:///tmp/jsonfile.json|badtype")
+	_, err = d.readMerge(source)
+	assert.Error(t, err)
+
+	source.URL = mustParseURL("merge:file:///tmp/jsonfile.json|array")
+	_, err = d.readMerge(source)
+	assert.Error(t, err)
+}

--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -70,6 +70,12 @@ func TestParseSourceWithAlias(t *testing.T) {
 	assert.Equal(t, "sftp", s.URL.Scheme)
 	assert.True(t, s.URL.IsAbs())
 	assert.Equal(t, "/blahblah/foo.json", s.URL.Path)
+
+	s, err = parseSource("merged=merge:./foo.yaml|http://example.com/bar.json%3Ffoo=bar")
+	assert.NoError(t, err)
+	assert.Equal(t, "merged", s.Alias)
+	assert.Equal(t, "merge", s.URL.Scheme)
+	assert.Equal(t, "./foo.yaml|http://example.com/bar.json%3Ffoo=bar", s.URL.Opaque)
 }
 
 func TestDatasource(t *testing.T) {

--- a/tests/integration/datasources_merge_test.go
+++ b/tests/integration/datasources_merge_test.go
@@ -1,0 +1,66 @@
+//+build integration
+//+build !windows
+
+package integration
+
+import (
+	"net"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/gotestyourself/gotestyourself/fs"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+type MergeDatasourceSuite struct {
+	tmpDir *fs.Dir
+	l      *net.TCPListener
+}
+
+var _ = Suite(&MergeDatasourceSuite{})
+
+func (s *MergeDatasourceSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFiles(map[string]string{
+			"config.json": `{"foo": {"bar": "baz"}}`,
+			"default.yml": "foo:\n  bar: qux\nother: true\n",
+		}),
+	)
+
+	var err error
+	s.l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	handle(c, err)
+
+	http.HandleFunc("/foo.json", typeHandler("application/json", `{"foo": "bar"}`))
+	go http.Serve(s.l, nil)
+}
+
+func (s *MergeDatasourceSuite) TearDownSuite(c *C) {
+	s.l.Close()
+	s.tmpDir.Remove()
+}
+
+func (s *MergeDatasourceSuite) TestMergeDatasource(c *C) {
+	result := icmd.RunCommand(GomplateBin,
+		"-d", "user="+s.tmpDir.Join("config.json"),
+		"-d", "default="+s.tmpDir.Join("default.yml"),
+		"-d", "config=merge:user|default",
+		"-i", `{{ ds "config" | toJSON }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: `{"foo":{"bar":"baz"},"other":true}`})
+
+	result = icmd.RunCommand(GomplateBin,
+		"-d", "default="+s.tmpDir.Join("default.yml"),
+		"-d", "config=merge:user|default",
+		"-i", `{{ defineDatasource "user" "`+s.tmpDir.Join("config.json")+`" }}{{ ds "config" | toJSON }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: `{"foo":{"bar":"baz"},"other":true}`})
+
+	result = icmd.RunCommand(GomplateBin,
+		"-d", "default="+s.tmpDir.Join("default.yml"),
+		"-d", "config=merge:http://"+s.l.Addr().String()+"/foo.json|default",
+		"-i", `{{ ds "config" | toJSON }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: `{"foo":"bar","other":true}`})
+}


### PR DESCRIPTION
Fixes #467 

This adds a new meta-datasource with the scheme `merge:`.

See this comment for details: https://github.com/hairyhenderson/gomplate/issues/467#issuecomment-457983206

Signed-off-by: Dave Henderson <dhenderson@gmail.com>