### PR TITLE
Adding strings.RuneCount function

### DIFF
--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -479,6 +479,29 @@ funcs:
         http://example.com/a/very/long/url
         which should not be
         broken
+  - name: strings.RuneCount
+    description: |
+      Return the number of _runes_ (Unicode code-points) contained within the
+      input. This is similar to the built-in `len` function, but `len` counts
+      the length in _bytes_. The length of an input containing multi-byte
+      code-points should therefore be measured with `strings.RuneCount`.
+
+      Inputs will first be converted to strings, and multiple inputs are
+      concatenated.
+
+      This wraps Go's [`utf8.RuneCountInString`](https://golang.org/pkg/unicode/utf8/#RuneCountInString)
+      function.
+    pipeline: true
+    arguments:
+      - name: input
+        required: true
+        description: the input(s) to measure
+    examples:
+      - |
+        $ gomplate -i '{{ range (slice "\u03a9" "\u0030" "\u1430") }}{{ printf "%s is %d bytes and %d runes\n" . (len .) (strings.RuneCount .) }}{{ end }}'
+        Ω is 2 bytes and 1 runes
+        0 is 1 bytes and 1 runes
+        ᐰ is 3 bytes and 1 runes
   - name: contains
     description: |
       **See [`strings.Contains`](#strings-contains) for a pipeline-compatible version**

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -804,6 +804,43 @@ which should not be
 broken
 ```
 
+## `strings.RuneCount`
+
+Return the number of _runes_ (Unicode code-points) contained within the
+input. This is similar to the built-in `len` function, but `len` counts
+the length in _bytes_. The length of an input containing multi-byte
+code-points should therefore be measured with `strings.RuneCount`.
+
+Inputs will first be converted to strings, and multiple inputs are
+concatenated.
+
+This wraps Go's [`utf8.RuneCountInString`](https://golang.org/pkg/unicode/utf8/#RuneCountInString)
+function.
+
+### Usage
+
+```go
+strings.RuneCount input
+```
+```go
+input | strings.RuneCount
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `input` | _(required)_ the input(s) to measure |
+
+### Examples
+
+```console
+$ gomplate -i '{{ range (slice "\u03a9" "\u0030" "\u1430") }}{{ printf "%s is %d bytes and %d runes\n" . (len .) (strings.RuneCount .) }}{{ end }}'
+Ω is 2 bytes and 1 runes
+0 is 1 bytes and 1 runes
+ᐰ is 3 bytes and 1 runes
+```
+
 ## `contains`
 
 **See [`strings.Contains`](#strings-contains) for a pipeline-compatible version**

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -8,6 +8,7 @@ package funcs
 import (
 	"fmt"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/Masterminds/goutils"
 	"github.com/hairyhenderson/gomplate/conv"
@@ -261,4 +262,13 @@ func (f *StringFuncs) WordWrap(args ...interface{}) (string, error) {
 		opts.LBSeq = conv.ToString(args[1])
 	}
 	return gompstrings.WordWrap(in, opts), nil
+}
+
+// RuneCount - like len(s), but for runes
+func (f *StringFuncs) RuneCount(args ...interface{}) (int, error) {
+	s := ""
+	for _, arg := range args {
+		s += conv.ToString(arg)
+	}
+	return utf8.RuneCountInString(s), nil
 }

--- a/funcs/strings_test.go
+++ b/funcs/strings_test.go
@@ -144,3 +144,31 @@ func TestSquote(t *testing.T) {
 		assert.Equal(t, d.out, sf.Squote(d.in))
 	}
 }
+
+func TestRuneCount(t *testing.T) {
+	sf := &StringFuncs{}
+
+	n, err := sf.RuneCount("")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	n, err = sf.RuneCount("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	n, err = sf.RuneCount("foo", "bar")
+	assert.NoError(t, err)
+	assert.Equal(t, 6, n)
+
+	n, err = sf.RuneCount(42, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 6, n)
+
+	n, err = sf.RuneCount("😂\U0001F602")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	n, err = sf.RuneCount("\U0001F600", 3.14)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+}


### PR DESCRIPTION
New `strings.RuneCount` function, properly character-count for strings involving multi-byte code-points.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>