### PR TITLE
AWS STS functions

### DIFF
--- a/aws/sts.go
+++ b/aws/sts.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+// STS -
+type STS struct {
+	identifier func() CallerIdentitifier
+	cache      map[string]interface{}
+}
+
+var identifierClient CallerIdentitifier
+
+// CallerIdentitifier - an interface to wrap GetCallerIdentity
+type CallerIdentitifier interface {
+	GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error)
+}
+
+// NewSTS -
+func NewSTS(options ClientOptions) *STS {
+	return &STS{
+		identifier: func() CallerIdentitifier {
+			if identifierClient == nil {
+				session := SDKSession()
+				identifierClient = sts.New(session)
+			}
+			return identifierClient
+		},
+		cache: make(map[string]interface{}),
+	}
+}
+
+func (s *STS) getCallerID() (*sts.GetCallerIdentityOutput, error) {
+	i := s.identifier()
+	if val, ok := s.cache["GetCallerIdentity"]; ok {
+		if c, ok := val.(*sts.GetCallerIdentityOutput); ok {
+			return c, nil
+		}
+	}
+	in := &sts.GetCallerIdentityInput{}
+	out, err := i.GetCallerIdentity(in)
+	if err != nil {
+		return nil, err
+	}
+	s.cache["GetCallerIdentity"] = out
+	return out, nil
+}
+
+// UserID -
+func (s *STS) UserID() (string, error) {
+	cid, err := s.getCallerID()
+	if err != nil {
+		return "", err
+	}
+	return aws.StringValue(cid.UserId), nil
+}
+
+// Account -
+func (s *STS) Account() (string, error) {
+	cid, err := s.getCallerID()
+	if err != nil {
+		return "", err
+	}
+	return aws.StringValue(cid.Account), nil
+}
+
+// Arn -
+func (s *STS) Arn() (string, error) {
+	cid, err := s.getCallerID()
+	if err != nil {
+		return "", err
+	}
+	return aws.StringValue(cid.Arn), nil
+}

--- a/aws/sts_test.go
+++ b/aws/sts_test.go
@@ -1,0 +1,106 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSTS(t *testing.T) {
+	s := NewSTS(ClientOptions{})
+	cid := &DummyCallerIdentifier{
+		account: "acct",
+		userID:  "uid",
+		arn:     "arn",
+	}
+	s.identifier = func() CallerIdentitifier {
+		return cid
+	}
+
+	out, err := s.getCallerID()
+	assert.NoError(t, err)
+	assert.EqualValues(t, &sts.GetCallerIdentityOutput{
+		Account: aws.String("acct"),
+		Arn:     aws.String("arn"),
+		UserId:  aws.String("uid"),
+	}, out)
+
+	assert.Equal(t, "acct", must(s.Account()))
+	assert.Equal(t, "arn", must(s.Arn()))
+	assert.Equal(t, "uid", must(s.UserID()))
+
+	s = NewSTS(ClientOptions{})
+	cid = &DummyCallerIdentifier{
+		account: "acct",
+		userID:  "uid",
+		arn:     "arn",
+	}
+	oldIDClient := identifierClient
+	identifierClient = cid
+	defer func() { identifierClient = oldIDClient }()
+
+	out, err = s.getCallerID()
+	assert.NoError(t, err)
+	assert.EqualValues(t, &sts.GetCallerIdentityOutput{
+		Account: aws.String("acct"),
+		Arn:     aws.String("arn"),
+		UserId:  aws.String("uid"),
+	}, out)
+
+	assert.Equal(t, "acct", must(s.Account()))
+	assert.Equal(t, "arn", must(s.Arn()))
+	assert.Equal(t, "uid", must(s.UserID()))
+}
+
+func TestGetCallerIDErrors(t *testing.T) {
+	s := NewSTS(ClientOptions{})
+	cid := &DummyCallerIdentifier{
+		account: "acct",
+		userID:  "uid",
+		arn:     "arn",
+	}
+	s.identifier = func() CallerIdentitifier {
+		return cid
+	}
+
+	out, err := s.Account()
+	assert.NoError(t, err)
+	assert.Equal(t, "acct", out)
+
+	s = NewSTS(ClientOptions{})
+	cid = &DummyCallerIdentifier{
+		err: errors.New("ERRORED"),
+	}
+	s.identifier = func() CallerIdentitifier {
+		return cid
+	}
+
+	_, err = s.Account()
+	assert.EqualError(t, err, "ERRORED")
+	_, err = s.UserID()
+	assert.EqualError(t, err, "ERRORED")
+	_, err = s.Arn()
+	assert.EqualError(t, err, "ERRORED")
+}
+
+type DummyCallerIdentifier struct {
+	account, arn, userID string
+	err                  error
+}
+
+func (c *DummyCallerIdentifier) GetCallerIdentity(*sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	out := &sts.GetCallerIdentityOutput{
+		Account: aws.String(c.account),
+		Arn:     aws.String(c.arn),
+		UserId:  aws.String(c.userID),
+	}
+	return out, nil
+}

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -11,6 +11,14 @@ import (
 
 // MockServer -
 func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
+	server, httpClient := MockHTTPServer(code, body)
+
+	client := &Ec2Meta{server.URL + "/", httpClient, false, make(map[string]string), ClientOptions{}}
+	return server, client
+}
+
+// MockHTTPServer -
+func MockHTTPServer(code int, body string) (*httptest.Server, *http.Client) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(code)
 		// nolint: errcheck
@@ -23,9 +31,7 @@ func MockServer(code int, body string) (*httptest.Server, *Ec2Meta) {
 		},
 	}
 	httpClient := &http.Client{Transport: tr}
-
-	client := &Ec2Meta{server.URL + "/", httpClient, false, make(map[string]string), ClientOptions{}}
-	return server, client
+	return server, httpClient
 }
 
 // NewDummyEc2Info -

--- a/docs-src/content/functions/aws.yml
+++ b/docs-src/content/functions/aws.yml
@@ -150,3 +150,42 @@ funcs:
       - |
         $ export CIPHER=$(gomplate -i '{{ aws.KMSEncrypt "alias/gomplate" "hello world" }}')
         $ gomplate -i '{{ env.Getenv "CIPHER" | aws.KMSDecrypt }}'
+  - name: aws.Account
+    description: |
+      Returns the currently-authenticated AWS account ID number.
+
+      Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+
+      See also [`aws.UserID`](#aws-userid) and [`aws.ARN`](#aws-arn).
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i 'My account is {{ aws.Account }}'
+        My account is 123456789012
+  - name: aws.ARN
+    description: |
+      Returns the AWS ARN (Amazon Resource Name) associated with the current authentication credentials.
+
+      Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+
+      See also [`aws.UserID`](#aws-userid) and [`aws.Account`](#aws-account).
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i 'Calling from {{ aws.ARN }}'
+        Calling from arn:aws:iam::123456789012:user/Alice
+  - name: aws.UserID
+    description: |
+      Returns the unique identifier of the calling entity. The exact value
+      depends on the type of entity making the call. The values returned are those
+      listed in the `aws:userid` column in the [Principal table](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)
+      found on the Policy Variables reference page in the IAM User Guide.
+
+      Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+
+      See also [`aws.ARN`](#aws-arn) and [`aws.Account`](#aws-account).
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i 'I am {{ aws.UserID }}'
+        I am AIDACKCEVSQ6C2EXAMPLE

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -221,3 +221,72 @@ input | aws.KMSDecrypt
 $ export CIPHER=$(gomplate -i '{{ aws.KMSEncrypt "alias/gomplate" "hello world" }}')
 $ gomplate -i '{{ env.Getenv "CIPHER" | aws.KMSDecrypt }}'
 ```
+
+## `aws.Account`
+
+Returns the currently-authenticated AWS account ID number.
+
+Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+
+See also [`aws.UserID`](#aws-userid) and [`aws.ARN`](#aws-arn).
+
+### Usage
+
+```go
+aws.Account
+```
+
+
+### Examples
+
+```console
+$ gomplate -i 'My account is {{ aws.Account }}'
+My account is 123456789012
+```
+
+## `aws.ARN`
+
+Returns the AWS ARN (Amazon Resource Name) associated with the current authentication credentials.
+
+Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+
+See also [`aws.UserID`](#aws-userid) and [`aws.Account`](#aws-account).
+
+### Usage
+
+```go
+aws.ARN
+```
+
+
+### Examples
+
+```console
+$ gomplate -i 'Calling from {{ aws.ARN }}'
+Calling from arn:aws:iam::123456789012:user/Alice
+```
+
+## `aws.UserID`
+
+Returns the unique identifier of the calling entity. The exact value
+depends on the type of entity making the call. The values returned are those
+listed in the `aws:userid` column in the [Principal table](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable)
+found on the Policy Variables reference page in the IAM User Guide.
+
+Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html)
+
+See also [`aws.ARN`](#aws-arn) and [`aws.Account`](#aws-account).
+
+### Usage
+
+```go
+aws.UserID
+```
+
+
+### Examples
+
+```console
+$ gomplate -i 'I am {{ aws.UserID }}'
+I am AIDACKCEVSQ6C2EXAMPLE
+```


### PR DESCRIPTION
Adding 3 new functions that wrap the AWS STS `GetCallerIdentity` API:

- `aws.Account`
- `aws.UserID`
- `aws.ARN`

These all answer various facets of "who am I?"

Signed-off-by: Dave Henderson <dhenderson@gmail.com>