### PR TITLE
New function coll.Sort, expanding on strings.Sort

### DIFF
--- a/docs-src/content/functions/coll.yml
+++ b/docs-src/content/functions/coll.yml
@@ -195,6 +195,39 @@ funcs:
       - |
         $ gomplate -i '{{ slice 4 3 2 1 | reverse }}'
         [1 2 3 4]
+  - name: coll.Sort
+    alias: sort
+    description: |
+      Sort a given list. Uses the natural sort order if possible. For inputs
+      that are not sortable (either because the elements are of different types,
+      or of an un-sortable type), the input will simply be returned, unmodified.
+
+      Maps and structs can be sorted by a named key.
+
+      _Note that this function does not modify the input._
+    pipeline: true
+    arguments:
+      - name: key
+        required: false
+        description: the key to sort by, for lists of maps or structs
+      - name: list
+        required: true
+        description: the slice or array to sort
+    examples:
+      - |
+        $ gomplate -i '{{ slice "foo" "bar" "baz" | coll.Sort }}'
+        [bar baz foo]
+      - |
+        $ gomplate -i '{{ sort (slice 3 4 1 2 5) }}'
+        [1 2 3 4 5]
+      - |
+        $ cat <<EOF > in.json
+        [{"a": "foo", "b": 1}, {"a": "bar", "b": 8}, {"a": "baz", "b": 3}]
+        EOF
+        $ gomplate -d in.json -i '{{ range (include "in" | jsonArray | coll.Sort "b") }}{{ print .a "\n" }}{{ end }}'
+        foo
+        baz
+        bar
   - name: coll.Merge
     alias: merge
     description: |

--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -25,7 +25,7 @@ funcs:
         $ gomplate -i '{{ strings.Quote 500 }}'
         "500"
   - name: strings.Sort
-    alias: sort
+    deprecated: Use [`coll.Sort`](../coll/#coll-sort) instead
     description: |
       Returns an alphanumerically-sorted copy of a given string list.
     pipeline: true

--- a/docs/content/functions/coll.md
+++ b/docs/content/functions/coll.md
@@ -320,6 +320,54 @@ $ gomplate -i '{{ slice 4 3 2 1 | reverse }}'
 [1 2 3 4]
 ```
 
+## `coll.Sort`
+
+**Alias:** `sort`
+
+Sort a given list. Uses the natural sort order if possible. For inputs
+that are not sortable (either because the elements are of different types,
+or of an un-sortable type), the input will simply be returned, unmodified.
+
+Maps and structs can be sorted by a named key.
+
+_Note that this function does not modify the input._
+
+### Usage
+```go
+coll.Sort [key] list 
+```
+
+```go
+list | coll.Sort [key]  
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `key` | _(optional)_ the key to sort by, for lists of maps or structs |
+| `list` | _(required)_ the slice or array to sort |
+
+### Examples
+
+```console
+$ gomplate -i '{{ slice "foo" "bar" "baz" | coll.Sort }}'
+[bar baz foo]
+```
+```console
+$ gomplate -i '{{ sort (slice 3 4 1 2 5) }}'
+[1 2 3 4 5]
+```
+```console
+$ cat <<EOF > in.json
+[{"a": "foo", "b": 1}, {"a": "bar", "b": 8}, {"a": "baz", "b": 3}]
+EOF
+$ gomplate -d in.json -i '{{ range (include "in" | jsonArray | coll.Sort "b") }}{{ print .a "\n" }}{{ end }}'
+foo
+baz
+bar
+```
+
 ## `coll.Merge`
 
 **Alias:** `merge`

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -153,12 +153,10 @@ foo:
     quuz: 42
 ```
 
-## `strings.Sort`
-
-**Alias:** `sort`
+## `strings.Sort` _(deprecated)_
+**Deprecation Notice:** Use [`coll.Sort`](../coll/#coll-sort) instead
 
 Returns an alphanumerically-sorted copy of a given string list.
-
 
 ### Usage
 ```go
@@ -178,7 +176,7 @@ list | strings.Sort
 ### Examples
 
 ```console
-$ gomplate -i '{{ (slice "foo" "bar" "baz") | sort }}'
+$ gomplate -i '{{ (slice "foo" "bar" "baz") | strings.Sort }}'
 [bar baz foo]
 ```
 

--- a/funcs/coll.go
+++ b/funcs/coll.go
@@ -3,7 +3,10 @@ package funcs
 import (
 	"sync"
 
+	"github.com/hairyhenderson/gomplate/conv"
+
 	"github.com/hairyhenderson/gomplate/coll"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -31,6 +34,7 @@ func AddCollFuncs(f map[string]interface{}) {
 	f["uniq"] = CollNS().Uniq
 	f["reverse"] = CollNS().Reverse
 	f["merge"] = CollNS().Merge
+	f["sort"] = CollNS().Sort
 }
 
 // CollFuncs -
@@ -84,4 +88,23 @@ func (f *CollFuncs) Reverse(in interface{}) ([]interface{}, error) {
 // Merge -
 func (f *CollFuncs) Merge(dst map[string]interface{}, src ...map[string]interface{}) (map[string]interface{}, error) {
 	return coll.Merge(dst, src...)
+}
+
+// Sort -
+func (f *CollFuncs) Sort(args ...interface{}) ([]interface{}, error) {
+	var (
+		key  string
+		list interface{}
+	)
+	if len(args) == 0 || len(args) > 2 {
+		return nil, errors.Errorf("wrong number of args: wanted 1 or 2, got %d", len(args))
+	}
+	if len(args) == 1 {
+		list = args[0]
+	}
+	if len(args) == 2 {
+		key = conv.ToString(args[0])
+		list = args[1]
+	}
+	return coll.Sort(key, list)
 }

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -40,7 +40,6 @@ func AddStringFuncs(f map[string]interface{}) {
 	f["toLower"] = StrNS().ToLower
 	f["trimSpace"] = StrNS().TrimSpace
 	f["indent"] = StrNS().Indent
-	f["sort"] = StrNS().Sort
 	f["quote"] = StrNS().Quote
 	f["squote"] = StrNS().Squote
 
@@ -112,6 +111,8 @@ func (f *StringFuncs) Repeat(count int, s interface{}) (string, error) {
 }
 
 // Sort -
+//
+// Deprecated: use coll.Sort instead
 func (f *StringFuncs) Sort(list interface{}) ([]string, error) {
 	switch v := list.(type) {
 	case []string:

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -38,6 +38,8 @@ func Trunc(length int, s string) string {
 }
 
 // Sort - return an alphanumerically-sorted list of strings
+//
+// Deprecated: use coll.Sort instead
 func Sort(list []string) []string {
 	sorted := sort.StringSlice(list)
 	sorted.Sort()

--- a/tests/integration/collection_test.go
+++ b/tests/integration/collection_test.go
@@ -62,3 +62,28 @@ func (s *CollSuite) TestMerge(c *C) {
   two: 2
 `})
 }
+
+func (s *CollSuite) TestSort(c *C) {
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"-i", `{{ $maps := jsonArray "[{\"a\": \"foo\", \"b\": 1}, {\"a\": \"bar\", \"b\": 8}, {\"a\": \"baz\", \"b\": 3}]" -}}
+{{ range coll.Sort "b" $maps -}}
+{{ .a }}
+{{ end -}}
+`))
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "foo\nbaz\nbar\n"})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"-i", `
+{{- coll.Sort (slice "b" "a" "c" "aa") }}
+{{ coll.Sort (slice "b" 14 "c" "aa") }}
+{{ coll.Sort (slice 3.14 3.0 4.0) }}
+{{ coll.Sort "Scheme" (coll.Slice (conv.URL "zzz:///") (conv.URL "https:///") (conv.URL "http:///")) }}
+`))
+	result.Assert(c, icmd.Expected{ExitCode: 0,
+		Out: `[a aa b c]
+[b 14 c aa]
+[3 3.14 4]
+[http:/// https:/// zzz:///]
+`,
+	})
+}


### PR DESCRIPTION
New function `coll.Sort`, which will replace `strings.Sort`. Alias `sort` is switching now.

The reason for a new function is that this'll do numeric and string sorting, and will sort maps and structs by key.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>