### PR TITLE
docs: YAMLifying the rest of the function docs, improving the doc template

### DIFF
--- a/docs-src/content/functions/aws.yml
+++ b/docs-src/content/functions/aws.yml
@@ -1,0 +1,98 @@
+ns: aws
+preamble: |
+  The functions in the `aws` namespace interface with various Amazon Web Services
+  APIs to make it possible for a template to render differently based on the AWS
+  environment and metadata.
+
+  ### Configuring AWS
+
+  A number of environment variables can be used to control how gomplate communicates
+  with AWS APIs. A few are documented here for convenience. See [the `aws-sdk-go` documentation](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)
+  for details.
+
+  | Environment Variable | Description |
+  | -------------------- | ----------- |
+  | `AWS_TIMEOUT` | _(Default `500`)_ Adjusts timeout for API requests, in milliseconds. Not part of the AWS SDK. |
+  | `AWS_PROFILE` | Profile name the SDK should use when loading shared config from the configuration files. If not provided `default` will be used as the profile name. |
+  | `AWS_REGION` | Specifies where to send requests. See [this list](https://docs.aws.amazon.com/general/latest/gr/rande.html). Note that the region must be set for AWS functions to work correctly, either through this variable, or a configuration profile. |
+funcs:
+  - name: aws.EC2Meta
+    alias: ec2meta
+    description: |
+      Queries AWS [EC2 Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `meta-data` path -- for data in the `dynamic` path use `aws.EC2Dynamic`.
+
+      For times when running outside EC2, or when the metadata API can't be reached, a `default` value can be provided.
+    pipeline: false
+    arguments:
+      - name: key
+        required: true
+        description: the metadata key to query
+      - name: default
+        required: false
+        description: the default value
+    examples:
+      - |
+        $ echo '{{aws.EC2Meta "instance-id"}}' | gomplate
+        i-12345678
+  - name: aws.EC2Dynamic
+    alias: ec2dynamic
+    description: |
+      Queries AWS [EC2 Instance Dynamic Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `dynamic` path -- for data in the `meta-data` path use `aws.EC2Meta`.
+
+      For times when running outside EC2, or when the metadata API can't be reached, a `default` value can be provided.
+    pipeline: false
+    arguments:
+      - name: key
+        required: true
+        description: the dynamic metadata key to query
+      - name: default
+        required: false
+        description: the default value
+    examples:
+      - |
+        $ echo '{{ (aws.EC2Dynamic "instance-identity/document" | json).region }}' | gomplate
+        us-east-1
+  - name: aws.EC2Region
+    alias: ec2region
+    description: |
+      Queries AWS to get the region. An optional default can be provided, or returns
+      `unknown` if it can't be determined for some reason.
+    pipeline: false
+    arguments:
+      - name: default
+        required: false
+        description: the default value
+    rawExamples:
+      - |
+        _In EC2_
+        ```console
+        $ echo '{{ aws.EC2Region }}' | ./gomplate
+        us-east-1
+        ```
+        _Not in EC2_
+        ```console
+        $ echo '{{ aws.EC2Region }}' | ./gomplate
+        unknown
+        $ echo '{{ aws.EC2Region "foo" }}' | ./gomplate
+        foo
+        ```
+  - name: aws.EC2Tag
+    alias: ec2tag
+    description: |
+      Queries the AWS EC2 API to find the value of the given [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). An optional default
+      can be provided.
+    pipeline: false
+    arguments:
+      - name: tag
+        required: true
+        description: the tag to query
+      - name: default
+        required: false
+        description: the default value
+    examples:
+      - |
+        $ echo 'This server is in the {{ aws.EC2Tag "Account" }} account.' | ./gomplate
+        foo
+      - |
+        $ echo 'I am a {{ aws.EC2Tag "classification" "meat popsicle" }}.' | ./gomplate
+        I am a meat popsicle.

--- a/docs-src/content/functions/base64.yml
+++ b/docs-src/content/functions/base64.yml
@@ -1,0 +1,35 @@
+ns: base64
+preamble: ''
+funcs:
+  - name: base64.Encode
+    description: |
+      Encode data as a Base64 string. Specifically, this uses the standard Base64 encoding as defined in [RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4) (and _not_ the URL-safe encoding).
+    pipeline: false
+    arguments:
+      - name: input
+        required: true
+        description: The data to encode. Can be a string, a byte array, or a buffer. Other types will be converted to strings first.
+    examples:
+      - |
+        $ gomplate -i '{{ base64.Encode "hello world" }}'
+        aGVsbG8gd29ybGQ=
+      - |
+        $ gomplate -i '{{ "hello world" | base64.Encode }}'
+        aGVsbG8gd29ybGQ=
+  - name: base64.Decode
+    description: |
+      Decode a Base64 string. This supports both standard ([RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4)) and URL-safe ([RFC4648 &sect;5](https://tools.ietf.org/html/rfc4648#section-5)) encodings.
+
+      This implementation outputs the data as a string, so it may not be appropriate for decoding binary data. If this functionality is desired, [file an issue](https://github.com/hairyhenderson/gomplate/issues/new).
+    pipeline: false
+    arguments:
+      - name: input
+        required: true
+        description: The base64 string to decode
+    examples:
+      - |
+        $ gomplate -i '{{ base64.Decode "aGVsbG8gd29ybGQ=" }}'
+        hello world
+      - |
+        $ gomplate -i '{{ "aGVsbG8gd29ybGQ=" | base64.Decode }}'
+        hello world

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -1,0 +1,98 @@
+ns: crypto
+preamble: |
+  A set of crypto-related functions to be able to perform hashing and (simple!) encryption operations with `gomplate`.
+
+  _Note: These functions are mostly wrappers of existing functions in the Go standard library. The authors of gomplate are not cryptographic experts, however, and so can not guarantee correctness of implementation. It is recommended to have your resident security experts inspect gomplate's code before using gomplate for critical security infrastructure!_
+funcs:
+  - name: crypto.Bcrypt
+    description: |
+      Uses the [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) password hashing algorithm to generate the hash of a given string. Wraps the [`golang.org/x/crypto/brypt`](https://godoc.org/golang.org/x/crypto/bcrypt) package.
+    pipeline: true
+    arguments:
+      - name: cost
+        required: false
+        description: the cost, as a number from `4` to `31` - defaults to `10`
+      - name: input
+        required: true
+        description: the input to hash, usually a password
+    examples:
+      - |
+        $ gomplate -i '{{ "foo" | crypto.Bcrypt }}'
+        $2a$10$jO8nKZ1etGkKK7I3.vPti.fYDAiBqwazQZLUhaFoMN7MaLhTP0SLy
+      - |
+        $ gomplate -i '{{ crypto.Bcrypt 4 "foo" }}
+        $2a$04$zjba3N38sjyYsw0Y7IRCme1H4gD0MJxH8Ixai0/sgsrf7s1MFUK1C
+  - name: crypto.PBKDF2
+    description: |
+      Run the Password-Based Key Derivation Function &num;2 as defined in
+      [RFC 8018 (PKCS &num;5 v2.1)](https://tools.ietf.org/html/rfc8018#section-5.2).
+
+      This function outputs the binary result as a hexadecimal string.
+    pipeline: false
+    arguments:
+      - name: password
+        required: true
+        description: the password to use to derive the key
+      - name: salt
+        required: true
+        description: the salt
+      - name: iter
+        required: true
+        description: iteration count
+      - name: keylen
+        required: true
+        description: desired length of derived key
+      - name: hashfunc
+        required: false
+        description: the hash function to use - must be one of the allowed functions (either in the SHA-1 or SHA-2 sets). Defaults to `SHA-1`
+    examples:
+      - |
+        $ gomplate -i '{{ crypto.PBKDF2 "foo" "bar" 1024 8 }}'
+        32c4907c3c80792b
+  - rawName: '`crypto.SHA1`, `crypto.SHA224`, `crypto.SHA256`, `crypto.SHA384`, `crypto.SHA512`, `crypto.SHA512_224`, `crypto.SHA512_256`'
+    description: |
+      Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
+
+      These functions output the binary result as a hexadecimal string.
+
+      _Note: SHA-1 is cryptographically broken and should not be used for secure applications._
+    pipeline: false
+    rawUsage: |
+      ```
+      crypto.SHA1 input
+      crypto.SHA224 input
+      crypto.SHA256 input
+      crypto.SHA384 input
+      crypto.SHA512 input
+      crypto.SHA512_224 input
+      crypto.SHA512_256 input
+      ```
+    arguments:
+      - name: input
+        required: true
+        description: the data to hash - can be binary data or text
+    examples:
+      - |
+        $ gomplate -i '{{ crypto.SHA1 "foo" }}'
+        f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+      - |
+        $ gomplate -i '{{ crypto.SHA512 "bar" }}'
+        cc06808cbbee0510331aa97974132e8dc296aeb795be229d064bae784b0a87a5cf4281d82e8c99271b75db2148f08a026c1a60ed9cabdb8cac6d24242dac4063
+  - name: crypto.WPAPSK
+    description: |
+      This is really an alias to [`crypto.PBKDF2`](#crypto.PBKDF2) with the
+      values necessary to convert ASCII passphrases to the WPA pre-shared keys for use with WiFi networks.
+
+      This can be used, for example, to help generate a configuration for [wpa_supplicant](http://w1.fi/wpa_supplicant/).
+    pipeline: false
+    arguments:
+      - name: ssid
+        required: true
+        description: the WiFi SSID (network name) - must be less than 32 characters
+      - name: password
+        required: true
+        description: the password - must be between 8 and 63 characters
+    examples:
+      - |
+        $ PW=abcd1234 gomplate -i '{{ crypto.WPAPSK "mynet" (getenv "PW") }}'
+        2c201d66f01237d17d4a7788051191f31706844ac3ffe7547a66c902f2900d34

--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -1,0 +1,479 @@
+ns: data
+preamble: |
+  A collection of functions that retrieve, parse, and convert structured data.
+funcs:
+  - name: datasource
+    alias: ds
+    description: |
+      Parses a given datasource (provided by the [`--datasource/-d`](#--datasource-d) argument or [`defineDatasource`](#definedatasource)).
+
+      If the `alias` is undefined, but is a valid URL, `datasource` will dynamically read from that URL.
+
+      See [Datasources](../../datasources) for (much!) more information.
+    pipeline: false
+    arguments:
+      - name: alias
+        required: true
+        description: the datasource alias (or a URL for dynamic use)
+      - name: subpath
+        required: false
+        description: the subpath to use, if supported by the datasource
+    rawExamples:
+      - |
+        _`person.json`:_
+        ```json
+        { "name": "Dave" }
+        ```
+
+        ```console
+        $ gomplate -d person.json -i 'Hello {{ (datasource "person").name }}'
+        Hello Dave
+        ```
+  - name: datasourceExists
+    description: |
+      Tests whether or not a given datasource was defined on the commandline (with the
+      [`--datasource/-d`](#--datasource-d) argument). This is intended mainly to allow
+      a template to be rendered differently whether or not a given datasource was
+      defined.
+
+      Note: this does _not_ verify if the datasource is reachable.
+
+      Useful when used in an `if`/`else` block.
+    pipeline: false
+    arguments:
+      - name: alias
+        required: true
+        description: the datasource alias
+    examples:
+      - |
+        $ echo '{{if (datasourceExists "test")}}{{datasource "test"}}{{else}}no worries{{end}}' | gomplate
+        no worries
+  - name: datasourceReachable
+    description: |
+      Tests whether or not a given datasource is defined and reachable, where the definition of "reachable" differs by datasource, but generally means the data is able to be read successfully.
+
+      Useful when used in an `if`/`else` block.
+    pipeline: false
+    arguments:
+      - name: alias
+        required: true
+        description: the datasource alias
+    examples:
+      - |
+        $ gomplate -i '{{if (datasourceReachable "test")}}{{datasource "test"}}{{else}}no worries{{end}}' -d test=https://bogus.example.com/wontwork.json
+        no worries
+  - name: defineDatasource
+    description: |
+      Define a datasource alias with target URL inside the template. Overridden by the [`--datasource/-d`](#--datasource-d) flag.
+
+      Note: once a datasource is defined, it can not be redefined (i.e. if this function is called twice with the same alias, only the first applies).
+
+      This function can provide a good way to set a default datasource when sharing templates.
+
+      See [Datasources](../../datasources) for (much!) more information.
+    pipeline: false
+    arguments:
+      - name: alias
+        required: true
+        description: the datasource alias
+      - name: url
+        required: true
+        description: the datasource's URL
+    rawExamples:
+      - |
+        _`person.json`:_
+        ```json
+        { "name": "Dave" }
+        ```
+
+        ```console
+        $ gomplate -i '{{ defineDatasource "person" "person.json" }}Hello {{ (ds "person").name }}'
+        Hello Dave
+        $ FOO='{"name": "Daisy"}' gomplate -d person=env:///FOO -i '{{ defineDatasource "person" "person.json" }}Hello {{ (ds "person").name }}'
+        Hello Daisy
+        ```
+  - name: include
+    description: |
+      Includes the content of a given datasource (provided by the [`--datasource/-d`](../usage/#datasource-d) argument).
+
+      This is similar to [`datasource`](#datasource), except that the data is not parsed. There is no restriction on the type of data included, except that it should be textual.
+    pipeline: false
+    arguments:
+      - name: alias
+        required: true
+        description: the datasource alias, as provided by [`--datasource/-d`](../usage/#datasource-d)
+      - name: subpath
+        required: false
+        description: the subpath to use, if supported by the datasource
+    rawExamples:
+      - |
+        _`person.json`:_
+        ```json
+        { "name": "Dave" }
+        ```
+
+        _`input.tmpl`:_
+        ```go
+        {
+          "people": [
+            {{ include "person" }}
+          ]
+        }
+        ```
+
+        ```console
+        $ gomplate -d person.json -f input.tmpl
+        {
+          "people": [
+            { "name": "Dave" }
+          ]
+        }
+        ```
+  - name: data.JSON
+    alias: json
+    description: |
+      Converts a JSON string into an object. Only works for JSON Objects (not Arrays or other valid JSON types). This can be used to access properties of JSON objects.
+
+      #### Encrypted JSON support (EJSON)
+
+      If the input is in the [EJSON](https://github.com/Shopify/ejson) format (i.e. has a `_public_key` field), this function will attempt to decrypt the document first. A private key must be provided by one of these methods:
+
+      - set the `EJSON_KEY` environment variable to the private key's value
+      - set the `EJSON_KEY_FILE` environment variable to the path to a file containing the private key
+      - set the `EJSON_KEYDIR` environment variable to the path to a directory containing private keys (filename must be the public key), just like [`ejson decrypt`'s `--keydir`](https://github.com/Shopify/ejson/blob/master/man/man1/ejson.1.ronn) flag. Defaults to `/opt/ejson/keys`.
+    pipeline: true
+    arguments:
+      - name: in
+        required: true
+        description: the input string
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        Hello {{ (getenv "FOO" | json).hello }}
+        ```
+
+        ```console
+        $ export FOO='{"hello":"world"}'
+        $ gomplate < input.tmpl
+        Hello world
+        ```
+  - name: data.JSONArray
+    alias: jsonArray
+    description: |
+      Converts a JSON string into a slice. Only works for JSON Arrays.
+    pipeline: true
+    arguments:
+      - name: in
+        required: true
+        description: the input string
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        Hello {{ index (getenv "FOO" | jsonArray) 1 }}
+        ```
+
+        ```console
+        $ export FOO='[ "you", "world" ]'
+        $ gomplate < input.tmpl
+        Hello world
+        ```
+  - name: data.YAML
+    alias: yaml
+    description: |
+      Converts a YAML string into an object. Only works for YAML Objects (not Arrays or other valid YAML types). This can be used to access properties of YAML objects.
+    pipeline: true
+    arguments:
+      - name: in
+        required: true
+        description: the input string
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        Hello {{ (getenv "FOO" | yaml).hello }}
+        ```
+
+        ```console
+        $ export FOO='hello: world'
+        $ gomplate < input.tmpl
+        Hello world
+        ```
+  - name: data.YAMLArray
+    alias: yamlArray
+    description: |
+      Converts a YAML string into a slice. Only works for YAML Arrays.
+    pipeline: true
+    arguments:
+      - name: in
+        required: true
+        description: the input string
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        Hello {{ index (getenv "FOO" | yamlArray) 1 }}
+        ```
+
+        ```console
+        $ export FOO='[ "you", "world" ]'
+        $ gomplate < input.tmpl
+        Hello world
+        ```
+  - name: data.TOML
+    alias: toml
+    description: |
+      Converts a [TOML](https://github.com/toml-lang/toml) document into an object.
+      This can be used to access properties of TOML documents.
+
+      Compatible with [TOML v0.4.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md).
+    pipeline: true
+    arguments:
+      - name: input
+        required: true
+        description: the TOML document to parse
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        {{ $t := `[data]
+        hello = "world"` -}}
+        Hello {{ (toml $t).hello }}
+        ```
+
+        ```console
+        $ gomplate -f input.tmpl
+        Hello world
+        ```
+  - name: data.CSV
+    alias: csv
+    description: |
+      Converts a CSV-format string into a 2-dimensional string array.
+
+      By default, the [RFC 4180](https://tools.ietf.org/html/rfc4180) format is
+      supported, but any single-character delimiter can be specified.
+    pipeline: true
+    arguments:
+      - name: delim
+        required: false
+        description: the (single-character!) field delimiter, defaults to `","`
+      - name: input
+        required: true
+        description: the CSV-format string to parse
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        {{ $c := `C,32
+        Go,25
+        COBOL,357` -}}
+        {{ range ($c | csv) -}}
+        {{ index . 0 }} has {{ index . 1 }} keywords.
+        {{ end }}
+        ```
+
+        ```console
+        $ gomplate < input.tmpl
+        C has 32 keywords.
+        Go has 25 keywords.
+        COBOL has 357 keywords.
+        ```
+  - name: data.CSVByRow
+    alias: csvByRow
+    description: |
+      Converts a CSV-format string into a slice of maps.
+
+      By default, the [RFC 4180](https://tools.ietf.org/html/rfc4180) format is
+      supported, but any single-character delimiter can be specified.
+
+      Also by default, the first line of the string will be assumed to be the header,
+      but this can be overridden by providing an explicit header, or auto-indexing
+      can be used.
+    pipeline: true
+    arguments:
+      - name: delim
+        required: false
+        description: the (single-character!) field delimiter, defaults to `","`
+      - name: header
+        required: false
+        description: comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
+      - name: input
+        required: true
+        description: the CSV-format string to parse
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        {{ $c := `lang,keywords
+        C,32
+        Go,25
+        COBOL,357` -}}
+        {{ range ($c | csvByRow) -}}
+        {{ .lang }} has {{ .keywords }} keywords.
+        {{ end }}
+        ```
+
+        ```console
+        $ gomplate < input.tmpl
+        C has 32 keywords.
+        Go has 25 keywords.
+        COBOL has 357 keywords.
+        ```
+  - name: data.CSVByColumn
+    alias: csvByColumn
+    description: |
+      Like [`csvByRow`](#csvByRow), except that the data is presented as a columnar
+      (column-oriented) map.
+    pipeline: true
+    arguments:
+      - name: delim
+        required: false
+        description: the (single-character!) field delimiter, defaults to `","`
+      - name: header
+        required: false
+        description: comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
+      - name: input
+        required: true
+        description: the CSV-format string to parse
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        {{ $c := `C;32
+        Go;25
+        COBOL;357` -}}
+        {{ $langs := ($c | csvByColumn ";" "lang,keywords").lang -}}
+        {{ range $langs }}{{ . }}
+        {{ end -}}
+        ```
+
+        ```console
+        $ gomplate < input.tmpl
+        C
+        Go
+        COBOL
+        ```
+  - name: data.ToJSON
+    alias: toJSON
+    description: |
+      Converts an object to a JSON document. Input objects may be the result of `json`, `yaml`, `jsonArray`, or `yamlArray` functions, or they could be provided by a `datasource`.
+    pipeline: true
+    arguments:
+      - name: obj
+        required: true
+        description: the object to marshal
+    rawExamples:
+      - |
+        _This is obviously contrived - `json` is used to create an object._
+
+        _`input.tmpl`:_
+        ```
+        {{ (`{"foo":{"hello":"world"}}` | json).foo | toJSON }}
+        ```
+
+        ```console
+        $ gomplate < input.tmpl
+        {"hello":"world"}
+        ```
+  - name: data.ToJSONPretty
+    alias: toJSONPretty
+    description: |
+      Converts an object to a pretty-printed (or _indented_) JSON document.
+      Input objects may be the result of functions like `data.JSON`, `data.YAML`,
+      `data.JSONArray`, or `data.YAMLArray` functions, or they could be provided
+      by a [`datasource`](../general/datasource).
+
+      The indent string must be provided as an argument.
+    pipeline: true
+    arguments:
+      - name: indent
+        required: true
+        description: the string to use for indentation
+      - name: obj
+        required: true
+        description: the object to marshal
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```
+        {{ `{"hello":"world"}` | data.JSON | data.ToJSONPretty "  " }}
+        ```
+
+        ```console
+        $ gomplate < input.tmpl
+        {
+          "hello": "world"
+        }
+        ```
+  - name: data.ToYAML
+    alias: toYAML
+    description: |
+      Converts an object to a YAML document. Input objects may be the result of
+      `data.JSON`, `data.YAML`, `data.JSONArray`, or `data.YAMLArray` functions,
+      or they could be provided by a [`datasource`](../general/datasource).
+    pipeline: true
+    arguments:
+      - name: obj
+        required: true
+        description: the object to marshal
+    rawExamples:
+      - |
+        _This is obviously contrived - `data.JSON` is used to create an object._
+
+        _`input.tmpl`:_
+        ```
+        {{ (`{"foo":{"hello":"world"}}` | data.JSON).foo | data.ToYAML }}
+        ```
+
+        ```console
+        $ gomplate < input.tmpl
+        hello: world
+        ```
+  - name: data.ToTOML
+    alias: toTOML
+    description: |
+      Converts an object to a [TOML](https://github.com/toml-lang/toml) document.
+    pipeline: true
+    arguments:
+      - name: obj
+        required: true
+        description: the object to marshal as a TOML document
+    examples:
+      - |
+        $ gomplate -i '{{ `{"foo":"bar"}` | data.JSON | data.ToTOML }}'
+        foo = "bar"
+  - name: data.ToCSV
+    alias: toCSV
+    description: |
+      Converts an object to a CSV document. The input object must be a 2-dimensional
+      array of strings (a `[][]string`). Objects produced by [`data.CSVByRow`](#conv-csvbyrow)
+      and [`data.CSVByColumn`](#conv-csvbycolumn) cannot yet be converted back to CSV documents.
+
+      **Note:** With the exception that a custom delimiter can be used, `data.ToCSV`
+      outputs according to the [RFC 4180](https://tools.ietf.org/html/rfc4180) format,
+      which means that line terminators are `CRLF` (Windows format, or `\r\n`). If
+      you require `LF` (UNIX format, or `\n`), the output can be piped through
+      [`strings.ReplaceAll`](../strings/#strings-replaceall) to replace `"\r\n"` with `"\n"`.
+    pipeline: true
+    arguments:
+      - name: delim
+        required: false
+        description: the (single-character!) field delimiter, defaults to `","`
+      - name: input
+        required: true
+        description: the object to convert to a CSV
+    rawExamples:
+      - |
+        _`input.tmpl`:_
+        ```go
+        {{ $rows := (jsonArray `[["first","second"],["1","2"],["3","4"]]`) -}}
+        {{ data.ToCSV ";" $rows }}
+        ```
+
+        ```console
+        $ gomplate -f input.tmpl
+        first,second
+        1,2
+        3,4
+        ```

--- a/docs-src/content/functions/env.yml
+++ b/docs-src/content/functions/env.yml
@@ -1,0 +1,67 @@
+ns: env
+preamble: |
+  [12-factor]: https://12factor.net
+  [Docker Secrets]: https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images
+funcs:
+  - name: env.Getenv
+    alias: getenv
+    description: |
+      Exposes the [os.Getenv](https://golang.org/pkg/os/#Getenv) function.
+
+      Retrieves the value of the environment variable named by the key. If the
+      variable is unset, but the same variable ending in `_FILE` is set, the contents
+      of the file will be returned. Otherwise the provided default (or an empty
+      string) is returned.
+
+      This is a more forgiving alternative to using `.Env`, since missing keys will
+      return an empty string, instead of panicking.
+
+      The `_FILE` fallback is especially useful for use with [12-factor][]-style
+      applications configurable only by environment variables, and especially in
+      conjunction with features like [Docker Secrets][].
+    pipeline: false
+    arguments:
+      - name: var
+        required: true
+        description: the environment variable name
+      - name: default
+        required: false
+        description: the default
+    examples:
+      - |
+        $ gomplate -i 'Hello, {{env.Getenv "USER"}}'
+        Hello, hairyhenderson
+        $ gomplate -i 'Hey, {{getenv "FIRSTNAME" "you"}}!'
+        Hey, you!
+      - |
+        $ echo "safe" > /tmp/mysecret
+        $ export SECRET_FILE=/tmp/mysecret
+        $ gomplate -i 'Your secret is {{getenv "SECRET"}}'
+        Your secret is safe
+  - name: env.ExpandEnv
+    description: |
+      Exposes the [os.ExpandEnv](https://golang.org/pkg/os/#ExpandEnv) function.
+
+      Replaces `${var}` or `$var` in the input string according to the values of the
+      current environment variables. References to undefined variables are replaced by the empty string.
+
+      Like [`env.Getenv`](#env-getenv), the `_FILE` variant of a variable is used.
+    pipeline: false
+    arguments:
+      - name: input
+        required: true
+        description: the input
+    examples:
+      - |
+        $ gomplate -i '{{env.ExpandEnv "Hello $USER"}}'
+        Hello, hairyhenderson
+        $ gomplate -i 'Hey, {{env.ExpandEnv "Hey, ${FIRSTNAME}!"}}'
+        Hey, you!
+      - |
+        $ echo "safe" > /tmp/mysecret
+        $ export SECRET_FILE=/tmp/mysecret
+        $ gomplate -i '{{env.ExpandEnv "Your secret is $SECRET"}}'
+        Your secret is safe
+      - |
+        $ gomplate -i '{{env.ExpandEnv (file.Read "foo")}}
+        contents of file "foo"...

--- a/docs-src/content/functions/func_doc.md.tmpl
+++ b/docs-src/content/functions/func_doc.md.tmpl
@@ -1,3 +1,19 @@
+{{ define "argName" }}{{ if not .required }}[{{ .name }}]{{else}}{{ .name }}{{end}}{{ end }}
+
+{{- define "usage" }}### Usage
+{{- $arguments := index . "arguments" | default slice }}
+{{ if has . "rawUsage" }}{{ .rawUsage | strings.TrimSpace }}{{ else }}
+```go
+{{ .name }}{{ range $a := $arguments }} {{template "argName" $a }}{{end}}
+```
+{{- if (index . "pipeline" | default false) }}
+```go
+{{ $last := (sub (len $arguments) 1) -}}
+{{ (index $arguments $last).name }} | {{ .name }}{{ range $i, $a := $arguments }}{{if not (eq $i $last)}} {{template "argName" $a }}{{end}}{{end}}
+```
+{{- end }}{{ end -}}
+{{ end -}}
+
 {{ $data := ds "data" -}}
 ---
 title: {{ index $data "title" | default (print $data.ns " functions") }}
@@ -9,8 +25,8 @@ menu:
 {{ $data.preamble -}}
 
 {{ range $_, $f := $data.funcs }}
-## `{{ $f.name }}`{{ if has $f "deprecated" }} _(deprecated)_
-**Deprecation Notice:** {{ $f.deprecated }}{{ end }}
+## {{ if has $f "rawName" }}{{ $f.rawName }}{{ else }}`{{ $f.name }}`{{ if has $f "deprecated" }} _(deprecated)_
+**Deprecation Notice:** {{ $f.deprecated }}{{ end }}{{ end }}
 {{ if has $f "alias" }}
 **Alias:** `{{$f.alias}}`
 {{ end }}
@@ -19,17 +35,9 @@ menu:
 {{ $f.description }}
 {{ end -}}
 
+{{ template "usage" $f }}
+
 {{ if has $f "arguments" -}}
-### Usage
-```go
-{{ $f.name }} {{ range $f.arguments -}} {{ if not .required }}[{{ .name }}]{{else}}{{ .name }}{{end}} {{end}}
-```
-{{ if has $f "pipeline" }}{{ if $f.pipeline }}
-```go
-{{ $last := (sub (len $f.arguments) 1) -}}
-{{ (index $f.arguments $last).name }} | {{ $f.name }} {{ range $i, $a := $f.arguments -}} {{if not (eq $i $last)}}{{ if not $a.required }}[{{ .name }}]{{else}}{{ .name }}{{end}}{{end}} {{end}}
-```
-{{ end }}{{ end }}
 ### Arguments
 
 | name | description |

--- a/docs-src/content/functions/math.yml
+++ b/docs-src/content/functions/math.yml
@@ -55,7 +55,7 @@ funcs:
     arguments:
       - name: num
         required: true
-        description: The input number. Will be converted to a `float64`, or `0` if not convertable
+        description: The input number. Will be converted to a `float64`, or `0` if not convertible
     examples:
       - |
         $ gomplate -i '{{ range (slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}ceil {{ printf "%#v" . }} = {{ math.Ceil . }}{{"\n"}}{{ end }}'

--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -1,0 +1,119 @@
+ns: net
+preamble: ''
+funcs:
+  - name: net.LookupIP
+    description: |
+      Resolve an IPv4 address for a given host name. When multiple IP addresses
+      are resolved, the first one is returned.
+    pipeline: true
+    arguments:
+      - name: name
+        required: true
+        description: The hostname to look up. This can be a simple hostname, or a fully-qualified domain name.
+    examples:
+      - |
+        $ gomplate -i '{{ net.LookupIP "example.com" }}'
+        93.184.216.34
+  - name: net.LookupIPs
+    description: |
+      Resolve all IPv4 addresses for a given host name. Returns an array of strings.
+    pipeline: true
+    arguments:
+      - name: name
+        required: true
+        description: The hostname to look up. This can be a simple hostname, or a fully-qualified domain name.
+    examples:
+      - |
+        $ gomplate -i '{{ join (net.LookupIPs "twitter.com") "," }}'
+        104.244.42.65,104.244.42.193
+  - name: net.LookupCNAME
+    description: |
+      Resolve the canonical name for a given host name. This does a DNS lookup for the
+      `CNAME` record type. If no `CNAME` is present, a canonical form of the given name
+      is returned -- e.g. `net.LookupCNAME "localhost"` will return `"localhost."`.
+    pipeline: true
+    arguments:
+      - name: name
+        required: true
+        description: The hostname to look up. This can be a simple hostname, or a fully-qualified domain name.
+    examples:
+      - |
+        $ gomplate -i '{{ net.LookupCNAME "www.amazon.com" }}'
+        d3ag4hukkh62yn.cloudfront.net.
+  - name: net.LookupSRV
+    description: |
+      Resolve a DNS [`SRV` service record](https://en.wikipedia.org/wiki/SRV_record).
+      This implementation supports the canonical [RFC2782](https://tools.ietf.org/html/rfc2782)
+      form (i.e. `_Service._Proto.Name`), but other forms are also supported, such as
+      those served by [Consul's DNS interface](https://www.consul.io/docs/agent/dns.html#standard-lookup).
+
+      When multiple records are returned, this function returns the first.
+
+      A [`net.SRV`](https://golang.org/pkg/net/#SRV) data structure is returned. The
+      following properties are available:
+      - `Target` - _(string)_ the hostname where the service can be reached
+      - `Port` - _(uint16)_ the service's port
+      - `Priority`, `Weight` - see [RFC2782](https://tools.ietf.org/html/rfc2782) for details
+    pipeline: true
+    arguments:
+      - name: name
+        required: true
+        description: The service name to look up
+    examples:
+      - |
+        $ gomplate -i '{{ net.LookupSRV "_sip._udp.sip.voice.google.com" | toJSONPretty "  " }}'
+        {
+          "Port": 5060,
+          "Priority": 10,
+          "Target": "sip-anycast-1.voice.google.com.",
+          "Weight": 1
+        }
+  - name: net.LookupSRVs
+    description: |
+      Resolve a DNS [`SRV` service record](https://en.wikipedia.org/wiki/SRV_record).
+      This implementation supports the canonical [RFC2782](https://tools.ietf.org/html/rfc2782)
+      form (i.e. `_Service._Proto.Name`), but other forms are also supported, such as
+      those served by [Consul's DNS interface](https://www.consul.io/docs/agent/dns.html#standard-lookup).
+
+      This function returns all available SRV records.
+
+      An array of [`net.SRV`](https://golang.org/pkg/net/#SRV) data structures is
+      returned. For each element, the following properties are available:
+      - `Target` - _(string)_ the hostname where the service can be reached
+      - `Port` - _(uint16)_ the service's port
+      - `Priority`, `Weight` - see [RFC2782](https://tools.ietf.org/html/rfc2782) for details
+    pipeline: true
+    arguments:
+      - name: name
+        required: true
+        description: The hostname to look up. This can be a simple hostname, or a fully-qualified domain name.
+    rawExamples:
+      - |
+        _input.tmpl:_
+        ```
+        {{ range (net.LookupSRVs "_sip._udp.sip.voice.google.com") -}}
+        priority={{.Priority}}/port={{.Port}}
+        {{- end }}
+        ```
+
+        ```console
+        $ gomplate -f input.tmpl
+        priority=10/port=5060
+        priority=20/port=5060
+        ```
+  - name: net.LookupTXT
+    description: |
+      Resolve a DNS [`TXT` record](https://en.wikipedia.org/wiki/SRV_record).
+
+      This function returns all available TXT records as an array of strings.
+    pipeline: true
+    arguments:
+      - name: name
+        required: true
+        description: The host name to look up
+    examples:
+      - |
+        $ gomplate -i '{{net.LookupTXT "example.com" | data.ToJSONPretty "  " }}'
+        [
+          "v=spf1 -all"
+        ]

--- a/docs-src/content/functions/path.yml
+++ b/docs-src/content/functions/path.yml
@@ -113,7 +113,7 @@ funcs:
     description: |
       Splits path immediately following the final slash, separating it into a directory and file name component.
 
-      The function returns an array with two values, the first being the diretory, and the second the file.
+      The function returns an array with two values, the first being the directory, and the second the file.
 
       A wrapper for Go's [`path.Split`](https://golang.org/pkg/path/#Split) function.
     pipeline: true

--- a/docs-src/content/functions/sockaddr.yml
+++ b/docs-src/content/functions/sockaddr.yml
@@ -1,0 +1,327 @@
+ns: sockaddr
+preamble: |
+  This namespace wraps the [`github.com/hashicorp/go-sockaddr`](https://github.com/hashicorp/go-sockaddr)
+  package, which makes it easy to discover information about a system's network
+  interfaces.
+
+  These functions are _partly_ documented here for convenience, but the canonical
+  documentation is at https://godoc.org/github.com/hashicorp/go-sockaddr.
+
+  Aside from some convenience functions, the general method of working with these
+  functions is through a _pipeline_. There are _source_ functions, which select
+  interfaces ([`IfAddr`](https://godoc.org/github.com/hashicorp/go-sockaddr#IfAddr)),
+  and there are functions to further filter, refine, and finally to select
+  the specific attributes you're interested in.
+
+  To demonstrate how this can be used, here's an example that lists all of the IPv4 addresses available on the system:
+
+  ```console
+  $ gomplate -i '{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ipv4") -}}
+  {{ . | sockaddr.Attr "address" }}
+  {{end}}'
+  127.0.0.1
+  10.0.0.8
+  132.79.79.79
+  ```
+
+  [RFC 1918]: http://tools.ietf.org/html/rfc1918
+  [RFC 6890]: http://tools.ietf.org/html/rfc6890
+funcs:
+  - name: sockaddr.GetAllInterfaces
+    description: |
+      Iterates over all available network interfaces and finds all available IP
+      addresses on each interface and converts them to `sockaddr.IPAddrs`, and returning
+      the result as an array of `IfAddr`.
+
+      Should be piped through a further function to refine and extract attributes.
+  - name: sockaddr.GetDefaultInterfaces
+    description: |
+      Returns `IfAddrs` of the addresses attached to the default route.
+
+      Should be piped through a further function to refine and extract attributes.
+  - name: sockaddr.GetPrivateInterfaces
+    description: |
+      Returns an array of `IfAddr`s containing every IP that matches
+      [RFC 6890][], is attached to the interface with
+      the default route, and is a forwardable IP address.
+
+      **Note:** [RFC 6890][] is a more exhaustive version of [RFC 1918][]
+      because it spans IPv4 and IPv6, however it does permit the inclusion of likely
+      undesired addresses such as multicast, therefore our definition of a "private"
+      address also excludes non-forwardable IP addresses (as defined by the IETF).
+
+      Should be piped through a further function to refine and extract attributes.
+  - name: sockaddr.GetPublicInterfaces
+    description: |
+      Returns an array of `IfAddr`s that do not match [RFC 6890][],
+      are attached to the default route, and are forwardable.
+
+      Should be piped through a further function to refine and extract attributes.
+  - name: sockaddr.Sort
+    description: |
+      Returns an array of `IfAddr`s sorted based on the given selector. Multiple sort
+      clauses can be passed in as a comma-delimited list without whitespace.
+
+      ### Selectors
+
+      The valid selectors are:
+
+      | selector | sorts by... |
+      |----------|-------------|
+      | `address` | the network address |
+      | `default` | whether or not the `IfAddr` has a default route |
+      | `name` | the interface name |
+      | `port` | the port, if included in the `IfAddr` |
+      | `size` | the size of the network mask, smaller mask (larger number of hosts per network) to largest (e.g. a /24 sorts before a /32) |
+      | `type` | the type of the `IfAddr`. Order is Unix, IPv4, then IPv6 |
+
+      Each of these selectors sort _ascending_, but a _descending_ sort may be chosen
+      by prefixing the selector with a `-` (e.g. `-address`). You may prefix with a `+`
+      to make explicit that the sort is ascending.
+
+      `IfAddr`s that are not comparable will be at the end of the list and in a
+      non-deterministic order.
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: which selector to use (see above for values)
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s to sort
+    rawExamples:
+      - |
+        To sort first by interface name, then by address (descending):
+        ```console
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Sort "name,-address" }}'
+        ```
+  - name: sockaddr.Exclude
+    description: |
+      Returns an array of `IfAddr`s filtered by interfaces that do not match the given
+      selector's value.
+
+      ### Selectors
+
+      The valid selectors are:
+
+      | selector | excludes by... |
+      |----------|-------------|
+      | `address` | the network address |
+      | `flag` | the specified flags (see below) |
+      | `name` | the interface name |
+      | `network` | being part of the given IP network (in net/mask format) |
+      | `port` | the port, if included in the `IfAddr` |
+      | `rfc` | being included in networks defined by the given RFC. See [the source code](https://github.com/hashicorp/go-sockaddr/blob/master/rfc.go#L38) for a list of valid RFCs |
+      | `size` | the size of the network mask, as number of bits (e.g. `"24"` for a /24) |
+      | `type` | the type of the `IfAddr`. `unix`, `ipv4`, or `ipv6` |
+
+      #### supported flags
+
+      These flags are supported by the `flag` selector:
+      `broadcast`, `down`, `forwardable`, `global unicast`, `interface-local multicast`,
+      `link-local multicast`, `link-local unicast`, `loopback`, `multicast`, `point-to-point`,
+      `unspecified`, `up`
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: which selector to use (see above for values)
+      - name: value
+        required: true
+        description: the selector value to exclude
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s to consider
+    rawExamples:
+      - |
+        To exclude all IPv6 interfaces:
+        ```console
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Exclude "type" "ipv6" }}'
+        ```
+  - name: sockaddr.Include
+    description: |
+      Returns an array of `IfAddr`s filtered by interfaces that match the given
+      selector's value.
+
+      This is the inverse of `sockaddr.Exclude`. See [`sockaddr.Exclude`](#sockaddr.Exclude) for details.
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: which selector to use (see above for values)
+      - name: value
+        required: true
+        description: the selector value to include
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s to consider
+  - name: sockaddr.Attr
+    description: |
+      Returns the named attribute as a string.
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: the attribute to return
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s to inspect
+    examples:
+      - |
+        $ gomplate -i '{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ipv4") }}{{ . | sockaddr.Attr "name" }} {{end}}'
+        lo0 en0
+  - name: sockaddr.Join
+    description: |
+      Selects the given attribute from each `IfAddr` in the source array, and joins
+      the results with the given separator.
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: the attribute to select
+      - name: separator
+        required: true
+        description: the separator
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s to join
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Join "name" "," }}'
+        lo0,lo0,lo0,en0,en0
+  - name: sockaddr.Limit
+    description: |
+      Returns a slice of `IfAddr`s based on the specified limit.
+    pipeline: true
+    arguments:
+      - name: limit
+        required: true
+        description: the maximum number of `IfAddrs`
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Limit 2 | sockaddr.Join "name" "|" }}'
+        lo0|lo0
+  - name: sockaddr.Offset
+    description: |
+      Returns a slice of `IfAddr`s based on the specified offset.
+    pipeline: true
+    arguments:
+      - name: offset
+        required: true
+        description: the offset
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Limit 2 | sockaddr.Offset 1 | sockaddr.Attr "address" }}'
+        ::1
+  - name: sockaddr.Unique
+    description: |
+      Creates a unique array of `IfAddr`s based on the matching selector. Assumes the input has
+      already been sorted.
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: the attribute to select
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Unique "name" | sockaddr.Join "name" ", " }}'
+        lo0, en0
+  - name: sockaddr.Math
+    description: |
+      Applies a math operation to each `IfAddr` in the input. Any failure will result in zero results.
+
+      See [the source code](https://github.com/hashicorp/go-sockaddr/blob/master/ifaddrs.go#L725)
+      for details.
+    pipeline: true
+    arguments:
+      - name: selector
+        required: true
+        description: the attribute to operate on
+      - name: operation
+        required: true
+        description: the operation
+      - name: <array-of-IfAddrs>
+        required: true
+        description: the array of `IfAddr`s
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Math "address" "+5" | sockaddr.Attr "address" }}'
+        127.0.0.6
+  - name: sockaddr.GetPrivateIP
+    description: |
+      Returns a string with a single IP address that is part of [RFC 6890][] and has a
+      default route. If the system can't determine its IP address or find an [RFC 6890][]
+      IP address, an empty string will be returned instead.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetPrivateIP }}'
+        10.0.0.28
+  - name: sockaddr.GetPrivateIPs
+    description: |
+      Returns a space-separated string with all IP addresses that are part of [RFC 6890][]
+      (regardless of whether or not there is a default route, unlike `GetPublicIP`).
+      If the system can't find any [RFC 6890][] IP addresses, an empty string will be
+      returned instead.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetPrivateIPs }}'
+        10.0.0.28 192.168.0.1
+  - name: sockaddr.GetPublicIP
+    description: |
+      Returns a string with a single IP address that is NOT part of [RFC 6890][] and
+      has a default route. If the system can't determine its IP address or find a
+      non-[RFC 6890][] IP address, an empty string will be returned instead.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetPublicIP }}'
+        8.1.2.3
+  - name: sockaddr.GetPublicIPs
+    description: |
+      Returns a space-separated string with all IP addresses that are NOT part of
+      [RFC 6890][] (regardless of whether or not there is a default route, unlike
+      `GetPublicIP`). If the system can't find any non-[RFC 6890][] IP addresses, an
+      empty string will be returned instead.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetPublicIPs }}'
+        8.1.2.3 8.2.3.4
+  - name: sockaddr.GetInterfaceIP
+    description: |
+      Returns a string with a single IP address sorted by the size of the network
+      (i.e. IP addresses with a smaller netmask, larger network size, are sorted first).
+    pipeline: false
+    arguments:
+      - name: name
+        required: true
+        description: the interface name
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetInterfaceIP "en0" }}'
+        10.0.0.28
+  - name: sockaddr.GetInterfaceIPs
+    description: |
+      Returns a string with all IPs, sorted by the size of the network (i.e. IP
+      addresses with a smaller netmask, larger network size, are sorted first), on a
+      named interface.
+    pipeline: false
+    arguments:
+      - name: name
+        required: true
+        description: the interface name
+    examples:
+      - |
+        $ gomplate -i '{{ sockaddr.GetInterfaceIPs "en0" }}'
+        10.0.0.28 fe80::1f9a:5582:4b41:bd18

--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -257,7 +257,7 @@ funcs:
     description: |
       Surrounds an input string with a single-quote (apostrophe) character (`'`). If the input is not a string, converts first.
 
-      `'` characters in the input are first escaped in the YAML-style (by repetition: `''`).<!-- ' -->
+      `'` characters in the input are first escaped in the YAML-style (by repetition: `''`).
     pipeline: true
     arguments:
       - name: in

--- a/docs-src/content/functions/time.yml
+++ b/docs-src/content/functions/time.yml
@@ -1,0 +1,255 @@
+ns: time
+preamble: |
+  This namespace wraps Go's [`time` package](https://golang.org/pkg/time/), and a
+  few of the functions return a `time.Time` value. All of the
+  [`time.Time` functions](https://golang.org/pkg/time/#Time) can then be used to
+  convert, adjust, or format the time in your template.
+
+  ### Reference time
+
+  An important difference between this and many other time/date utilities is how
+  parsing and formatting is accomplished. Instead of relying solely on pre-defined
+  formats, or having a complex system of variables, formatting is accomplished by
+  declaring an example of the layout you wish to display.
+
+  This uses a _reference time_, which is:
+
+  ```
+  Mon Jan 2 15:04:05 -0700 MST 2006
+  ```
+
+  ### Constants
+
+  #### format layouts
+
+  Some pre-defined layouts have been provided for convenience:
+
+  | layout name | value |
+  |-------------|-------|
+  | `time.ANSIC`       | `"Mon Jan _2 15:04:05 2006"` |
+  | `time.UnixDate`    | `"Mon Jan _2 15:04:05 MST 2006"` |
+  | `time.RubyDate`    | `"Mon Jan 02 15:04:05 -0700 2006"` |
+  | `time.RFC822`      | `"02 Jan 06 15:04 MST"` |
+  | `time.RFC822Z`     | `"02 Jan 06 15:04 -0700"` // RFC822 with numeric zone |
+  | `time.RFC850`      | `"Monday, 02-Jan-06 15:04:05 MST"` |
+  | `time.RFC1123`     | `"Mon, 02 Jan 2006 15:04:05 MST"` |
+  | `time.RFC1123Z`    | `"Mon, 02 Jan 2006 15:04:05 -0700"` // RFC1123 with numeric zone |
+  | `time.RFC3339`     | `"2006-01-02T15:04:05Z07:00"` |
+  | `time.RFC3339Nano` | `"2006-01-02T15:04:05.999999999Z07:00"` |
+  | `time.Kitchen`     | `"3:04PM"` |
+  | `time.Stamp`      | `"Jan _2 15:04:05"` |
+  | `time.StampMilli` | `"Jan _2 15:04:05.000" `|
+  | `time.StampMicro` | `"Jan _2 15:04:05.000000"` |
+  | `time.StampNano`  | `"Jan _2 15:04:05.000000000"` |
+
+  See below for examples of how these layouts can be used.
+
+  #### durations
+
+  Some operations (such as [`Time.Add`](https://golang.org/pkg/time/#Time.Add) and
+  [`Time.Round`](https://golang.org/pkg/time/#Time.Round)) require a
+  [`Duration`](https://golang.org/pkg/time/#Duration) value. These can be created
+  conveniently with the following functions:
+
+  - `time.Nanosecond`
+  - `time.Microsecond`
+  - `time.Millisecond`
+  - `time.Second`
+  - `time.Minute`
+  - `time.Hour`
+
+  For example:
+
+  ```console
+  $ gomplate -i '{{ (time.Now).Format time.Kitchen }}
+  {{ ((time.Now).Add (time.Hour 2)).Format time.Kitchen }}'
+  9:05AM
+  11:05AM
+  ```
+
+  For other durations, such as `2h10m`, [`time.ParseDuration`](#time-parseduration) can be used.
+funcs:
+  - name: time.Now
+    description: |
+      Returns the current local time, as a `time.Time`. This wraps [`time.Now`](https://golang.org/pkg/time/#Now).
+
+      Usually, further functions are called using the value returned by `Now`.
+    pipeline: false
+    rawExamples:
+      - |
+        Usage with [`UTC`](https://golang.org/pkg/time/#Time.UTC) and [`Format`](https://golang.org/pkg/time/#Time.Format):
+        ```console
+        $ gomplate -i '{{ (time.Now).UTC.Format "Day 2 of month 1 in year 2006 (timezone MST)" }}'
+        Day 14 of month 10 in year 2017 (timezone UTC)
+        ```
+      - |
+        Usage with [`AddDate`](https://golang.org/pkg/time/#Time.AddDate):
+        ```console
+        $ date
+        Sat Oct 14 09:57:02 EDT 2017
+        $ gomplate -i '{{ ((time.Now).AddDate 0 1 0).Format "Mon Jan 2 15:04:05 MST 2006" }}'
+        Tue Nov 14 09:57:02 EST 2017
+        ```
+
+        _(notice how the TZ adjusted for daylight savings!)_
+  - name: time.Parse
+    description: |
+      Parses a timestamp defined by the given layout. This wraps [`time.Parse`](https://golang.org/pkg/time/#Parse).
+
+      A number of pre-defined layouts are provided as constants, defined
+      [here](https://golang.org/pkg/time/#pkg-constants).
+
+      Just like [`time.Now`](#time-now), this is usually used in conjunction with
+      other functions.
+
+      _Note: In the absence of a time zone indicator, `time.Parse` returns a time in UTC._
+    pipeline: true
+    arguments:
+      - name: layout
+        required: true
+        description: The layout string to parse with
+      - name: timestamp
+        required: true
+        description: The timestamp to parse
+    rawExamples:
+      - |
+        Usage with [`Format`](https://golang.org/pkg/time/#Time.Format):
+        ```console
+        $ gomplate -i '{{ (time.Parse "2006-01-02" "1993-10-23").Format "Monday January 2, 2006 MST" }}'
+        Saturday October 23, 1993 UTC
+        ```
+  - name: time.ParseDuration
+    description: |
+      Parses a duration string. This wraps [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration).
+
+      A duration string is a possibly signed sequence of decimal numbers, each with
+      optional fraction and a unit suffix, such as `300ms`, `-1.5h` or `2h45m`. Valid
+      time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+    pipeline: true
+    arguments:
+      - name: duration
+        required: true
+        description: The duration string to parse
+    examples:
+      - |
+        $ gomplate -i '{{ (time.Now).Format time.Kitchen }}
+        {{ ((time.Now).Add (time.ParseDuration "2h30m")).Format time.Kitchen }}'
+        12:43AM
+        3:13AM
+  - name: time.ParseLocal
+    description: |
+      Same as [`time.Parse`](#time-parse), except that in the absence of a time zone
+      indicator, the timestamp wil be parsed in the local timezone.
+    pipeline: true
+    arguments:
+      - name: layout
+        required: true
+        description: The layout string to parse with
+      - name: timestamp
+        required: true
+        description: The timestamp to parse
+    rawExamples:
+      - |
+        Usage with [`Format`](https://golang.org/pkg/time/#Time.Format):
+        ```console
+        $ bin/gomplate -i '{{ (time.ParseLocal time.Kitchen "6:00AM").Format "15:04 MST" }}'
+        06:00 EST
+        ```
+  - name: time.ParseInLocation
+    description: |
+      Same as [`time.Parse`](#time-parse), except that the time is parsed in the given location's time zone.
+
+      This wraps [`time.ParseInLocation`](https://golang.org/pkg/time/#ParseInLocation).
+    pipeline: true
+    arguments:
+      - name: layout
+        required: true
+        description: The layout string to parse with
+      - name: location
+        required: true
+        description: The location to parse in
+      - name: timestamp
+        required: true
+        description: The timestamp to parse
+    rawExamples:
+      - |
+        Usage with [`Format`](https://golang.org/pkg/time/#Time.Format):
+        ```console
+        $ gomplate -i '{{ (time.ParseInLocation time.Kitchen "Africa/Luanda" "6:00AM").Format "15:04 MST" }}'
+        06:00 LMT
+        ```
+  - name: time.Since
+    description: |
+      Returns the time elapsed since a given time. This wraps [`time.Since`](https://golang.org/pkg/time/#Since).
+
+      It is shorthand for `time.Now.Sub t`.
+    pipeline: true
+    arguments:
+      - name: t
+        required: true
+        description: the `Time` to calculate since
+    examples:
+      - |
+        $ gomplate -i '{{ $t := time.Parse time.RFC3339 "1970-01-01T00:00:00Z" }}time since the epoch:{{ time.Since $t }}'
+        time since the epoch:423365h0m24.353828924s
+  - name: time.Unix
+    description: |
+      Returns the local `Time` corresponding to the given Unix time, in seconds since
+      January 1, 1970 UTC. Note that fractional seconds can be used to denote
+      milliseconds, but must be specified as a string, not a floating point number.
+    pipeline: true
+    arguments:
+      - name: time
+        required: true
+        description: the time to parse
+    rawExamples:
+      - |
+        _with whole seconds:_
+        ```console
+        $ gomplate -i '{{ (time.Unix 42).UTC.Format time.Stamp}}'
+        Jan  1, 00:00:42
+        ```
+
+        _with fractional seconds:_
+        ```console
+        $ gomplate -i '{{ (time.Unix "123456.789").UTC.Format time.StampMilli}}'
+        Jan  2 10:17:36.789
+        ```
+  - name: time.Until
+    description: |
+      Returns the duration until a given time. This wraps [`time.Until`](https://golang.org/pkg/time/#Until).
+
+      It is shorthand for `$t.Sub time.Now`.
+    pipeline: true
+    arguments:
+      - name: t
+        required: true
+        description: the `Time` to calculate until
+    rawExamples:
+      - |
+        ```console
+        $ gomplate -i '{{ $t := time.Parse time.RFC3339 "2020-01-01T00:00:00Z" }}only {{ time.Until $t }} to go...'
+        only 14922h56m46.578625891s to go...
+        ```
+
+        Or, less precise:
+        ```console
+        $ bin/gomplate -i '{{ $t := time.Parse time.RFC3339 "2020-01-01T00:00:00Z" }}only {{ (time.Until $t).Round (time.Hour 1) }} to go...'
+        only 14923h0m0s to go...
+        ```
+  - name: time.ZoneName
+    description: |
+      Return the local system's time zone's name.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i '{{time.ZoneName}}'
+        EDT
+  - name: time.ZoneOffset
+    description: |
+      Return the local system's time zone offset, in seconds east of UTC.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i '{{time.ZoneOffset}}'
+        -14400

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -23,13 +23,26 @@ for details.
 
 ## `aws.EC2Meta`
 
-**Alias:** _(to be deprecated)_ `ec2meta`
+**Alias:** `ec2meta`
 
 Queries AWS [EC2 Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `meta-data` path -- for data in the `dynamic` path use `aws.EC2Dynamic`.
 
-This only works when running `gomplate` on an EC2 instance. If the EC2 instance metadata API isn't available, the tool will timeout and fail.
+For times when running outside EC2, or when the metadata API can't be reached, a `default` value can be provided.
 
-#### Example
+### Usage
+
+```go
+aws.EC2Meta key [default]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `key` | _(required)_ the metadata key to query |
+| `default` | _(optional)_ the default value |
+
+### Examples
 
 ```console
 $ echo '{{aws.EC2Meta "instance-id"}}' | gomplate
@@ -38,27 +51,52 @@ i-12345678
 
 ## `aws.EC2Dynamic`
 
-**Alias:** _(to be deprecated)_ `ec2dynamic`
+**Alias:** `ec2dynamic`
 
 Queries AWS [EC2 Instance Dynamic Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `dynamic` path -- for data in the `meta-data` path use `aws.EC2Meta`.
 
-This only works when running `gomplate` on an EC2 instance. If the EC2 instance metadata API isn't available, the tool will timeout and fail.
+For times when running outside EC2, or when the metadata API can't be reached, a `default` value can be provided.
 
-#### Example
+### Usage
+
+```go
+aws.EC2Dynamic key [default]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `key` | _(required)_ the dynamic metadata key to query |
+| `default` | _(optional)_ the default value |
+
+### Examples
 
 ```console
-$ echo '{{ (aws.EC2Dynamic "instance-identity/document" | json).region }}' | ./gomplate
+$ echo '{{ (aws.EC2Dynamic "instance-identity/document" | json).region }}' | gomplate
 us-east-1
 ```
 
 ## `aws.EC2Region`
 
-**Alias:** _(to be deprecated)_ `ec2region`
+**Alias:** `ec2region`
 
 Queries AWS to get the region. An optional default can be provided, or returns
 `unknown` if it can't be determined for some reason.
 
-#### Example
+### Usage
+
+```go
+aws.EC2Region [default]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `default` | _(optional)_ the default value |
+
+### Examples
 
 _In EC2_
 ```console
@@ -75,16 +113,31 @@ foo
 
 ## `aws.EC2Tag`
 
-**Alias:** _(to be deprecated)_ `ec2tag`
+**Alias:** `ec2tag`
 
 Queries the AWS EC2 API to find the value of the given [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). An optional default
 can be provided.
 
-#### Example
+### Usage
+
+```go
+aws.EC2Tag tag [default]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `tag` | _(required)_ the tag to query |
+| `default` | _(optional)_ the default value |
+
+### Examples
 
 ```console
 $ echo 'This server is in the {{ aws.EC2Tag "Account" }} account.' | ./gomplate
 foo
+```
+```console
 $ echo 'I am a {{ aws.EC2Tag "classification" "meat popsicle" }}.' | ./gomplate
 I am a meat popsicle.
 ```

--- a/docs/content/functions/base64.md
+++ b/docs/content/functions/base64.md
@@ -5,6 +5,7 @@ menu:
     parent: functions
 ---
 
+
 ## `base64.Encode`
 
 Encode data as a Base64 string. Specifically, this uses the standard Base64 encoding as defined in [RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4) (and _not_ the URL-safe encoding).
@@ -17,9 +18,9 @@ base64.Encode input
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `input` | The data to encode. Can be a string, a byte array, or a buffer. Other types will be converted to strings first. |
+| name | description |
+|------|-------------|
+| `input` | _(required)_ The data to encode. Can be a string, a byte array, or a buffer. Other types will be converted to strings first. |
 
 ### Examples
 
@@ -27,7 +28,6 @@ base64.Encode input
 $ gomplate -i '{{ base64.Encode "hello world" }}'
 aGVsbG8gd29ybGQ=
 ```
-
 ```console
 $ gomplate -i '{{ "hello world" | base64.Encode }}'
 aGVsbG8gd29ybGQ=
@@ -47,9 +47,9 @@ base64.Decode input
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `input` | The base64 string to decode |
+| name | description |
+|------|-------------|
+| `input` | _(required)_ The base64 string to decode |
 
 ### Examples
 
@@ -57,7 +57,6 @@ base64.Decode input
 $ gomplate -i '{{ base64.Decode "aGVsbG8gd29ybGQ=" }}'
 hello world
 ```
-
 ```console
 $ gomplate -i '{{ "aGVsbG8gd29ybGQ=" | base64.Decode }}'
 hello world

--- a/docs/content/functions/coll.md
+++ b/docs/content/functions/coll.md
@@ -30,8 +30,9 @@ For creating more complex maps, see [`data.JSON`](../data/#data-json) or [`data.
 For creating arrays, see [`coll.Slice`](#coll-slice).
 
 ### Usage
+
 ```go
-coll.Dict in... 
+coll.Dict in...
 ```
 
 ### Arguments
@@ -66,8 +67,9 @@ Hello everybody!
 Creates a slice (like an array or list). Useful when needing to `range` over a bunch of variables.
 
 ### Usage
+
 ```go
-coll.Slice in... 
+coll.Slice in...
 ```
 
 ### Arguments
@@ -92,8 +94,9 @@ Hello, Maggie
 Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
 
 ### Usage
+
 ```go
-coll.Has in item 
+coll.Has in item
 ```
 
 ### Arguments
@@ -134,12 +137,12 @@ then alphabetically.
 See also [`coll.Values`](#coll-values).
 
 ### Usage
-```go
-coll.Keys in... 
-```
 
 ```go
-in... | coll.Keys  
+coll.Keys in...
+```
+```go
+in... | coll.Keys
 ```
 
 ### Arguments
@@ -169,12 +172,12 @@ then alphabetically by key.
 See also [`coll.Keys`](#coll-keys).
 
 ### Usage
-```go
-coll.Values in... 
-```
 
 ```go
-in... | coll.Values  
+coll.Values in...
+```
+```go
+in... | coll.Values
 ```
 
 ### Arguments
@@ -203,12 +206,12 @@ _Note that this function does not change the given list; it always produces a ne
 See also [`coll.Prepend`](#coll-prepend).
 
 ### Usage
-```go
-coll.Append value list... 
-```
 
 ```go
-list... | coll.Append value  
+coll.Append value list...
+```
+```go
+list... | coll.Append value
 ```
 
 ### Arguments
@@ -236,12 +239,12 @@ _Note that this function does not change the given list; it always produces a ne
 See also [`coll.Append`](#coll-append).
 
 ### Usage
-```go
-coll.Prepend value list... 
-```
 
 ```go
-list... | coll.Prepend value  
+coll.Prepend value list...
+```
+```go
+list... | coll.Prepend value
 ```
 
 ### Arguments
@@ -269,12 +272,12 @@ _Note that this function does not change the given list; it always produces a ne
 See also [`coll.Append`](#coll-append).
 
 ### Usage
-```go
-coll.Uniq list 
-```
 
 ```go
-list | coll.Uniq  
+coll.Uniq list
+```
+```go
+list | coll.Uniq
 ```
 
 ### Arguments
@@ -299,12 +302,12 @@ Reverse a list.
 _Note that this function does not change the given list; it always produces a new one._
 
 ### Usage
-```go
-coll.Reverse list 
-```
 
 ```go
-list | coll.Reverse  
+coll.Reverse list
+```
+```go
+list | coll.Reverse
 ```
 
 ### Arguments
@@ -333,12 +336,12 @@ Maps and structs can be sorted by a named key.
 _Note that this function does not modify the input._
 
 ### Usage
-```go
-coll.Sort [key] list 
-```
 
 ```go
-list | coll.Sort [key]  
+coll.Sort [key] list
+```
+```go
+list | coll.Sort [key]
 ```
 
 ### Arguments
@@ -382,12 +385,12 @@ Many source maps can be provided. Precedence is in left-to-right order.
 Note that this function _changes_ the destination map.
 
 ### Usage
-```go
-coll.Merge dst srcs... 
-```
 
 ```go
-srcs... | coll.Merge dst  
+coll.Merge dst srcs...
+```
+```go
+srcs... | coll.Merge dst
 ```
 
 ### Arguments

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -17,12 +17,12 @@ to another - generally from a `string` to something else, and vice-versa.
 Converts a true-ish string to a boolean. Can be used to simplify conditional statements based on environment variables or other text input.
 
 ### Usage
-```go
-conv.Bool in 
-```
 
 ```go
-in | conv.Bool  
+conv.Bool in
+```
+```go
+in | conv.Bool
 ```
 
 ### Arguments
@@ -57,12 +57,12 @@ Note that this will not provide a default for the case where the input is undefi
 [`conv.Has`](#conv-has) can be used for that.
 
 ### Usage
-```go
-conv.Default default in 
-```
 
 ```go
-in | conv.Default default  
+conv.Default default in
+```
+```go
+in | conv.Default default
 ```
 
 ### Arguments
@@ -99,8 +99,9 @@ For creating more complex maps, see [`data.JSON`](../data/#data-json) or [`data.
 For creating arrays, see [`conv.Slice`](#conv-slice).
 
 ### Usage
+
 ```go
-conv.Dict in... 
+conv.Dict in...
 ```
 
 ### Arguments
@@ -136,8 +137,9 @@ Hello everybody!
 Creates a slice (like an array or list). Useful when needing to `range` over a bunch of variables.
 
 ### Usage
+
 ```go
-conv.Slice in... 
+conv.Slice in...
 ```
 
 ### Arguments
@@ -163,8 +165,9 @@ Hello, Maggie
 Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
 
 ### Usage
+
 ```go
-conv.Has in item 
+conv.Has in item
 ```
 
 ### Arguments
@@ -200,8 +203,9 @@ THERE IS NO FOO
 Concatenates the elements of an array to create a string. The separator string `sep` is placed between elements in the resulting string.
 
 ### Usage
+
 ```go
-conv.Join in sep 
+conv.Join in sep
 ```
 
 ### Arguments
@@ -225,8 +229,9 @@ $ gomplate -i '{{ $a := slice 1 2 3 }}{{ join $a "-" }}'
 Parses a string as a URL for later use. Equivalent to [url.Parse](https://golang.org/pkg/net/url/#Parse)
 
 ### Usage
+
 ```go
-conv.URL in 
+conv.URL in
 ```
 
 ### Arguments
@@ -258,6 +263,12 @@ _**Note:**_ See [`conv.ToInt64`](#conv-toint64) instead for a simpler and more f
 
 Parses a string as an int64. Equivalent to [strconv.ParseInt](https://golang.org/pkg/strconv/#ParseInt)
 
+### Usage
+
+```go
+conv.ParseInt
+```
+
 
 ### Examples
 
@@ -279,6 +290,12 @@ _**Note:**_ See [`conv.ToFloat`](#conv-tofloat) instead for a simpler and more f
 
 Parses a string as an float64 for later use. Equivalent to [strconv.ParseFloat](https://golang.org/pkg/strconv/#ParseFloat)
 
+### Usage
+
+```go
+conv.ParseFloat
+```
+
 
 ### Examples
 
@@ -298,6 +315,12 @@ pi is greater than 3
 ## `conv.ParseUint`
 
 Parses a string as an uint64 for later use. Equivalent to [strconv.ParseUint](https://golang.org/pkg/strconv/#ParseUint)
+
+### Usage
+
+```go
+conv.ParseUint
+```
 
 
 ### Examples
@@ -319,6 +342,12 @@ $ BIG=FFFFFFFFFFFFFFFF gomplate < input.tmpl
 _**Note:**_ See [`conv.ToInt`](#conv-toint) and [`conv.ToInt64`](#conv-toint64) instead for simpler and more flexible variants of this function.
 
 Parses a string as an int for later use. Equivalent to [strconv.Atoi](https://golang.org/pkg/strconv/#Atoi)
+
+### Usage
+
+```go
+conv.Atoi
+```
 
 
 ### Examples
@@ -345,12 +374,12 @@ Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
 (any capitalizations). All other values are considered `false`.
 
 ### Usage
-```go
-conv.ToBool input 
-```
 
 ```go
-input | conv.ToBool  
+conv.ToBool input
+```
+```go
+input | conv.ToBool
 ```
 
 ### Arguments
@@ -375,12 +404,12 @@ Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
 (any capitalizations). All other values are considered `false`.
 
 ### Usage
-```go
-conv.ToBools input 
-```
 
 ```go
-input | conv.ToBools  
+conv.ToBools input
+```
+```go
+input | conv.ToBools
 ```
 
 ### Arguments
@@ -410,8 +439,9 @@ errors, or `0` or `-1`.
 Floating-point numbers (with decimal points) are truncated.
 
 ### Usage
+
 ```go
-conv.ToInt64 in 
+conv.ToInt64 in
 ```
 
 ### Arguments
@@ -445,8 +475,9 @@ as an `int`.
 See also [`conv.ToInt64`](#conv-toint64).
 
 ### Usage
+
 ```go
-conv.ToInt in 
+conv.ToInt in
 ```
 
 ### Arguments
@@ -477,8 +508,9 @@ Converts the inputs to an array of `int64`s.
 This delegates to [`conv.ToInt64`](#conv-toint64) for each input argument.
 
 ### Usage
+
 ```go
-conv.ToInt64s in... 
+conv.ToInt64s in...
 ```
 
 ### Arguments
@@ -501,8 +533,9 @@ Converts the inputs to an array of `int`s.
 This delegates to [`conv.ToInt`](#conv-toint) for each input argument.
 
 ### Usage
+
 ```go
-conv.ToInts in... 
+conv.ToInts in...
 ```
 
 ### Arguments
@@ -528,8 +561,9 @@ undefined and subject to change. Unconvertable inputs may result in
 errors, or `0` or `-1`.
 
 ### Usage
+
 ```go
-conv.ToFloat64 in 
+conv.ToFloat64 in
 ```
 
 ### Arguments
@@ -554,8 +588,9 @@ Converts the inputs to an array of `float64`s.
 This delegates to [`conv.ToFloat64`](#conv-tofloat64) for each input argument.
 
 ### Usage
+
 ```go
-conv.ToFloat64s in... 
+conv.ToFloat64s in...
 ```
 
 ### Arguments
@@ -578,8 +613,9 @@ Converts the input (of any type) to a `string`.
 The input will always be represented in _some_ way.
 
 ### Usage
+
 ```go
-conv.ToString in 
+conv.ToString in
 ```
 
 ### Arguments
@@ -606,8 +642,9 @@ Converts the inputs (of any type) to an array of `string`s
 This delegates to [`conv.ToString`](#conv-tostring) for each input argument.
 
 ### Usage
+
 ```go
-conv.ToStrings in... 
+conv.ToStrings in...
 ```
 
 ### Arguments

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -14,52 +14,56 @@ _Note: These functions are mostly wrappers of existing functions in the Go stand
 Uses the [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) password hashing algorithm to generate the hash of a given string. Wraps the [`golang.org/x/crypto/brypt`](https://godoc.org/golang.org/x/crypto/bcrypt) package.
 
 ### Usage
-```
+
+```go
 crypto.Bcrypt [cost] input
 ```
-```
+```go
 input | crypto.Bcrypt [cost]
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `input` | _(required)_ the input to hash, usually a password |
+| name | description |
+|------|-------------|
 | `cost` | _(optional)_ the cost, as a number from `4` to `31` - defaults to `10` |
+| `input` | _(required)_ the input to hash, usually a password |
 
-### Example
+### Examples
 
 ```console
 $ gomplate -i '{{ "foo" | crypto.Bcrypt }}'
 $2a$10$jO8nKZ1etGkKK7I3.vPti.fYDAiBqwazQZLUhaFoMN7MaLhTP0SLy
+```
+```console
 $ gomplate -i '{{ crypto.Bcrypt 4 "foo" }}
 $2a$04$zjba3N38sjyYsw0Y7IRCme1H4gD0MJxH8Ixai0/sgsrf7s1MFUK1C
 ```
 
 ## `crypto.PBKDF2`
 
-Run the Password-Based Key Derivation Function #2 as defined in
-[RFC 8018 (PKCS #5 v2.1)](https://tools.ietf.org/html/rfc8018#section-5.2).
+Run the Password-Based Key Derivation Function &num;2 as defined in
+[RFC 8018 (PKCS &num;5 v2.1)](https://tools.ietf.org/html/rfc8018#section-5.2).
 
 This function outputs the binary result as a hexadecimal string.
 
 ### Usage
-```
+
+```go
 crypto.PBKDF2 password salt iter keylen [hashfunc]
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `password` | _(required)_ the password to use to derive the key |
 | `salt` | _(required)_ the salt |
 | `iter` | _(required)_ iteration count |
 | `keylen` | _(required)_ desired length of derived key |
 | `hashfunc` | _(optional)_ the hash function to use - must be one of the allowed functions (either in the SHA-1 or SHA-2 sets). Defaults to `SHA-1` |
 
-### Example
+### Examples
 
 ```console
 $ gomplate -i '{{ crypto.PBKDF2 "foo" "bar" 1024 8 }}'
@@ -70,7 +74,7 @@ $ gomplate -i '{{ crypto.PBKDF2 "foo" "bar" 1024 8 }}'
 
 Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
 
-These function outputs the binary result as a hexadecimal string.
+These functions output the binary result as a hexadecimal string.
 
 _Note: SHA-1 is cryptographically broken and should not be used for secure applications._
 
@@ -87,15 +91,17 @@ crypto.SHA512_256 input
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `input` | _(required)_ the data to hash - can be binary data or text |
 
-### Example
+### Examples
 
 ```console
 $ gomplate -i '{{ crypto.SHA1 "foo" }}'
 f1d2d2f924e986ac86fdf7b36c94bcdf32beec15
+```
+```console
 $ gomplate -i '{{ crypto.SHA512 "bar" }}'
 cc06808cbbee0510331aa97974132e8dc296aeb795be229d064bae784b0a87a5cf4281d82e8c99271b75db2148f08a026c1a60ed9cabdb8cac6d24242dac4063
 ```
@@ -108,14 +114,15 @@ values necessary to convert ASCII passphrases to the WPA pre-shared keys for use
 This can be used, for example, to help generate a configuration for [wpa_supplicant](http://w1.fi/wpa_supplicant/).
 
 ### Usage
+
 ```go
 crypto.WPAPSK ssid password
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `ssid` | _(required)_ the WiFi SSID (network name) - must be less than 32 characters |
 | `password` | _(required)_ the password - must be between 8 and 63 characters |
 

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -9,9 +9,11 @@ A collection of functions that retrieve, parse, and convert structured data.
 
 ## `datasource`
 
+**Alias:** `ds`
+
 Parses a given datasource (provided by the [`--datasource/-d`](#--datasource-d) argument or [`defineDatasource`](#definedatasource)).
 
-If the `alias` is undefined, but is a valid URL, `datasource` will dynamically read from that URL. 
+If the `alias` is undefined, but is a valid URL, `datasource` will dynamically read from that URL.
 
 See [Datasources](../../datasources) for (much!) more information.
 
@@ -23,9 +25,9 @@ datasource alias [subpath]
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `alias` | the datasource alias (or a URL for dynamic use) |
+| name | description |
+|------|-------------|
+| `alias` | _(required)_ the datasource alias (or a URL for dynamic use) |
 | `subpath` | _(optional)_ the subpath to use, if supported by the datasource |
 
 ### Examples
@@ -51,6 +53,20 @@ Note: this does _not_ verify if the datasource is reachable.
 
 Useful when used in an `if`/`else` block.
 
+### Usage
+
+```go
+datasourceExists alias
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `alias` | _(required)_ the datasource alias |
+
+### Examples
+
 ```console
 $ echo '{{if (datasourceExists "test")}}{{datasource "test"}}{{else}}no worries{{end}}' | gomplate
 no worries
@@ -61,6 +77,20 @@ no worries
 Tests whether or not a given datasource is defined and reachable, where the definition of "reachable" differs by datasource, but generally means the data is able to be read successfully.
 
 Useful when used in an `if`/`else` block.
+
+### Usage
+
+```go
+datasourceReachable alias
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `alias` | _(required)_ the datasource alias |
+
+### Examples
 
 ```console
 $ gomplate -i '{{if (datasourceReachable "test")}}{{datasource "test"}}{{else}}no worries{{end}}' -d test=https://bogus.example.com/wontwork.json
@@ -85,10 +115,10 @@ defineDatasource alias url
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `alias` | the datasource alias |
-| `url` | the datasource's URL |
+| name | description |
+|------|-------------|
+| `alias` | _(required)_ the datasource alias |
+| `url` | _(required)_ the datasource's URL |
 
 ### Examples
 
@@ -104,10 +134,6 @@ $ FOO='{"name": "Daisy"}' gomplate -d person=env:///FOO -i '{{ defineDatasource 
 Hello Daisy
 ```
 
-## `ds`
-
-Alias to [`datasource`](#datasource)
-
 ## `include`
 
 Includes the content of a given datasource (provided by the [`--datasource/-d`](../usage/#datasource-d) argument).
@@ -122,9 +148,9 @@ include alias [subpath]
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `alias` | the datasource alias, as provided by [`--datasource/-d`](../usage/#datasource-d) |
+| name | description |
+|------|-------------|
+| `alias` | _(required)_ the datasource alias, as provided by [`--datasource/-d`](../usage/#datasource-d) |
 | `subpath` | _(optional)_ the subpath to use, if supported by the datasource |
 
 ### Examples
@@ -167,10 +193,10 @@ If the input is in the [EJSON](https://github.com/Shopify/ejson) format (i.e. ha
 - set the `EJSON_KEYDIR` environment variable to the path to a directory containing private keys (filename must be the public key), just like [`ejson decrypt`'s `--keydir`](https://github.com/Shopify/ejson/blob/master/man/man1/ejson.1.ronn) flag. Defaults to `/opt/ejson/keys`.
 
 ### Usage
+
 ```go
 data.JSON in
 ```
-
 ```go
 in | data.JSON
 ```
@@ -200,7 +226,22 @@ Hello world
 
 Converts a JSON string into a slice. Only works for JSON Arrays.
 
-#### Example
+### Usage
+
+```go
+data.JSONArray in
+```
+```go
+in | data.JSONArray
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in` | _(required)_ the input string |
+
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -219,7 +260,22 @@ Hello world
 
 Converts a YAML string into an object. Only works for YAML Objects (not Arrays or other valid YAML types). This can be used to access properties of YAML objects.
 
-#### Example
+### Usage
+
+```go
+data.YAML in
+```
+```go
+in | data.YAML
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in` | _(required)_ the input string |
+
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -238,7 +294,22 @@ Hello world
 
 Converts a YAML string into a slice. Only works for YAML Arrays.
 
-#### Example
+### Usage
+
+```go
+data.YAMLArray in
+```
+```go
+in | data.YAMLArray
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in` | _(required)_ the input string |
+
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -263,21 +334,19 @@ Compatible with [TOML v0.4.0](https://github.com/toml-lang/toml/blob/master/vers
 ### Usage
 
 ```go
-toml input
+data.TOML input
 ```
-
-Can also be used in a pipeline:
 ```go
-input | toml
+input | data.TOML
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `input` | the TOML document to parse |
+| name | description |
+|------|-------------|
+| `input` | _(required)_ the TOML document to parse |
 
-#### Example
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -303,22 +372,20 @@ supported, but any single-character delimiter can be specified.
 ### Usage
 
 ```go
-csv [delim] input
+data.CSV [delim] input
 ```
-
-Can also be used in a pipeline:
 ```go
-input | csv [delim]
+input | data.CSV [delim]
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `input` | the CSV-format string to parse |
+| `input` | _(required)_ the CSV-format string to parse |
 
-### Example
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -350,27 +417,24 @@ Also by default, the first line of the string will be assumed to be the header,
 but this can be overridden by providing an explicit header, or auto-indexing
 can be used.
 
-
 ### Usage
 
 ```go
-csv [delim] [header] input
+data.CSVByRow [delim] [header] input
 ```
-
-Can also be used in a pipeline:
 ```go
-input | csv [delim] [header]
+input | data.CSVByRow [delim] [header]
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `header`| _(optional)_ comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
-| `input` | the CSV-format string to parse |
+| `header` | _(optional)_ comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
+| `input` | _(required)_ the CSV-format string to parse |
 
-### Example
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -397,7 +461,24 @@ COBOL has 357 keywords.
 Like [`csvByRow`](#csvByRow), except that the data is presented as a columnar
 (column-oriented) map.
 
-### Example
+### Usage
+
+```go
+data.CSVByColumn [delim] [header] input
+```
+```go
+input | data.CSVByColumn [delim] [header]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
+| `header` | _(optional)_ comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
+| `input` | _(required)_ the CSV-format string to parse |
+
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -422,7 +503,22 @@ COBOL
 
 Converts an object to a JSON document. Input objects may be the result of `json`, `yaml`, `jsonArray`, or `yamlArray` functions, or they could be provided by a `datasource`.
 
-#### Example
+### Usage
+
+```go
+data.ToJSON obj
+```
+```go
+obj | data.ToJSON
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `obj` | _(required)_ the object to marshal |
+
+### Examples
 
 _This is obviously contrived - `json` is used to create an object._
 
@@ -447,7 +543,23 @@ by a [`datasource`](../general/datasource).
 
 The indent string must be provided as an argument.
 
-#### Example
+### Usage
+
+```go
+data.ToJSONPretty indent obj
+```
+```go
+obj | data.ToJSONPretty indent
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `indent` | _(required)_ the string to use for indentation |
+| `obj` | _(required)_ the object to marshal |
+
+### Examples
 
 _`input.tmpl`:_
 ```
@@ -469,7 +581,22 @@ Converts an object to a YAML document. Input objects may be the result of
 `data.JSON`, `data.YAML`, `data.JSONArray`, or `data.YAMLArray` functions,
 or they could be provided by a [`datasource`](../general/datasource).
 
-#### Example
+### Usage
+
+```go
+data.ToYAML obj
+```
+```go
+obj | data.ToYAML
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `obj` | _(required)_ the object to marshal |
+
+### Examples
 
 _This is obviously contrived - `data.JSON` is used to create an object._
 
@@ -494,19 +621,17 @@ Converts an object to a [TOML](https://github.com/toml-lang/toml) document.
 ```go
 data.ToTOML obj
 ```
-
-Can also be used in a pipeline:
 ```go
 obj | data.ToTOML
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `obj`  | the object to marshal as a TOML document |
+| name | description |
+|------|-------------|
+| `obj` | _(required)_ the object to marshal as a TOML document |
 
-#### Example
+### Examples
 
 ```console
 $ gomplate -i '{{ `{"foo":"bar"}` | data.JSON | data.ToTOML }}'
@@ -532,18 +657,16 @@ you require `LF` (UNIX format, or `\n`), the output can be piped through
 ```go
 data.ToCSV [delim] input
 ```
-
-Can also be used in a pipeline:
 ```go
 input | data.ToCSV [delim]
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
+| name | description |
+|------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `input` | the object to convert to a CSV |
+| `input` | _(required)_ the object to convert to a CSV |
 
 ### Examples
 

--- a/docs/content/functions/env.md
+++ b/docs/content/functions/env.md
@@ -5,13 +5,16 @@ menu:
     parent: functions
 ---
 
+[12-factor]: https://12factor.net
+[Docker Secrets]: https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images
+
 ## `env.Getenv`
 
 **Alias:** `getenv`
 
 Exposes the [os.Getenv](https://golang.org/pkg/os/#Getenv) function.
 
-Retrieves the value of the environment variable named by the key. If the 
+Retrieves the value of the environment variable named by the key. If the
 variable is unset, but the same variable ending in `_FILE` is set, the contents
 of the file will be returned. Otherwise the provided default (or an empty
 string) is returned.
@@ -23,7 +26,20 @@ The `_FILE` fallback is especially useful for use with [12-factor][]-style
 applications configurable only by environment variables, and especially in
 conjunction with features like [Docker Secrets][].
 
-#### Example
+### Usage
+
+```go
+env.Getenv var [default]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `var` | _(required)_ the environment variable name |
+| `default` | _(optional)_ the default |
+
+### Examples
 
 ```console
 $ gomplate -i 'Hello, {{env.Getenv "USER"}}'
@@ -31,7 +47,6 @@ Hello, hairyhenderson
 $ gomplate -i 'Hey, {{getenv "FIRSTNAME" "you"}}!'
 Hey, you!
 ```
-
 ```console
 $ echo "safe" > /tmp/mysecret
 $ export SECRET_FILE=/tmp/mysecret
@@ -48,7 +63,19 @@ current environment variables. References to undefined variables are replaced by
 
 Like [`env.Getenv`](#env-getenv), the `_FILE` variant of a variable is used.
 
-#### Example
+### Usage
+
+```go
+env.ExpandEnv input
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `input` | _(required)_ the input |
+
+### Examples
 
 ```console
 $ gomplate -i '{{env.ExpandEnv "Hello $USER"}}'
@@ -56,18 +83,13 @@ Hello, hairyhenderson
 $ gomplate -i 'Hey, {{env.ExpandEnv "Hey, ${FIRSTNAME}!"}}'
 Hey, you!
 ```
-
 ```console
 $ echo "safe" > /tmp/mysecret
 $ export SECRET_FILE=/tmp/mysecret
 $ gomplate -i '{{env.ExpandEnv "Your secret is $SECRET"}}'
 Your secret is safe
 ```
-
 ```console
 $ gomplate -i '{{env.ExpandEnv (file.Read "foo")}}
 contents of file "foo"...
 ```
-
-[12-factor]: https://12factor.net
-[Docker Secrets]: https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images

--- a/docs/content/functions/file.md
+++ b/docs/content/functions/file.md
@@ -12,12 +12,12 @@ Functions for working with files.
 Reports whether a file or directory exists at the given path.
 
 ### Usage
-```go
-file.Exists path 
-```
 
 ```go
-path | file.Exists  
+file.Exists path
+```
+```go
+path | file.Exists
 ```
 
 ### Arguments
@@ -46,12 +46,12 @@ yes
 Reports whether a given path is a directory.
 
 ### Usage
-```go
-file.IsDir path 
-```
 
 ```go
-path | file.IsDir  
+file.IsDir path
+```
+```go
+path | file.IsDir
 ```
 
 ### Arguments
@@ -83,12 +83,12 @@ yes
 Reads a given file _as text_. Note that this will succeed if the given file is binary, but the output may be gibberish.
 
 ### Usage
-```go
-file.Read path 
-```
 
 ```go
-path | file.Read  
+file.Read path
+```
+```go
+path | file.Read
 ```
 
 ### Arguments
@@ -110,12 +110,12 @@ hello world
 Reads a directory and lists the files and directories contained within.
 
 ### Usage
-```go
-file.ReadDir path 
-```
 
 ```go
-path | file.ReadDir  
+file.ReadDir path
+```
+```go
+path | file.ReadDir
 ```
 
 ### Arguments
@@ -144,12 +144,12 @@ Returns a [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo) describing the na
 Essentially a wrapper for Go's [`os.Stat`](https://golang.org/pkg/os/#Stat) function.
 
 ### Usage
-```go
-file.Stat path 
-```
 
 ```go
-path | file.Stat  
+file.Stat path
+```
+```go
+path | file.Stat
 ```
 
 ### Arguments
@@ -177,12 +177,12 @@ Walk does not follow symbolic links.
 Similar to Go's [`filepath.Walk`](https://golang.org/pkg/path/filepath/#Walk) function.
 
 ### Usage
-```go
-file.Walk path 
-```
 
 ```go
-path | file.Walk  
+file.Walk path
+```
+```go
+path | file.Walk
 ```
 
 ### Arguments
@@ -223,12 +223,12 @@ Non-existing directories in the output path will be created.
 If the data is a byte array (`[]byte`), it will be written as-is. Otherwise, it will be converted to a string before being written.
 
 ### Usage
-```go
-file.Write filename data 
-```
 
 ```go
-data | file.Write filename  
+file.Write filename data
+```
+```go
+data | file.Write filename
 ```
 
 ### Arguments

--- a/docs/content/functions/filepath.md
+++ b/docs/content/functions/filepath.md
@@ -20,12 +20,12 @@ Returns the last element of path. Trailing path separators are removed before ex
 A wrapper for Go's [`filepath.Base`](https://golang.org/pkg/path/filepath/#Base) function.
 
 ### Usage
-```go
-filepath.Base path 
-```
 
 ```go
-path | filepath.Base  
+filepath.Base path
+```
+```go
+path | filepath.Base
 ```
 
 ### Arguments
@@ -48,12 +48,12 @@ Clean returns the shortest path name equivalent to path by purely lexical proces
 A wrapper for Go's [`filepath.Clean`](https://golang.org/pkg/path/filepath/#Clean) function.
 
 ### Usage
-```go
-filepath.Clean path 
-```
 
 ```go
-path | filepath.Clean  
+filepath.Clean path
+```
+```go
+path | filepath.Clean
 ```
 
 ### Arguments
@@ -76,12 +76,12 @@ Returns all but the last element of path, typically the path's directory.
 A wrapper for Go's [`filepath.Dir`](https://golang.org/pkg/path/filepath/#Dir) function.
 
 ### Usage
-```go
-filepath.Dir path 
-```
 
 ```go
-path | filepath.Dir  
+filepath.Dir path
+```
+```go
+path | filepath.Dir
 ```
 
 ### Arguments
@@ -104,12 +104,12 @@ Returns the file name extension used by path.
 A wrapper for Go's [`filepath.Ext`](https://golang.org/pkg/path/filepath/#Ext) function.
 
 ### Usage
-```go
-filepath.Ext path 
-```
 
 ```go
-path | filepath.Ext  
+filepath.Ext path
+```
+```go
+path | filepath.Ext
 ```
 
 ### Arguments
@@ -132,12 +132,12 @@ Returns the result of replacing each slash (`/`) character in the path with the 
 A wrapper for Go's [`filepath.FromSlash`](https://golang.org/pkg/path/filepath/#FromSlash) function.
 
 ### Usage
-```go
-filepath.FromSlash path 
-```
 
 ```go
-path | filepath.FromSlash  
+filepath.FromSlash path
+```
+```go
+path | filepath.FromSlash
 ```
 
 ### Arguments
@@ -162,12 +162,12 @@ Reports whether the path is absolute.
 A wrapper for Go's [`filepath.IsAbs`](https://golang.org/pkg/path/filepath/#IsAbs) function.
 
 ### Usage
-```go
-filepath.IsAbs path 
-```
 
 ```go
-path | filepath.IsAbs  
+filepath.IsAbs path
+```
+```go
+path | filepath.IsAbs
 ```
 
 ### Arguments
@@ -192,8 +192,9 @@ Joins any number of path elements into a single path, adding a separator if nece
 A wrapper for Go's [`filepath.Join`](https://golang.org/pkg/path/filepath/#Join) function.
 
 ### Usage
+
 ```go
-filepath.Join elem... 
+filepath.Join elem...
 ```
 
 ### Arguments
@@ -218,8 +219,9 @@ Reports whether name matches the shell file name pattern.
 A wrapper for Go's [`filepath.Match`](https://golang.org/pkg/path/filepath/#Match) function.
 
 ### Usage
+
 ```go
-filepath.Match pattern path 
+filepath.Match pattern path
 ```
 
 ### Arguments
@@ -243,8 +245,9 @@ Returns a relative path that is lexically equivalent to targetpath when joined t
 A wrapper for Go's [`filepath.Rel`](https://golang.org/pkg/path/filepath/#Rel) function.
 
 ### Usage
+
 ```go
-filepath.Rel basepath targetpath 
+filepath.Rel basepath targetpath
 ```
 
 ### Arguments
@@ -270,12 +273,12 @@ The function returns an array with two values, the first being the diretory, and
 A wrapper for Go's [`filepath.Split`](https://golang.org/pkg/path/filepath/#Split) function.
 
 ### Usage
-```go
-filepath.Split path 
-```
 
 ```go
-path | filepath.Split  
+filepath.Split path
+```
+```go
+path | filepath.Split
 ```
 
 ### Arguments
@@ -300,12 +303,12 @@ Returns the result of replacing each separator character in path with a slash (`
 A wrapper for Go's [`filepath.ToSlash`](https://golang.org/pkg/path/filepath/#ToSlash) function.
 
 ### Usage
-```go
-filepath.ToSlash path 
-```
 
 ```go
-path | filepath.ToSlash  
+filepath.ToSlash path
+```
+```go
+path | filepath.ToSlash
 ```
 
 ### Arguments
@@ -330,12 +333,12 @@ Returns the leading volume name. Given `C:\foo\bar` it returns `C:` on Windows. 
 A wrapper for Go's [`filepath.VolumeName`](https://golang.org/pkg/path/filepath/#VolumeName) function.
 
 ### Usage
-```go
-filepath.VolumeName path 
-```
 
 ```go
-path | filepath.VolumeName  
+filepath.VolumeName path
+```
+```go
+path | filepath.VolumeName
 ```
 
 ### Arguments

--- a/docs/content/functions/math.md
+++ b/docs/content/functions/math.md
@@ -34,8 +34,9 @@ $ gomplate -i '{{ add 2.5 2.5 }}'
 Returns the absolute value of a given number. When the input is an integer, the result will be an `int64`, otherwise it will be a `float64`.
 
 ### Usage
+
 ```go
-math.Abs num 
+math.Abs num
 ```
 
 ### Arguments
@@ -58,8 +59,9 @@ $ gomplate -i '{{ math.Abs -3.5 }} {{ math.Abs 3.5 }} {{ math.Abs -42 }}'
 Adds all given operators. When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
 
 ### Usage
+
 ```go
-math.Add n... 
+math.Add n...
 ```
 
 ### Arguments
@@ -82,8 +84,9 @@ Returns the least integer value greater than or equal to a given floating-point 
 **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
 ### Usage
+
 ```go
-math.Ceil num 
+math.Ceil num
 ```
 
 ### Arguments
@@ -112,12 +115,12 @@ ceil "-0" = 0
 Divide the first number by the second. Division by zero is disallowed. The result will be a `float64`.
 
 ### Usage
-```go
-math.Div a b 
-```
 
 ```go
-b | math.Div a  
+math.Div a b
+```
+```go
+b | math.Div a
 ```
 
 ### Arguments
@@ -141,8 +144,9 @@ Returns the greatest integer value less than or equal to a given floating-point 
 **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
 ### Usage
+
 ```go
-math.Floor num 
+math.Floor num
 ```
 
 ### Arguments
@@ -171,8 +175,9 @@ Returns whether or not the given number can be interpreted as a floating-point l
 **Note:** If a decimal point is part of the input number, it will be considered a floating-point number, even if the decimal is `0`.
 
 ### Usage
+
 ```go
-math.IsFloat num 
+math.IsFloat num
 ```
 
 ### Arguments
@@ -198,8 +203,9 @@ Inf is a float
 Returns whether or not the given number is an integer.
 
 ### Usage
+
 ```go
-math.IsInt num 
+math.IsInt num
 ```
 
 ### Arguments
@@ -222,8 +228,9 @@ $ gomplate -i '{{ range (slice 1.0 "-1.0" 5.1 42 "3.14" "foo" "0xFF" "NaN" "Inf"
 Returns whether the given input is a number. Useful for `if` conditions.
 
 ### Usage
+
 ```go
-math.IsNum in 
+math.IsNum in
 ```
 
 ### Arguments
@@ -244,8 +251,9 @@ false true
 Returns the largest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Max`](https://golang.org/pkg/math/#Max) are followed.
 
 ### Usage
+
 ```go
-math.Max nums... 
+math.Max nums...
 ```
 
 ### Arguments
@@ -266,8 +274,9 @@ $ gomplate -i '{{ math.Max 0 8.0 4.5 "-1.5e-11" }}'
 Returns the smallest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Min`](https://golang.org/pkg/math/#Min) are followed.
 
 ### Usage
+
 ```go
-math.Min nums... 
+math.Min nums...
 ```
 
 ### Arguments
@@ -290,8 +299,9 @@ $ gomplate -i '{{ math.Min 0 8 4.5 "-1.5e-11" }}'
 Multiply all given operators together.
 
 ### Usage
+
 ```go
-math.Mul n... 
+math.Mul n...
 ```
 
 ### Arguments
@@ -314,8 +324,9 @@ $ gomplate -i '{{ math.Mul 8 8 2 }}'
 Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://golang.org/pkg/math/#Pow). If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned.
 
 ### Usage
+
 ```go
-math.Pow b n 
+math.Pow b n
 ```
 
 ### Arguments
@@ -343,12 +354,12 @@ $ gomplate -i '{{ math.Pow 1.5 2 }}'
 Return the remainder from an integer division operation.
 
 ### Usage
-```go
-math.Rem a b 
-```
 
 ```go
-b | math.Rem a  
+math.Rem a b
+```
+```go
+b | math.Rem a
 ```
 
 ### Arguments
@@ -374,8 +385,9 @@ Returns the nearest integer, rounding half away from zero.
 **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
 ### Usage
+
 ```go
-math.Round num 
+math.Round num
 ```
 
 ### Arguments
@@ -405,8 +417,9 @@ down as well as up, including with negative numbers.
 Note that the sequence _may_ not end at `end`, if `end` is not divisible by `step`.
 
 ### Usage
+
 ```go
-math.Seq [start] end [step] 
+math.Seq [start] end [step]
 ```
 
 ### Arguments
@@ -435,12 +448,12 @@ $ gomplate -i '{{ conv.Join (math.Seq 10 -3 2) ", " }}'
 Subtract the second from the first of the given operators.  When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
 
 ### Usage
-```go
-math.Sub a b 
-```
 
 ```go
-b | math.Sub a  
+math.Sub a b
+```
+```go
+b | math.Sub a
 ```
 
 ### Arguments

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -5,24 +5,26 @@ menu:
     parent: functions
 ---
 
+
 ## `net.LookupIP`
 
 Resolve an IPv4 address for a given host name. When multiple IP addresses
 are resolved, the first one is returned.
-
-**Note:** Unresolvable hostnames will result in an error, and `gomplate` will panic.
 
 ### Usage
 
 ```go
 net.LookupIP name
 ```
+```go
+name | net.LookupIP
+```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `name` | The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
+| name | description |
+|------|-------------|
+| `name` | _(required)_ The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
 
 ### Examples
 
@@ -35,24 +37,25 @@ $ gomplate -i '{{ net.LookupIP "example.com" }}'
 
 Resolve all IPv4 addresses for a given host name. Returns an array of strings.
 
-**Note:** Unresolvable hostnames will result in an error, and `gomplate` will panic.
-
 ### Usage
 
 ```go
 net.LookupIPs name
 ```
+```go
+name | net.LookupIPs
+```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `name` | The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
+| name | description |
+|------|-------------|
+| `name` | _(required)_ The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
 
 ### Examples
 
 ```console
-$ gomplate -i '{{ join (net.LookupIPs "twitter.com") "," }}'  
+$ gomplate -i '{{ join (net.LookupIPs "twitter.com") "," }}'
 104.244.42.65,104.244.42.193
 ```
 
@@ -62,24 +65,25 @@ Resolve the canonical name for a given host name. This does a DNS lookup for the
 `CNAME` record type. If no `CNAME` is present, a canonical form of the given name
 is returned -- e.g. `net.LookupCNAME "localhost"` will return `"localhost."`.
 
-**Note:** Unresolvable hostnames will result in an error, and `gomplate` will panic.
-
 ### Usage
 
 ```go
 net.LookupCNAME name
 ```
+```go
+name | net.LookupCNAME
+```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `name` | The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
+| name | description |
+|------|-------------|
+| `name` | _(required)_ The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
 
 ### Examples
 
 ```console
-$ gomplate -i '{{ net.LookupCNAME "www.amazon.com" }}'  
+$ gomplate -i '{{ net.LookupCNAME "www.amazon.com" }}'
 d3ag4hukkh62yn.cloudfront.net.
 ```
 
@@ -98,25 +102,25 @@ following properties are available:
 - `Port` - _(uint16)_ the service's port
 - `Priority`, `Weight` - see [RFC2782](https://tools.ietf.org/html/rfc2782) for details
 
-**Note:** Unresolvable hostnames will result in an error, and `gomplate` will panic.
-
 ### Usage
 
 ```go
 net.LookupSRV name
 ```
+```go
+name | net.LookupSRV
+```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `name` | The service name to look up |
+| name | description |
+|------|-------------|
+| `name` | _(required)_ The service name to look up |
 
 ### Examples
 
 ```console
-$ gomplate -i '{{ net.LookupSRV "_sip._udp.sip.voice.google.com" | toJSONPretty "  " }}
-'
+$ gomplate -i '{{ net.LookupSRV "_sip._udp.sip.voice.google.com" | toJSONPretty "  " }}'
 {
   "Port": 5060,
   "Priority": 10,
@@ -140,19 +144,20 @@ returned. For each element, the following properties are available:
 - `Port` - _(uint16)_ the service's port
 - `Priority`, `Weight` - see [RFC2782](https://tools.ietf.org/html/rfc2782) for details
 
-**Note:** Unresolvable hostnames will result in an error, and `gomplate` will panic.
-
 ### Usage
 
 ```go
 net.LookupSRVs name
 ```
+```go
+name | net.LookupSRVs
+```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `name` | The service name to look up |
+| name | description |
+|------|-------------|
+| `name` | _(required)_ The hostname to look up. This can be a simple hostname, or a fully-qualified domain name. |
 
 ### Examples
 
@@ -175,26 +180,26 @@ Resolve a DNS [`TXT` record](https://en.wikipedia.org/wiki/SRV_record).
 
 This function returns all available TXT records as an array of strings.
 
-**Note:** Unresolvable hostnames will result in an error, and `gomplate` will panic.
-
 ### Usage
 
 ```go
 net.LookupTXT name
 ```
+```go
+name | net.LookupTXT
+```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `name` | The host name to look up |
+| name | description |
+|------|-------------|
+| `name` | _(required)_ The host name to look up |
 
 ### Examples
 
 ```console
-$ gomplate -i '{{net.LookupTXT "example.com" | toJSONPretty "\t" }}'
+$ gomplate -i '{{net.LookupTXT "example.com" | data.ToJSONPretty "  " }}'
 [
-	"$Id: example.com 4415 2015-08-24 20:12:23Z davids $",
-	"v=spf1 -all"
+  "v=spf1 -all"
 ]
 ```

--- a/docs/content/functions/path.md
+++ b/docs/content/functions/path.md
@@ -20,12 +20,12 @@ Returns the last element of path. Trailing slashes are removed before extracting
 A wrapper for Go's [`path.Base`](https://golang.org/pkg/path/#Base) function.
 
 ### Usage
-```go
-path.Base path 
-```
 
 ```go
-path | path.Base  
+path.Base path
+```
+```go
+path | path.Base
 ```
 
 ### Arguments
@@ -48,12 +48,12 @@ Clean returns the shortest path name equivalent to path by purely lexical proces
 A wrapper for Go's [`path.Clean`](https://golang.org/pkg/path/#Clean) function.
 
 ### Usage
-```go
-path.Clean path 
-```
 
 ```go
-path | path.Clean  
+path.Clean path
+```
+```go
+path | path.Clean
 ```
 
 ### Arguments
@@ -76,12 +76,12 @@ Returns all but the last element of path, typically the path's directory.
 A wrapper for Go's [`path.Dir`](https://golang.org/pkg/path/#Dir) function.
 
 ### Usage
-```go
-path.Dir path 
-```
 
 ```go
-path | path.Dir  
+path.Dir path
+```
+```go
+path | path.Dir
 ```
 
 ### Arguments
@@ -104,12 +104,12 @@ Returns the file name extension used by path.
 A wrapper for Go's [`path.Ext`](https://golang.org/pkg/path/#Ext) function.
 
 ### Usage
-```go
-path.Ext path 
-```
 
 ```go
-path | path.Ext  
+path.Ext path
+```
+```go
+path | path.Ext
 ```
 
 ### Arguments
@@ -132,12 +132,12 @@ Reports whether the path is absolute.
 A wrapper for Go's [`path.IsAbs`](https://golang.org/pkg/path/#IsAbs) function.
 
 ### Usage
-```go
-path.IsAbs path 
-```
 
 ```go
-path | path.IsAbs  
+path.IsAbs path
+```
+```go
+path | path.IsAbs
 ```
 
 ### Arguments
@@ -162,8 +162,9 @@ Joins any number of path elements into a single path, adding a separating slash 
 A wrapper for Go's [`path.Join`](https://golang.org/pkg/path/#Join) function.
 
 ### Usage
+
 ```go
-path.Join elem... 
+path.Join elem...
 ```
 
 ### Arguments
@@ -186,8 +187,9 @@ Reports whether name matches the shell file name pattern.
 A wrapper for Go's [`path.Match`](https://golang.org/pkg/path/#Match) function.
 
 ### Usage
+
 ```go
-path.Match pattern path 
+path.Match pattern path
 ```
 
 ### Arguments
@@ -213,12 +215,12 @@ The function returns an array with two values, the first being the directory, an
 A wrapper for Go's [`path.Split`](https://golang.org/pkg/path/#Split) function.
 
 ### Usage
-```go
-path.Split path 
-```
 
 ```go
-path | path.Split  
+path.Split path
+```
+```go
+path | path.Split
 ```
 
 ### Arguments

--- a/docs/content/functions/regexp.md
+++ b/docs/content/functions/regexp.md
@@ -19,12 +19,12 @@ This function provides the same behaviour as Go's
 [`regexp.FindString`](https://golang.org/pkg/regexp/#Regexp.FindString) function.
 
 ### Usage
-```go
-regexp.Find expression input 
-```
 
 ```go
-input | regexp.Find expression  
+regexp.Find expression input
+```
+```go
+input | regexp.Find expression
 ```
 
 ### Arguments
@@ -57,12 +57,12 @@ This function provides the same behaviour as Go's
 [`regexp.FindAllString`](https://golang.org/pkg/regexp/#Regexp.FindAllString) function.
 
 ### Usage
-```go
-regexp.FindAll expression [false] input 
-```
 
 ```go
-input | regexp.FindAll expression [false]  
+regexp.FindAll expression [false] input
+```
+```go
+input | regexp.FindAll expression [false]
 ```
 
 ### Arguments
@@ -91,12 +91,12 @@ Returns `true` if a given regular expression matches a given input.
 This returns a boolean which can be used in an `if` condition, for example.
 
 ### Usage
-```go
-regexp.Match expression input 
-```
 
 ```go
-input | regexp.Match expression  
+regexp.Match expression input
+```
+```go
+input | regexp.Match expression
 ```
 
 ### Arguments
@@ -123,12 +123,12 @@ This function provides the same behaviour as Go's
 [`regexp.ReplaceAllString`](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) function.
 
 ### Usage
-```go
-regexp.Replace expression replacement input 
-```
 
 ```go
-input | regexp.Replace expression replacement  
+regexp.Replace expression replacement input
+```
+```go
+input | regexp.Replace expression replacement
 ```
 
 ### Arguments
@@ -161,12 +161,12 @@ This function provides the same behaviour as Go's
 [`regexp.ReplaceAllLiteralString`](https://golang.org/pkg/regexp/#Regexp.ReplaceAllLiteralString) function.
 
 ### Usage
-```go
-regexp.ReplaceLiteral expression replacement input 
-```
 
 ```go
-input | regexp.ReplaceLiteral expression replacement  
+regexp.ReplaceLiteral expression replacement input
+```
+```go
+input | regexp.ReplaceLiteral expression replacement
 ```
 
 ### Arguments
@@ -203,12 +203,12 @@ This function provides the same behaviour as Go's
 [`regexp.Split`](https://golang.org/pkg/regexp/#Regexp.Split) function.
 
 ### Usage
-```go
-regexp.Split expression [false] input 
-```
 
 ```go
-input | regexp.Split expression [false]  
+regexp.Split expression [false] input
+```
+```go
+input | regexp.Split expression [false]
 ```
 
 ### Arguments

--- a/docs/content/functions/sockaddr.md
+++ b/docs/content/functions/sockaddr.md
@@ -12,7 +12,7 @@ interfaces.
 These functions are _partly_ documented here for convenience, but the canonical
 documentation is at https://godoc.org/github.com/hashicorp/go-sockaddr.
 
-Aside from some convenience functions, the general method of working with these 
+Aside from some convenience functions, the general method of working with these
 functions is through a _pipeline_. There are _source_ functions, which select
 interfaces ([`IfAddr`](https://godoc.org/github.com/hashicorp/go-sockaddr#IfAddr)),
 and there are functions to further filter, refine, and finally to select
@@ -29,6 +29,9 @@ $ gomplate -i '{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ip
 132.79.79.79
 ```
 
+[RFC 1918]: http://tools.ietf.org/html/rfc1918
+[RFC 6890]: http://tools.ietf.org/html/rfc6890
+
 ## `sockaddr.GetAllInterfaces`
 
 Iterates over all available network interfaces and finds all available IP
@@ -37,11 +40,25 @@ the result as an array of `IfAddr`.
 
 Should be piped through a further function to refine and extract attributes.
 
+### Usage
+
+```go
+sockaddr.GetAllInterfaces
+```
+
+
 ## `sockaddr.GetDefaultInterfaces`
 
 Returns `IfAddrs` of the addresses attached to the default route.
 
 Should be piped through a further function to refine and extract attributes.
+
+### Usage
+
+```go
+sockaddr.GetDefaultInterfaces
+```
+
 
 ## `sockaddr.GetPrivateInterfaces`
 
@@ -56,6 +73,13 @@ address also excludes non-forwardable IP addresses (as defined by the IETF).
 
 Should be piped through a further function to refine and extract attributes.
 
+### Usage
+
+```go
+sockaddr.GetPrivateInterfaces
+```
+
+
 ## `sockaddr.GetPublicInterfaces`
 
 Returns an array of `IfAddr`s that do not match [RFC 6890][],
@@ -63,16 +87,17 @@ are attached to the default route, and are forwardable.
 
 Should be piped through a further function to refine and extract attributes.
 
+### Usage
+
+```go
+sockaddr.GetPublicInterfaces
+```
+
+
 ## `sockaddr.Sort`
 
 Returns an array of `IfAddr`s sorted based on the given selector. Multiple sort
 clauses can be passed in as a comma-delimited list without whitespace.
-
-### Usage
-
-```
-<array-of-IfAddrs> | sockaddr.Sort selector
-```
 
 ### Selectors
 
@@ -94,6 +119,22 @@ to make explicit that the sort is ascending.
 `IfAddr`s that are not comparable will be at the end of the list and in a
 non-deterministic order.
 
+### Usage
+
+```go
+sockaddr.Sort selector <array-of-IfAddrs>
+```
+```go
+<array-of-IfAddrs> | sockaddr.Sort selector
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ which selector to use (see above for values) |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s to sort |
+
 ### Examples
 
 To sort first by interface name, then by address (descending):
@@ -106,12 +147,6 @@ $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Sort "name,-address" }}'
 Returns an array of `IfAddr`s filtered by interfaces that do not match the given
 selector's value.
 
-### Usage
-
-```
-<array-of-IfAddrs> | sockaddr.Exclude selector value
-```
-
 ### Selectors
 
 The valid selectors are:
@@ -123,7 +158,7 @@ The valid selectors are:
 | `name` | the interface name |
 | `network` | being part of the given IP network (in net/mask format) |
 | `port` | the port, if included in the `IfAddr` |
-| `rfc` | being included in networks defined by the given RFC. See [the source code](https://github.com/hashicorp/go-sockaddr/blob/master/rfc.go#L38) for a list of valid RFCs | 
+| `rfc` | being included in networks defined by the given RFC. See [the source code](https://github.com/hashicorp/go-sockaddr/blob/master/rfc.go#L38) for a list of valid RFCs |
 | `size` | the size of the network mask, as number of bits (e.g. `"24"` for a /24) |
 | `type` | the type of the `IfAddr`. `unix`, `ipv4`, or `ipv6` |
 
@@ -133,6 +168,23 @@ These flags are supported by the `flag` selector:
 `broadcast`, `down`, `forwardable`, `global unicast`, `interface-local multicast`,
 `link-local multicast`, `link-local unicast`, `loopback`, `multicast`, `point-to-point`,
 `unspecified`, `up`
+
+### Usage
+
+```go
+sockaddr.Exclude selector value <array-of-IfAddrs>
+```
+```go
+<array-of-IfAddrs> | sockaddr.Exclude selector value
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ which selector to use (see above for values) |
+| `value` | _(required)_ the selector value to exclude |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s to consider |
 
 ### Examples
 
@@ -148,15 +200,42 @@ selector's value.
 
 This is the inverse of `sockaddr.Exclude`. See [`sockaddr.Exclude`](#sockaddr.Exclude) for details.
 
+### Usage
+
+```go
+sockaddr.Include selector value <array-of-IfAddrs>
+```
+```go
+<array-of-IfAddrs> | sockaddr.Include selector value
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ which selector to use (see above for values) |
+| `value` | _(required)_ the selector value to include |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s to consider |
+
 ## `sockaddr.Attr`
 
 Returns the named attribute as a string.
 
 ### Usage
 
+```go
+sockaddr.Attr selector <array-of-IfAddrs>
 ```
+```go
 <array-of-IfAddrs> | sockaddr.Attr selector
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ the attribute to return |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s to inspect |
 
 ### Examples
 
@@ -172,9 +251,20 @@ the results with the given separator.
 
 ### Usage
 
+```go
+sockaddr.Join selector separator <array-of-IfAddrs>
 ```
+```go
 <array-of-IfAddrs> | sockaddr.Join selector separator
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ the attribute to select |
+| `separator` | _(required)_ the separator |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s to join |
 
 ### Examples
 
@@ -189,9 +279,19 @@ Returns a slice of `IfAddr`s based on the specified limit.
 
 ### Usage
 
+```go
+sockaddr.Limit limit <array-of-IfAddrs>
 ```
+```go
 <array-of-IfAddrs> | sockaddr.Limit limit
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `limit` | _(required)_ the maximum number of `IfAddrs` |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s |
 
 ### Examples
 
@@ -206,9 +306,19 @@ Returns a slice of `IfAddr`s based on the specified offset.
 
 ### Usage
 
+```go
+sockaddr.Offset offset <array-of-IfAddrs>
 ```
+```go
 <array-of-IfAddrs> | sockaddr.Offset offset
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `offset` | _(required)_ the offset |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s |
 
 ### Examples
 
@@ -224,9 +334,19 @@ already been sorted.
 
 ### Usage
 
+```go
+sockaddr.Unique selector <array-of-IfAddrs>
 ```
+```go
 <array-of-IfAddrs> | sockaddr.Unique selector
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ the attribute to select |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s |
 
 ### Examples
 
@@ -244,9 +364,20 @@ for details.
 
 ### Usage
 
+```go
+sockaddr.Math selector operation <array-of-IfAddrs>
 ```
-<array-of-IfAddrs> | sockaddr.Math operation value
+```go
+<array-of-IfAddrs> | sockaddr.Math selector operation
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `selector` | _(required)_ the attribute to operate on |
+| `operation` | _(required)_ the operation |
+| `<array-of-IfAddrs>` | _(required)_ the array of `IfAddr`s |
 
 ### Examples
 
@@ -263,9 +394,10 @@ IP address, an empty string will be returned instead.
 
 ### Usage
 
-```
+```go
 sockaddr.GetPrivateIP
 ```
+
 
 ### Examples
 
@@ -283,9 +415,10 @@ returned instead.
 
 ### Usage
 
-```
+```go
 sockaddr.GetPrivateIPs
 ```
+
 
 ### Examples
 
@@ -302,9 +435,10 @@ non-[RFC 6890][] IP address, an empty string will be returned instead.
 
 ### Usage
 
-```
+```go
 sockaddr.GetPublicIP
 ```
+
 
 ### Examples
 
@@ -322,9 +456,10 @@ empty string will be returned instead.
 
 ### Usage
 
-```
+```go
 sockaddr.GetPublicIPs
 ```
+
 
 ### Examples
 
@@ -340,9 +475,15 @@ Returns a string with a single IP address sorted by the size of the network
 
 ### Usage
 
-```
+```go
 sockaddr.GetInterfaceIP name
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `name` | _(required)_ the interface name |
 
 ### Examples
 
@@ -359,9 +500,15 @@ named interface.
 
 ### Usage
 
-```
+```go
 sockaddr.GetInterfaceIPs name
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `name` | _(required)_ the interface name |
 
 ### Examples
 
@@ -369,6 +516,3 @@ sockaddr.GetInterfaceIPs name
 $ gomplate -i '{{ sockaddr.GetInterfaceIPs "en0" }}'
 10.0.0.28 fe80::1f9a:5582:4b41:bd18
 ```
-
-[RFC 1918]: http://tools.ietf.org/html/rfc1918
-[RFC 6890]: http://tools.ietf.org/html/rfc6890

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -13,12 +13,12 @@ Abbreviates a string using `...` (ellipses). Takes an optional offset from the b
 _Also see [`strings.Trunc`](#strings-trunc)._
 
 ### Usage
-```go
-strings.Abbrev [offset] width input 
-```
 
 ```go
-input | strings.Abbrev [offset] width  
+strings.Abbrev [offset] width input
+```
+```go
+input | strings.Abbrev [offset] width
 ```
 
 ### Arguments
@@ -43,12 +43,12 @@ $ gomplate -i '{{ "foobarbazquxquux" | strings.Abbrev 6 9 }}'
 Reports whether a substring is contained within a string.
 
 ### Usage
-```go
-strings.Contains substr input 
-```
 
 ```go
-input | strings.Contains substr  
+strings.Contains substr input
+```
+```go
+input | strings.Contains substr
 ```
 
 ### Arguments
@@ -77,12 +77,12 @@ no
 Tests whether a string begins with a certain prefix.
 
 ### Usage
-```go
-strings.HasPrefix prefix input 
-```
 
 ```go
-input | strings.HasPrefix prefix  
+strings.HasPrefix prefix input
+```
+```go
+input | strings.HasPrefix prefix
 ```
 
 ### Arguments
@@ -106,12 +106,12 @@ foo
 Tests whether a string ends with a certain suffix.
 
 ### Usage
-```go
-strings.HasSuffix suffix input 
-```
 
 ```go
-input | strings.HasSuffix suffix  
+strings.HasSuffix suffix input
+```
+```go
+input | strings.HasSuffix suffix
 ```
 
 ### Arguments
@@ -140,12 +140,12 @@ http://example.com:80
 Indents a string. If the input string has multiple lines, each line will be indented.
 
 ### Usage
-```go
-strings.Indent [width] [indent] input 
-```
 
 ```go
-input | strings.Indent [width] [indent]  
+strings.Indent [width] [indent] input
+```
+```go
+input | strings.Indent [width] [indent]
 ```
 
 ### Arguments
@@ -186,12 +186,12 @@ foo:
 Returns an alphanumerically-sorted copy of a given string list.
 
 ### Usage
-```go
-strings.Sort list 
-```
 
 ```go
-list | strings.Sort  
+strings.Sort list
+```
+```go
+list | strings.Sort
 ```
 
 ### Arguments
@@ -212,12 +212,12 @@ $ gomplate -i '{{ (slice "foo" "bar" "baz") | strings.Sort }}'
 Creates a slice by splitting a string on a given delimiter.
 
 ### Usage
-```go
-strings.Split separator input 
-```
 
 ```go
-input | strings.Split separator  
+strings.Split separator input
+```
+```go
+input | strings.Split separator
 ```
 
 ### Arguments
@@ -242,12 +242,12 @@ Creates a slice by splitting a string on a given delimiter. The count determines
 the number of substrings to return.
 
 ### Usage
-```go
-strings.SplitN separator count input 
-```
 
 ```go
-input | strings.SplitN separator count  
+strings.SplitN separator count input
+```
+```go
+input | strings.SplitN separator count
 ```
 
 ### Arguments
@@ -281,12 +281,12 @@ This is a convenience function which is equivalent to:
 ```
 
 ### Usage
-```go
-strings.Quote in 
-```
 
 ```go
-in | strings.Quote  
+strings.Quote in
+```
+```go
+in | strings.Quote
 ```
 
 ### Arguments
@@ -313,12 +313,12 @@ It errors if `count` is negative or if the length of `input` multiplied by `coun
 This wraps Go's [`strings.Repeat`](https://golang.org/pkg/strings/#Repeat).
 
 ### Usage
-```go
-strings.Repeat count input 
-```
 
 ```go
-input | strings.Repeat count  
+strings.Repeat count input
+```
+```go
+input | strings.Repeat count
 ```
 
 ### Arguments
@@ -342,12 +342,12 @@ hello hello hello hello hello
 Replaces all occurrences of a given string with another.
 
 ### Usage
-```go
-strings.ReplaceAll old new input 
-```
 
 ```go
-input | strings.ReplaceAll old new  
+strings.ReplaceAll old new input
+```
+```go
+input | strings.ReplaceAll old new
 ```
 
 ### Arguments
@@ -372,12 +372,12 @@ $ gomplate -i '{{ "172.21.1.42" | strings.ReplaceAll "." "-" }}'
 Creates a a "slug" from a given string - supports Unicode correctly. This wraps the [github.com/gosimple/slug](https://github.com/gosimple/slug) package. See [the github.com/gosimple/slug docs](https://godoc.org/github.com/gosimple/slug) for more information.
 
 ### Usage
-```go
-strings.Slug input 
-```
 
 ```go
-input | strings.Slug  
+strings.Slug input
+```
+```go
+input | strings.Slug
 ```
 
 ### Arguments
@@ -403,15 +403,15 @@ rock-and-roll-at-cafe-wha
 
 Surrounds an input string with a single-quote (apostrophe) character (`'`). If the input is not a string, converts first.
 
-`'` characters in the input are first escaped in the YAML-style (by repetition: `''`).<!-- ' -->
+`'` characters in the input are first escaped in the YAML-style (by repetition: `''`).
 
 ### Usage
-```go
-strings.Squote in 
-```
 
 ```go
-in | strings.Squote  
+strings.Squote in
+```
+```go
+in | strings.Squote
 ```
 
 ### Arguments
@@ -438,12 +438,12 @@ $ gomplate -i "{{ strings.Squote \"it's a banana\" }}"
 Convert to title-case.
 
 ### Usage
-```go
-strings.Title input 
-```
 
 ```go
-input | strings.Title  
+strings.Title input
+```
+```go
+input | strings.Title
 ```
 
 ### Arguments
@@ -466,12 +466,12 @@ Hello, World!
 Convert to lower-case.
 
 ### Usage
-```go
-strings.ToLower input 
-```
 
 ```go
-input | strings.ToLower  
+strings.ToLower input
+```
+```go
+input | strings.ToLower
 ```
 
 ### Arguments
@@ -494,12 +494,12 @@ hello, world!
 Convert to upper-case.
 
 ### Usage
-```go
-strings.ToUpper input 
-```
 
 ```go
-input | strings.ToUpper  
+strings.ToUpper input
+```
+```go
+input | strings.ToUpper
 ```
 
 ### Arguments
@@ -521,12 +521,12 @@ Trims a string by removing the given characters from the beginning and end of
 the string.
 
 ### Usage
-```go
-strings.Trim cutset input 
-```
 
 ```go
-input | strings.Trim cutset  
+strings.Trim cutset input
+```
+```go
+input | strings.Trim cutset
 ```
 
 ### Arguments
@@ -550,12 +550,12 @@ Returns a string without the provided leading prefix string, if the prefix is pr
 This wraps Go's [`strings.TrimPrefix`](https://golang.org/pkg/strings/#TrimPrefix).
 
 ### Usage
-```go
-strings.TrimPrefix prefix input 
-```
 
 ```go
-input | strings.TrimPrefix prefix  
+strings.TrimPrefix prefix input
+```
+```go
+input | strings.TrimPrefix prefix
 ```
 
 ### Arguments
@@ -580,12 +580,12 @@ Trims a string by removing whitespace from the beginning and end of
 the string.
 
 ### Usage
-```go
-strings.TrimSpace input 
-```
 
 ```go
-input | strings.TrimSpace  
+strings.TrimSpace input
+```
+```go
+input | strings.TrimSpace
 ```
 
 ### Arguments
@@ -608,12 +608,12 @@ Returns a string without the provided trailing suffix string, if the suffix is p
 This wraps Go's [`strings.TrimSuffix`](https://golang.org/pkg/strings/#TrimSuffix).
 
 ### Usage
-```go
-strings.TrimSuffix suffix input 
-```
 
 ```go
-input | strings.TrimSuffix suffix  
+strings.TrimSuffix suffix input
+```
+```go
+input | strings.TrimSuffix suffix
 ```
 
 ### Arguments
@@ -637,12 +637,12 @@ Returns a string truncated to the given length.
 _Also see [`strings.Abbrev`](#strings-abbrev)._
 
 ### Usage
-```go
-strings.Trunc length input 
-```
 
 ```go
-input | strings.Trunc length  
+strings.Trunc length input
+```
+```go
+input | strings.Trunc length
 ```
 
 ### Arguments
@@ -668,12 +668,12 @@ All non-alphanumeric characters are stripped, and the beginnings of words are up
 See [CamelCase on Wikipedia](https://en.wikipedia.org/wiki/Camel_case) for more details.
 
 ### Usage
-```go
-strings.CamelCase in 
-```
 
 ```go
-in | strings.CamelCase  
+strings.CamelCase in
+```
+```go
+in | strings.CamelCase
 ```
 
 ### Arguments
@@ -702,12 +702,12 @@ All non-alphanumeric characters are stripped, and spaces are replaced with an un
 See [Snake Case on Wikipedia](https://en.wikipedia.org/wiki/Snake_case) for more details.
 
 ### Usage
-```go
-strings.SnakeCase in 
-```
 
 ```go
-in | strings.SnakeCase  
+strings.SnakeCase in
+```
+```go
+in | strings.SnakeCase
 ```
 
 ### Arguments
@@ -736,12 +736,12 @@ All non-alphanumeric characters are stripped, and spaces are replaced with a hyp
 See [Kebab Case on Wikipedia](https://en.wikipedia.org/wiki/Kebab_case) for more details.
 
 ### Usage
-```go
-strings.KebabCase in 
-```
 
 ```go
-in | strings.KebabCase  
+strings.KebabCase in
+```
+```go
+in | strings.KebabCase
 ```
 
 ### Arguments
@@ -772,12 +772,12 @@ When words that are longer than the desired width are encountered (e.g. long URL
 The line-break sequence defaults to `\n` (i.e. the LF/Line Feed character), regardless of OS.
 
 ### Usage
-```go
-strings.WordWrap [width] [lbseq] in 
-```
 
 ```go
-in | strings.WordWrap [width] [lbseq]  
+strings.WordWrap [width] [lbseq] in
+```
+```go
+in | strings.WordWrap [width] [lbseq]
 ```
 
 ### Arguments
@@ -812,8 +812,9 @@ Contains reports whether the second string is contained within the first. Equiva
 [strings.Contains](https://golang.org/pkg/strings#Contains)
 
 ### Usage
+
 ```go
-contains input substring 
+contains input substring
 ```
 
 ### Arguments
@@ -845,8 +846,9 @@ Tests whether the string begins with a certain substring. Equivalent to
 [strings.HasPrefix](https://golang.org/pkg/strings#HasPrefix)
 
 ### Usage
+
 ```go
-hasPrefix input prefix 
+hasPrefix input prefix
 ```
 
 ### Arguments
@@ -878,8 +880,9 @@ Tests whether the string ends with a certain substring. Equivalent to
 [strings.HasSuffix](https://golang.org/pkg/strings#HasSuffix)
 
 ### Usage
+
 ```go
-hasSuffix input suffix 
+hasSuffix input suffix
 ```
 
 ### Arguments
@@ -909,8 +912,9 @@ Creates a slice by splitting a string on a given delimiter. Equivalent to
 [strings.Split](https://golang.org/pkg/strings#Split)
 
 ### Usage
+
 ```go
-split input separator 
+split input separator
 ```
 
 ### Arguments
@@ -937,8 +941,9 @@ Creates a slice by splitting a string on a given delimiter. The count determines
 the number of substrings to return. Equivalent to [strings.SplitN](https://golang.org/pkg/strings#SplitN)
 
 ### Usage
+
 ```go
-splitN input separator count 
+splitN input separator count
 ```
 
 ### Arguments
@@ -965,8 +970,9 @@ Trims a string by removing the given characters from the beginning and end of
 the string. Equivalent to [strings.Trim](https://golang.org/pkg/strings/#Trim)
 
 ### Usage
+
 ```go
-trim input cutset 
+trim input cutset
 ```
 
 ### Arguments

--- a/docs/content/functions/test.md
+++ b/docs/content/functions/test.md
@@ -16,12 +16,12 @@ Asserts that the given expression or value is `true`. If it is not, causes
 template generation to fail immediately with an optional message.
 
 ### Usage
-```go
-test.Assert [message] value 
-```
 
 ```go
-value | test.Assert [message]  
+test.Assert [message] value
+```
+```go
+value | test.Assert [message]
 ```
 
 ### Arguments
@@ -47,12 +47,12 @@ template: <arg>:1:3: executing "<arg>" at <assert "something ho...>: error calli
 Cause template generation to fail immediately, with an optional message.
 
 ### Usage
-```go
-test.Fail [message] 
-```
 
 ```go
-message | test.Fail  
+test.Fail [message]
+```
+```go
+message | test.Fail
 ```
 
 ### Arguments
@@ -87,12 +87,12 @@ cases where a referenced _key_ is missing, and this function will have no
 effect.
 
 ### Usage
-```go
-test.Required [message] value 
-```
 
 ```go
-value | test.Required [message]  
+test.Required [message] value
+```
+```go
+value | test.Required [message]
 ```
 
 ### Arguments
@@ -138,12 +138,12 @@ This is effectively a short-form of the following template:
 Keep in mind that using an explicit `if`/`else` block is often easier to understand than ternary expressions!
 
 ### Usage
-```go
-test.Ternary truevalue falsevalue condition 
-```
 
 ```go
-condition | test.Ternary truevalue falsevalue  
+test.Ternary truevalue falsevalue condition
+```
+```go
+condition | test.Ternary truevalue falsevalue
 ```
 
 ### Arguments

--- a/docs/content/functions/time.md
+++ b/docs/content/functions/time.md
@@ -6,7 +6,7 @@ menu:
 ---
 
 This namespace wraps Go's [`time` package](https://golang.org/pkg/time/), and a
-few of the functions return a `time.Time` value. All of the 
+few of the functions return a `time.Time` value. All of the
 [`time.Time` functions](https://golang.org/pkg/time/#Time) can then be used to
 convert, adjust, or format the time in your template.
 
@@ -25,7 +25,7 @@ Mon Jan 2 15:04:05 -0700 MST 2006
 
 ### Constants
 
-#### format layouts 
+#### format layouts
 
 Some pre-defined layouts have been provided for convenience:
 
@@ -51,7 +51,7 @@ See below for examples of how these layouts can be used.
 
 #### durations
 
-Some operations (such as [`Time.Add`](https://golang.org/pkg/time/#Time.Add) and 
+Some operations (such as [`Time.Add`](https://golang.org/pkg/time/#Time.Add) and
 [`Time.Round`](https://golang.org/pkg/time/#Time.Round)) require a
 [`Duration`](https://golang.org/pkg/time/#Duration) value. These can be created
 conveniently with the following functions:
@@ -81,9 +81,11 @@ Returns the current local time, as a `time.Time`. This wraps [`time.Now`](https:
 Usually, further functions are called using the value returned by `Now`.
 
 ### Usage
+
 ```go
 time.Now
 ```
+
 
 ### Examples
 
@@ -92,7 +94,6 @@ Usage with [`UTC`](https://golang.org/pkg/time/#Time.UTC) and [`Format`](https:/
 $ gomplate -i '{{ (time.Now).UTC.Format "Day 2 of month 1 in year 2006 (timezone MST)" }}'
 Day 14 of month 10 in year 2017 (timezone UTC)
 ```
-
 Usage with [`AddDate`](https://golang.org/pkg/time/#Time.AddDate):
 ```console
 $ date
@@ -116,16 +117,20 @@ other functions.
 _Note: In the absence of a time zone indicator, `time.Parse` returns a time in UTC._
 
 ### Usage
+
 ```go
 time.Parse layout timestamp
+```
+```go
+timestamp | time.Parse layout
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `layout` | The layout string to parse with|
-| `timestamp` | The timestamp to parse |
+| name | description |
+|------|-------------|
+| `layout` | _(required)_ The layout string to parse with |
+| `timestamp` | _(required)_ The timestamp to parse |
 
 ### Examples
 
@@ -144,12 +149,19 @@ optional fraction and a unit suffix, such as `300ms`, `-1.5h` or `2h45m`. Valid
 time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 
 ### Usage
+
 ```go
 time.ParseDuration duration
 ```
 ```go
 duration | time.ParseDuration
 ```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `duration` | _(required)_ The duration string to parse |
 
 ### Examples
 
@@ -166,16 +178,20 @@ Same as [`time.Parse`](#time-parse), except that in the absence of a time zone
 indicator, the timestamp wil be parsed in the local timezone.
 
 ### Usage
+
 ```go
 time.ParseLocal layout timestamp
+```
+```go
+timestamp | time.ParseLocal layout
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `layout` | The layout string to parse with|
-| `timestamp` | The timestamp to parse |
+| name | description |
+|------|-------------|
+| `layout` | _(required)_ The layout string to parse with |
+| `timestamp` | _(required)_ The timestamp to parse |
 
 ### Examples
 
@@ -192,17 +208,21 @@ Same as [`time.Parse`](#time-parse), except that the time is parsed in the given
 This wraps [`time.ParseInLocation`](https://golang.org/pkg/time/#ParseInLocation).
 
 ### Usage
+
 ```go
 time.ParseInLocation layout location timestamp
+```
+```go
+timestamp | time.ParseInLocation layout location
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------|
-| `layout` | The layout string to parse with |
-| `location` | The location to parse in |
-| `timestamp` | The timestamp to parse |
+| name | description |
+|------|-------------|
+| `layout` | _(required)_ The layout string to parse with |
+| `location` | _(required)_ The location to parse in |
+| `timestamp` | _(required)_ The timestamp to parse |
 
 ### Examples
 
@@ -219,21 +239,25 @@ Returns the time elapsed since a given time. This wraps [`time.Since`](https://g
 It is shorthand for `time.Now.Sub t`.
 
 ### Usage
+
 ```go
 time.Since t
+```
+```go
+t | time.Since
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------------|
-| `t`    | the `Time` to calculate since |
+| name | description |
+|------|-------------|
+| `t` | _(required)_ the `Time` to calculate since |
 
 ### Examples
 
 ```console
-$ gomplate -i '{{ $t := time.Parse time.RFC3339 "1970-01-01T00:00:00Z" }}time since the epoch: {{ time.Since $t }}'
-time since the epoch: 423365h0m24.353828924s
+$ gomplate -i '{{ $t := time.Parse time.RFC3339 "1970-01-01T00:00:00Z" }}time since the epoch:{{ time.Since $t }}'
+time since the epoch:423365h0m24.353828924s
 ```
 
 ## `time.Unix`
@@ -243,11 +267,21 @@ January 1, 1970 UTC. Note that fractional seconds can be used to denote
 milliseconds, but must be specified as a string, not a floating point number.
 
 ### Usage
+
 ```go
 time.Unix time
 ```
+```go
+time | time.Unix
+```
 
-### Example
+### Arguments
+
+| name | description |
+|------|-------------|
+| `time` | _(required)_ the time to parse |
+
+### Examples
 
 _with whole seconds:_
 ```console
@@ -268,15 +302,19 @@ Returns the duration until a given time. This wraps [`time.Until`](https://golan
 It is shorthand for `$t.Sub time.Now`.
 
 ### Usage
+
 ```go
 time.Until t
+```
+```go
+t | time.Until
 ```
 
 ### Arguments
 
-| name   | description |
-|--------|-------------|
-| `t`    | the `Time` to calculate until |
+| name | description |
+|------|-------------|
+| `t` | _(required)_ the `Time` to calculate until |
 
 ### Examples
 
@@ -296,11 +334,13 @@ only 14923h0m0s to go...
 Return the local system's time zone's name.
 
 ### Usage
+
 ```go
 time.ZoneName
 ```
 
-### Example
+
+### Examples
 
 ```console
 $ gomplate -i '{{time.ZoneName}}'
@@ -312,11 +352,13 @@ EDT
 Return the local system's time zone offset, in seconds east of UTC.
 
 ### Usage
+
 ```go
 time.ZoneOffset
 ```
 
-### Example
+
+### Examples
 
 ```console
 $ gomplate -i '{{time.ZoneOffset}}'

--- a/docs/content/functions/tmpl.md
+++ b/docs/content/functions/tmpl.md
@@ -14,12 +14,12 @@ Execute (render) the named template. This is equivalent to using the [`template`
 This allows for post-processing of templates.
 
 ### Usage
-```go
-tmpl.Exec name [context] 
-```
 
 ```go
-context | tmpl.Exec name  
+tmpl.Exec name [context]
+```
+```go
+context | tmpl.Exec name
 ```
 
 ### Arguments
@@ -51,8 +51,9 @@ If the template is given a name (see `name` argument below), it can be re-used l
 A context can be provided, otherwise the default gomplate context will be used.
 
 ### Usage
+
 ```go
-tmpl.Inline [name] in [context] 
+tmpl.Inline [name] in [context]
 ```
 
 ### Arguments


### PR DESCRIPTION
Just finishing the job I started too long ago... 😉

This aims for the least number of differences while also bringing all the function docs in-line with the standard format.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>