### PR TITLE
New tmpl namespace & move tpl function to tmpl.Inline

### DIFF
--- a/docs-src/content/functions/tmpl.yml
+++ b/docs-src/content/functions/tmpl.yml
@@ -1,9 +1,10 @@
-ns: _
-title: Other functions
+ns: tmpl
+title: template functions
 preamble: |
-  Miscellaneous functions that aren't part of a specific namespace. Most of these are fairly special-purpose.
+  Functions for defining or executing templates.
 funcs:
-  - name: tpl
+  - name: tmpl.Inline
+    alias: tpl
     description: |
       Render the given string as a template, just like a nested template.
 
@@ -23,7 +24,7 @@ funcs:
         description: The context to use when rendering - this becomes `.` inside the template.
     examples:
       - |
-        $ gomplate -i '{{ tpl "{{print `hello world`}}" }}'
+        $ gomplate -i '{{ tmpl.Inline "{{print `hello world`}}" }}'
         hello world
       - |
         $ gomplate -i '

--- a/docs/content/functions/tmpl.md
+++ b/docs/content/functions/tmpl.md
@@ -1,13 +1,15 @@
 ---
-title: Other functions
+title: template functions
 menu:
   main:
     parent: functions
 ---
 
-Miscellaneous functions that aren't part of a specific namespace. Most of these are fairly special-purpose.
+Functions for defining or executing templates.
 
-## `tpl`
+## `tmpl.Inline`
+
+**Alias:** `tpl`
 
 Render the given string as a template, just like a nested template.
 
@@ -17,7 +19,7 @@ A context can be provided, otherwise the default gomplate context will be used.
 
 ### Usage
 ```go
-tpl [name] in [context] 
+tmpl.Inline [name] in [context] 
 ```
 
 ### Arguments
@@ -31,7 +33,7 @@ tpl [name] in [context]
 ### Examples
 
 ```console
-$ gomplate -i '{{ tpl "{{print `hello world`}}" }}'
+$ gomplate -i '{{ tmpl.Inline "{{print `hello world`}}" }}'
 hello world
 ```
 ```console

--- a/tests/integration/tmpl_test.go
+++ b/tests/integration/tmpl_test.go
@@ -6,11 +6,11 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-type TplSuite struct{}
+type TmplSuite struct{}
 
-var _ = Suite(&TplSuite{})
+var _ = Suite(&TmplSuite{})
 
-func (s *TplSuite) TestTime(c *C) {
+func (s *TmplSuite) TestInline(c *C) {
 	inOutTest(c, `
 		{{- $nums := dict "first" 5 "second" 10 }}
 		{{- tpl "{{ add .first .second }}" $nums }}`,
@@ -19,7 +19,7 @@ func (s *TplSuite) TestTime(c *C) {
 	inOutTest(c, `
 		{{- $nums := dict "first" 5 "second" 10 }}
 		{{- $othernums := dict "first" 18 "second" -8 }}
-		{{- tpl "T" "{{ add .first .second }}" $nums }}
+		{{- tmpl.Inline "T" "{{ add .first .second }}" $nums }}
 		{{- template "T" $othernums }}`,
 		"1510")
 }


### PR DESCRIPTION
As a bit of a precursor to #444 and #485, I'm creating a new `tmpl` namespace (I considered `templates`, but `tmpl` seems better). I'm moving the `tpl` function into `tmpl.Inline`, and making `tpl` an alias to that.

This gets added in a bit of a different way (outside of the `Funcs` func), because it needs to be added a bit later on and with extra info.

This also marks the end of the short-lived `Other functions` doc section, _for now..._ 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>