### PR TITLE
Fix .env file parsing so merging works properly

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -104,7 +104,15 @@ func TOML(in string) (interface{}, error) {
 
 // dotEnv - Unmarshal a dotenv file
 func dotEnv(in string) (interface{}, error) {
-	return godotenv.Unmarshal(in)
+	env, err := godotenv.Unmarshal(in)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]interface{})
+	for k, v := range env {
+		out[k] = v
+	}
+	return out, nil
 }
 
 func parseCSV(args ...string) ([][]string, []string, error) {

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -471,7 +471,7 @@ FOO.BAR = "values can be double-quoted, and shell\nescapes are supported"
 BAZ = "variable expansion: ${FOO}"
 QUX='single quotes ignore $variables'
 `
-	expected := map[string]string{
+	expected := map[string]interface{}{
 		"FOO":     "a regular unquoted value",
 		"BAR":     "another value, exports are ignored",
 		"FOO.BAR": "values can be double-quoted, and shell\nescapes are supported",


### PR DESCRIPTION
Fixes #509 - had to adapt the `map[string]string` returned by `godotenv.Unmarshal` to a `map[string]interface{}` like all the other parsers!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>