### PR TITLE
New strings.WordWrap function

### DIFF
--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -112,3 +112,35 @@ funcs:
       - |
         $ gomplate -i '{{ "hello jello" | strings.KebabCase }}'
         hello-jello
+  - name: strings.WordWrap
+    description: |
+      Inserts new line breaks into the input string so it ends up with lines that are at most `width` characters wide.
+
+      The line-breaking algorithm is _naïve_ and _greedy_: lines are only broken between words (i.e. on whitespace characters), and no effort is made to "smooth" the line endings.
+
+      When words that are longer than the desired width are encountered (e.g. long URLs), they are not broken up. Correctness is valued above line length.
+
+      The line-break sequence defaults to `\n` (i.e. the LF/Line Feed character), regardless of OS.
+    pipeline: true
+    arguments:
+      - name: width
+        required: false
+        description: The desired maximum line length (number of characters - defaults to `80`)
+      - name: lbseq
+        required: false
+        description: The line-break sequence to use (defaults to `\n`)
+      - name: in
+        required: true
+        description: The input
+    examples:
+      - |
+        $ gomplate -i '{{ "Hello, World!" | strings.WordWrap 7 }}'
+        Hello,
+        World!
+      - |
+        $ gomplate -i '{{ strings.WordWrap 20 "\\\n" "a string with a long url http://example.com/a/very/long/url which should not be broken" }}'
+        a string with a long
+        url
+        http://example.com/a/very/long/url
+        which should not be
+        broken

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -632,6 +632,49 @@ $ gomplate -i '{{ "hello jello" | strings.KebabCase }}'
 hello-jello
 ```
 
+## `strings.WordWrap`
+
+Inserts new line breaks into the input string so it ends up with lines that are at most `width` characters wide.
+
+The line-breaking algorithm is _naïve_ and _greedy_: lines are only broken between words (i.e. on whitespace characters), and no effort is made to "smooth" the line endings.
+
+When words that are longer than the desired width are encountered (e.g. long URLs), they are not broken up. Correctness is valued above line length.
+
+The line-break sequence defaults to `\n` (i.e. the LF/Line Feed character), regardless of OS. 
+
+### Usage
+```go
+strings.WordWrap [width] [lbseq] in 
+```
+
+```go
+in | strings.WordWrap [width] [lbseq]  
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `width` | _(optional)_ The desired maximum line length (number of characters - defaults to `80`) |
+| `lbseq` | _(optional)_ The line-break sequence to use (defaults to `\n`) |
+| `in` | _(required)_ The input |
+
+### Examples
+
+```console
+$ gomplate -i '{{ "Hello, World!" | strings.WordWrap 7 }}'
+Hello,
+World!
+```
+```console
+$ gomplate -i '{{ strings.WordWrap 20 "\\\n" "a string with a long url http://example.com/a/very/long/url which should not be broken" }}'
+a string with a long
+url
+http://example.com/a/very/long/url
+which should not be
+broken
+```
+
 ## `contains`
 
 **See [`strings.Contains](#strings-contains) for a pipeline-compatible version**

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -239,3 +239,26 @@ func (f *StringFuncs) CamelCase(in interface{}) (string, error) {
 func (f *StringFuncs) KebabCase(in interface{}) (string, error) {
 	return gompstrings.KebabCase(conv.ToString(in)), nil
 }
+
+// WordWrap -
+func (f *StringFuncs) WordWrap(args ...interface{}) (string, error) {
+	if len(args) == 0 || len(args) > 3 {
+		return "", errors.Errorf("expected 1, 2, or 3 args, got %d", len(args))
+	}
+	in := conv.ToString(args[len(args)-1])
+
+	opts := gompstrings.WordWrapOpts{}
+	if len(args) == 2 {
+		switch a := (args[0]).(type) {
+		case string:
+			opts.LBSeq = a
+		default:
+			opts.Width = uint(conv.ToInt(a))
+		}
+	}
+	if len(args) == 3 {
+		opts.Width = uint(conv.ToInt(args[0]))
+		opts.LBSeq = conv.ToString(args[1])
+	}
+	return gompstrings.WordWrap(in, opts), nil
+}

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/Masterminds/goutils"
 )
 
 // Indent - indent each line of the string with the given indent string
@@ -80,4 +82,31 @@ func CamelCase(in string) string {
 	// make sure the first letter remains lower- or upper-cased
 	s = strings.Replace(s, string(s[0]), string(in[0]), 1)
 	return nonAlphaNum.ReplaceAllString(s, "")
+}
+
+// WordWrapOpts defines the options to apply to the WordWrap function
+type WordWrapOpts struct {
+	// The desired maximum line length in characters (defaults to 80)
+	Width uint
+
+	// Line-break sequence to insert (defaults to "\n")
+	LBSeq string
+}
+
+// applies default options
+func wwDefaults(opts WordWrapOpts) WordWrapOpts {
+	if opts.Width == 0 {
+		opts.Width = 80
+	}
+	if opts.LBSeq == "" {
+		opts.LBSeq = "\n"
+	}
+	return opts
+}
+
+// WordWrap - insert line-breaks into the string, before it reaches the given
+// width.
+func WordWrap(in string, opts WordWrapOpts) string {
+	opts = wwDefaults(opts)
+	return goutils.WrapCustom(in, int(opts.Width), opts.LBSeq, false)
 }

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -1,6 +1,7 @@
 package strings
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,4 +54,64 @@ func TestCaseFuncs(t *testing.T) {
 		assert.Equal(t, d.k, KebabCase(d.in))
 		assert.Equal(t, d.c, CamelCase(d.in))
 	}
+}
+
+func TestWordWrap(t *testing.T) {
+	in := "a short line that needs no wrapping"
+	assert.Equal(t, in, WordWrap(in, WordWrapOpts{Width: 40}))
+
+	in = "a short line that needs wrapping"
+	out := `a short
+line that
+needs
+wrapping`
+
+	assert.Equal(t, out, WordWrap(in, WordWrapOpts{Width: 9}))
+	in = "a short line that needs wrapping"
+	out = `a short \
+line that \
+needs \
+wrapping`
+	assert.Equal(t, out, WordWrap(in, WordWrapOpts{Width: 9, LBSeq: " \\\n"}))
+
+	out = `There shouldn't be any wrapping of long words or URLs because that would break
+things very badly. To wit:
+https://example.com/a/super-long/url/that-shouldnt-be?wrapped=for+fear+of#the-breaking-of-functionality
+should appear on its own line, regardless of the desired word-wrapping width
+that has been set.`
+	in = strings.Replace(out, "\n", " ", -1)
+	assert.Equal(t, out, WordWrap(in, WordWrapOpts{}))
+
+	// TODO: get these working - need to switch to a word-wrapping package that
+	// can handle multi-byte characters!
+	//
+	// 	out = `ΤΟΙΣ πᾶσι χρόνος καὶ καιρὸς τῷ παντὶ πράγματι ὑπὸ τὸν οὐρανόν. καιρὸς τοῦ
+	// τεκεῖν καὶ καιρὸς τοῦ ἀποθανεῖν, καιρὸς τοῦ φυτεῦσαι καὶ καιρὸς τοῦ ἐκτῖλαι τὸ
+	// πεφυτευμένον, καιρὸς τοῦ ἀποκτεῖναι καὶ καιρὸς τοῦ ἰάσασθαι, καιρὸς τοῦ
+	// καθελεῖν καὶ καιρὸς τοῦ οἰκοδομεῖν, καιρὸς τοῦ κλαῦσαι καὶ καιρὸς τοῦ γελάσαι,
+	// καιρὸς τοῦ κόψασθαι καὶ καιρὸς τοῦ ὀρχήσασθαι, καιρὸς τοῦ βαλεῖν λίθους καὶ
+	// καιρὸς τοῦ συναγαγεῖν λίθους, καιρὸς τοῦ περιλαβεῖν καὶ καιρὸς τοῦ μακρυνθῆναι
+	// ἀπὸ περιλήψεως, καιρὸς τοῦ ζητῆσαι καὶ καιρὸς τοῦ ἀπολέσαι, καιρὸς τοῦ φυλάξαι
+	// καὶ καιρὸς τοῦ ἐκβαλεῖν, καιρὸς τοῦ ρῆξαι καὶ καιρὸς τοῦ ράψαι, καιρὸς τοῦ
+	// σιγᾶν καὶ καιρὸς τοῦ λαλεῖν, καιρὸς τοῦ φιλῆσαι καὶ καιρὸς τοῦ μισῆσαι, καιρὸς
+	// πολέμου καὶ καιρὸς εἰρήνης.`
+	// 	in = strings.Replace(out, "\n", " ", -1)
+	// 	assert.Equal(t, out, WordWrap(in, WordWrapOpts{}))
+
+	// TODO: get these working - need to switch to a word-wrapping package that
+	// understands multi-byte and correctly identifies line-breaking opportunities
+	// for non-latin languages.
+	//
+	// 	out = `何事にも定まった時があります。
+	// 生まれる時、死ぬ時、植える時、収穫の時、
+	// 殺す時、病気が治る時、壊す時、やり直す時、
+	// 泣く時、笑う時、悲しむ時、踊る時、
+	// 石をばらまく時、石をかき集める時、
+	// 抱きしめる時、抱きしめない時、
+	// 何かを見つける時、物を失う時、
+	// 大切にしまっておく時、遠くに投げ捨てる時、
+	// 引き裂く時、修理する時、黙っている時、口を開く時、
+	// 愛する時、憎む時、戦う時、和解する時。`
+	// 	in = strings.Replace(out, "\n", " ", -1)
+	// 	assert.Equal(t, out, WordWrap(in, WordWrapOpts{Width: 100}))
 }

--- a/tests/integration/strings_test.go
+++ b/tests/integration/strings_test.go
@@ -4,6 +4,8 @@
 package integration
 
 import (
+	"strings"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/gotestyourself/gotestyourself/icmd"
@@ -58,5 +60,15 @@ func (s *StringsSuite) TestCaseFuncs(c *C) {
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: `HellöWôrldFreeLast
 Hellö_wôrld_free_last
 Hellö-wôrld-free-last`})
+}
 
+func (s *StringsSuite) TestWordWrap(c *C) {
+	out := `There shouldn't be any wrapping of long words or URLs because that would break
+things very badly. To wit:
+https://example.com/a/super-long/url/that-shouldnt-be?wrapped=for+fear+of#the-breaking-of-functionality
+should appear on its own line, regardless of the desired word-wrapping width
+that has been set.`
+	text := strings.Replace(out, "\n", " ", -1)
+	in := `{{ print "` + text + `" | strings.WordWrap 80 }}`
+	inOutTest(c, in, out)
 }


### PR DESCRIPTION
I've wanted a way to do word-wrapping/line-breaking for a while, so here's a start. I'm not 100% satisfied with this, mostly because it doesn't properly handle multi-byte runes or non-whitespace line-break opportunities (especially in non-alphabetic languages). But at the risk of letting the _perfect_ get in the way of the _good enough,_ here it is.

It uses the same package that Sprig's `wrap` uses (`github.com/Masterminds/goutils`), which is about as good as it gets in terms of Go word-wrapping packages (that I could find, at least!). Perhaps _some day_ I'll submit some enhancements to handle the use-cases I'm looking for.  https://godoc.org/github.com/gorilla/i18n/linebreak may be of some help as well.

For now, the function takes 1, 2, or 3 args, to customize the width and/or the line-breaking sequence.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>