### PR TITLE
gomplate can also be installed with npm

### DIFF
--- a/docs/content/installing.md
+++ b/docs/content/installing.md
@@ -100,6 +100,17 @@ $ gomplate --help
 ...
 ```
 
+## install with `npm`
+
+For some users, especially Node.js developers, using `npm` may be a natural fit.
+Even though `gomplate` is written in Go and not Node.js, it can still be installed
+with `npm`:
+
+```console
+$ npm install -g gomplate
+...
+```
+
 ## Slim binaries
 
 As a convenience, self-extracting compressed `gomplate` binaries are available from the [releases][] page. These are named with `-slim` as a suffix (or `-slim.exe`). They are compressed with [UPX][].


### PR DESCRIPTION
Fixes #519

Now that https://github.com/gomplate/gomplate-npm is active (mostly), gomplate can be installed with:

```console
$ npm install -g gomplate
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>