### PR TITLE
file.Write should truncate existing files

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -65,7 +65,7 @@ func Write(filename string, content []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to make dirs for %s", filename)
 	}
-	inFile, err := fs.OpenFile(filename, os.O_RDWR|os.O_CREATE, mode)
+	inFile, err := fs.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open %s", filename)
 	}

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -79,6 +79,13 @@ func TestWrite(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello world", string(out))
 
+	err = Write(foopath, []byte("truncate"))
+	assert.NoError(t, err)
+
+	out, err = ioutil.ReadFile(foopath)
+	assert.NoError(t, err)
+	assert.Equal(t, "truncate", string(out))
+
 	foopath = filepath.Join(newwd, "nonexistant", "subdir", "foo")
 	err = Write(foopath, []byte("Hello subdirranean world!"))
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes #512 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>