### PR TITLE
Some more Windows fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -30,7 +30,7 @@
   revision = "f0300d1749da6fa982027e449ec0c7a145510c3c"
 
 [[projects]]
-  digest = "1:21d05df076b6b49d1226c6edf002a6ab62354b1c06d02f70bc22fe082f6b965f"
+  digest = "1:319be7951b73cbd2788a8d34be7cf9a6471b4fe1e30ca4db7e521713df1b4cd6"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -447,12 +447,12 @@
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:e64931f43ab49e31f06c800d2ed6900e5c0d9af16a5ac9b32a4dd224d1e2ddaf"
+  digest = "1:9e4f30fec20838825756c20b38935a711419c1b9d7cb2a7e98b77d4c80ac099f"
   name = "github.com/zealic/xignore"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "a3a6e1eee5b33815a1a4abe4ed629ca237ce77d7"
-  version = "v0.3.2"
+  revision = "d72c65dd16ee9819723913f04e3438b08db3e447"
+  version = "v0.3.3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,4 +17,4 @@
 
 [[constraint]]
   name = "github.com/zealic/xignore"
-  version = "~0.3.2"
+  version = "~0.3.3"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build-release: artifacts.cid
 
 docker-images: gomplate.iid gomplate-slim.iid
 
-$(PREFIX)/bin/$(PKG_NAME)_%: $(shell find $(PREFIX) -type f -name '*.go')
+$(PREFIX)/bin/$(PKG_NAME)_%: $(shell find $(PREFIX) -type f -name "*.go")
 	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- | cut -f1 -d.) CGO_ENABLED=0 \
 		$(GO) build \
 			-ldflags "-w -s $(COMMIT_FLAG) $(VERSION_FLAG) $(BUILD_DATE_FLAG)" \
@@ -80,10 +80,15 @@ $(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS)): $(PREFIX)/bin/$(PKG_NAME)_$(
 
 build: $(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS))
 
+ifeq ($(OS),Windows_NT)
+test:
+	$(GO) test -v -coverprofile=c.out ./...
+else
 test:
 	$(GO) test -v -race -coverprofile=c.out ./...
+endif
 
-integration: ./bin/gomplate
+integration: build
 	$(GO) test -v -tags=integration \
 		./tests/integration -check.v
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image:
+  - Visual Studio 2015
 version: "{build}"
 
 clone_folder: c:\gopath\src\github.com\hairyhenderson\gomplate

--- a/data/datasource_awssmp_test.go
+++ b/data/datasource_awssmp_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package data
 
 import (

--- a/data/datasource_env_test.go
+++ b/data/datasource_env_test.go
@@ -3,7 +3,6 @@ package data
 import (
 	"net/url"
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,6 @@ import (
 
 func mustParseURL(in string) *url.URL {
 	u, _ := url.Parse(in)
-	p := regexp.MustCompile("^/[a-zA-Z]:.*$")
-	if p.MatchString(u.Path) {
-		u.Path = trimLeftChar(u.Path)
-	}
 	return u
 }
 

--- a/data/datasource_file_test.go
+++ b/data/datasource_file_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package data
 
 import (

--- a/data/datasource_merge_test.go
+++ b/data/datasource_merge_test.go
@@ -1,5 +1,3 @@
-//+build !windows
-
 package data
 
 import (

--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -64,6 +64,17 @@ func TestParseSourceWithAlias(t *testing.T) {
 	assert.Equal(t, "/otherdir/foo.json", s.URL.Path)
 
 	if runtime.GOOS == "windows" {
+		s, err = parseSource("data=foo.json")
+		assert.NoError(t, err)
+		assert.Equalf(t, byte(':'), s.URL.Path[1], "Path was %s", s.URL.Path)
+
+		s, err = parseSource(`data=\otherdir\foo.json`)
+		assert.NoError(t, err)
+		assert.Equal(t, "data", s.Alias)
+		assert.Equal(t, "file", s.URL.Scheme)
+		assert.True(t, s.URL.IsAbs())
+		assert.Equal(t, `/otherdir/foo.json`, s.URL.Path)
+
 		s, err = parseSource("data=C:\\windowsdir\\foo.json")
 		assert.NoError(t, err)
 		assert.Equal(t, "data", s.Alias)

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -58,6 +58,8 @@ By default, output files are created with the same file mode (permissions) as in
 
 The value must be an octal integer in the standard UNIX `chmod` format, i.e. `644` to indicate that owner gets read+write, group gets read-only, and others get read-only permissions. See the [`chmod(1)` man page](https://linux.die.net/man/1/chmod) for more details.
 
+**Note:** `--chmod` is not currently supported on Windows. Behaviour is undefined, but will likely not change file permissions at all.
+
 ### `--exclude`
 
 To prevent certain files from being processed, you can use `--exclude`. It takes a glob, and any files matching that glob will not be included.

--- a/template_test.go
+++ b/template_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package gomplate
 
 import (
@@ -58,30 +56,6 @@ func TestOpenOutFile(t *testing.T) {
 	f, err := openOutFile("-", 0644, false)
 	assert.NoError(t, err)
 	assert.Equal(t, Stdout, f)
-}
-
-func TestWalkDir(t *testing.T) {
-	origfs := fs
-	defer func() { fs = origfs }()
-	fs = afero.NewMemMapFs()
-
-	_, err := walkDir("/indir", "/outdir", nil, 0, false)
-	assert.Error(t, err)
-
-	_ = fs.MkdirAll("/indir/one", 0777)
-	_ = fs.MkdirAll("/indir/two", 0777)
-	afero.WriteFile(fs, "/indir/one/foo", []byte("foo"), 0644)
-	afero.WriteFile(fs, "/indir/one/bar", []byte("bar"), 0644)
-	afero.WriteFile(fs, "/indir/two/baz", []byte("baz"), 0644)
-
-	templates, err := walkDir("/indir", "/outdir", []string{"*/two"}, 0, false)
-
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(templates))
-	assert.Equal(t, "/indir/one/bar", templates[0].name)
-	assert.Equal(t, "/outdir/one/bar", templates[0].targetPath)
-	assert.Equal(t, "/indir/one/foo", templates[1].name)
-	assert.Equal(t, "/outdir/one/foo", templates[1].targetPath)
 }
 
 func TestLoadContents(t *testing.T) {

--- a/template_unix_test.go
+++ b/template_unix_test.go
@@ -1,0 +1,43 @@
+// +build !windows
+
+package gomplate
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalkDir(t *testing.T) {
+	origfs := fs
+	defer func() { fs = origfs }()
+	fs = afero.NewMemMapFs()
+
+	_, err := walkDir("/indir", "/outdir", nil, 0, false)
+	assert.Error(t, err)
+
+	_ = fs.MkdirAll("/indir/one", 0777)
+	_ = fs.MkdirAll("/indir/two", 0777)
+	afero.WriteFile(fs, "/indir/one/foo", []byte("foo"), 0644)
+	afero.WriteFile(fs, "/indir/one/bar", []byte("bar"), 0644)
+	afero.WriteFile(fs, "/indir/two/baz", []byte("baz"), 0644)
+
+	templates, err := walkDir("/indir", "/outdir", []string{"*/two"}, 0, false)
+
+	assert.NoError(t, err)
+	expected := []*tplate{
+		{
+			name:       "/indir/one/bar",
+			targetPath: "/outdir/one/bar",
+			mode:       0644,
+		},
+		{
+			name:       "/indir/one/foo",
+			targetPath: "/outdir/one/foo",
+			mode:       0644,
+		},
+	}
+	assert.EqualValues(t, expected, templates)
+}

--- a/template_windows_test.go
+++ b/template_windows_test.go
@@ -1,0 +1,43 @@
+// +build windows
+
+package gomplate
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWalkDir(t *testing.T) {
+	origfs := fs
+	defer func() { fs = origfs }()
+	fs = afero.NewMemMapFs()
+
+	_, err := walkDir(`C:\indir`, `C:\outdir`, nil, 0, false)
+	assert.Error(t, err)
+
+	_ = fs.MkdirAll(`C:\indir\one`, 0777)
+	_ = fs.MkdirAll(`C:\indir\two`, 0777)
+	afero.WriteFile(fs, `C:\indir\one\foo`, []byte("foo"), 0644)
+	afero.WriteFile(fs, `C:\indir\one\bar`, []byte("bar"), 0644)
+	afero.WriteFile(fs, `C:\indir\two\baz`, []byte("baz"), 0644)
+
+	templates, err := walkDir(`C:\indir`, `C:\outdir`, []string{`*\two`}, 0, false)
+
+	assert.NoError(t, err)
+	expected := []*tplate{
+		{
+			name:       `C:\indir\one\bar`,
+			targetPath: `C:\outdir\one\bar`,
+			mode:       0644,
+		},
+		{
+			name:       `C:\indir\one\foo`,
+			targetPath: `C:\outdir\one\foo`,
+			mode:       0644,
+		},
+	}
+	assert.EqualValues(t, expected, templates)
+}

--- a/tests/integration/basic_nonwindows_test.go
+++ b/tests/integration/basic_nonwindows_test.go
@@ -1,0 +1,73 @@
+//+build integration
+//+build !windows
+
+package integration
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/gotestyourself/gotestyourself/assert"
+	"github.com/gotestyourself/gotestyourself/icmd"
+)
+
+func (s *BasicSuite) TestRoutesInputsToProperOutputsWithChmod(c *C) {
+	oneOut := s.tmpDir.Join("one.out")
+	twoOut := s.tmpDir.Join("two.out")
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"-f", s.tmpDir.Join("one"),
+		"-f", s.tmpDir.Join("two"),
+		"-o", oneOut,
+		"-o", twoOut,
+		"--chmod", "0600"), func(cmd *icmd.Cmd) {
+		cmd.Stdin = bytes.NewBufferString("hello world")
+	})
+	result.Assert(c, icmd.Success)
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{oneOut, 0600, "hi\n"},
+		{twoOut, 0600, "hello\n"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.mode, info.Mode())
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *BasicSuite) TestOverridesOutputModeWithChmod(c *C) {
+	out := s.tmpDir.Join("two")
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"-f", s.tmpDir.Join("one"),
+		"-o", out,
+		"--chmod", "0600"), func(cmd *icmd.Cmd) {
+		cmd.Stdin = bytes.NewBufferString("hello world")
+	})
+	result.Assert(c, icmd.Success)
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{out, 0600, "hi\n"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.mode, info.Mode())
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}

--- a/tests/integration/basic_test.go
+++ b/tests/integration/basic_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 
@@ -7,6 +6,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"runtime"
 
 	. "gopkg.in/check.v1"
 
@@ -101,65 +101,9 @@ func (s *BasicSuite) TestRoutesInputsToProperOutputs(c *C) {
 	for _, v := range testdata {
 		info, err := os.Stat(v.path)
 		assert.NilError(c, err)
-		assert.Equal(c, v.mode, info.Mode())
-		content, err := ioutil.ReadFile(v.path)
-		assert.NilError(c, err)
-		assert.Equal(c, v.content, string(content))
-	}
-}
-
-func (s *BasicSuite) TestRoutesInputsToProperOutputsWithChmod(c *C) {
-	oneOut := s.tmpDir.Join("one.out")
-	twoOut := s.tmpDir.Join("two.out")
-	result := icmd.RunCmd(icmd.Command(GomplateBin,
-		"-f", s.tmpDir.Join("one"),
-		"-f", s.tmpDir.Join("two"),
-		"-o", oneOut,
-		"-o", twoOut,
-		"--chmod", "0600"), func(cmd *icmd.Cmd) {
-		cmd.Stdin = bytes.NewBufferString("hello world")
-	})
-	result.Assert(c, icmd.Success)
-
-	testdata := []struct {
-		path    string
-		mode    os.FileMode
-		content string
-	}{
-		{oneOut, 0600, "hi\n"},
-		{twoOut, 0600, "hello\n"},
-	}
-	for _, v := range testdata {
-		info, err := os.Stat(v.path)
-		assert.NilError(c, err)
-		assert.Equal(c, v.mode, info.Mode())
-		content, err := ioutil.ReadFile(v.path)
-		assert.NilError(c, err)
-		assert.Equal(c, v.content, string(content))
-	}
-}
-
-func (s *BasicSuite) TestOverridesOutputModeWithChmod(c *C) {
-	out := s.tmpDir.Join("two")
-	result := icmd.RunCmd(icmd.Command(GomplateBin,
-		"-f", s.tmpDir.Join("one"),
-		"-o", out,
-		"--chmod", "0600"), func(cmd *icmd.Cmd) {
-		cmd.Stdin = bytes.NewBufferString("hello world")
-	})
-	result.Assert(c, icmd.Success)
-
-	testdata := []struct {
-		path    string
-		mode    os.FileMode
-		content string
-	}{
-		{out, 0600, "hi\n"},
-	}
-	for _, v := range testdata {
-		info, err := os.Stat(v.path)
-		assert.NilError(c, err)
-		assert.Equal(c, v.mode, info.Mode())
+		if runtime.GOOS != "windows" {
+			assert.Equal(c, v.mode, info.Mode())
+		}
 		content, err := ioutil.ReadFile(v.path)
 		assert.NilError(c, err)
 		assert.Equal(c, v.content, string(content))

--- a/tests/integration/collection_test.go
+++ b/tests/integration/collection_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 

--- a/tests/integration/datasources_boltdb_test.go
+++ b/tests/integration/datasources_boltdb_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 

--- a/tests/integration/datasources_file_test.go
+++ b/tests/integration/datasources_file_test.go
@@ -72,6 +72,22 @@ func (s *FileDatasourcesSuite) TestFileDatasources(c *C) {
 	)
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "baz"})
 
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"-d", "config=config.json",
+		"-i", `{{ (ds "config").foo.bar }}`,
+	), func(c *icmd.Cmd) {
+		c.Dir = s.tmpDir.Path()
+	})
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "baz"})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"-d", "config.json",
+		"-i", `{{ (ds "config").foo.bar }}`,
+	), func(c *icmd.Cmd) {
+		c.Dir = s.tmpDir.Path()
+	})
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "baz"})
+
 	result = icmd.RunCommand(GomplateBin,
 		"-i", `foo{{defineDatasource "config" `+"`"+s.tmpDir.Join("config.json")+"`"+`}}bar{{(datasource "config").foo.bar}}`,
 	)

--- a/tests/integration/datasources_http_test.go
+++ b/tests/integration/datasources_http_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 

--- a/tests/integration/datasources_merge_test.go
+++ b/tests/integration/datasources_merge_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 
@@ -55,7 +54,7 @@ func (s *MergeDatasourceSuite) TestMergeDatasource(c *C) {
 	result = icmd.RunCommand(GomplateBin,
 		"-d", "default="+s.tmpDir.Join("default.yml"),
 		"-d", "config=merge:user|default",
-		"-i", `{{ defineDatasource "user" "`+s.tmpDir.Join("config.json")+`" }}{{ ds "config" | toJSON }}`,
+		"-i", `{{ defineDatasource "user" `+"`"+s.tmpDir.Join("config.json")+"`"+` }}{{ ds "config" | toJSON }}`,
 	)
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: `{"foo":{"bar":"baz"},"other":true}`})
 

--- a/tests/integration/file_test.go
+++ b/tests/integration/file_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 
@@ -33,7 +32,7 @@ func (s *FileSuite) TearDownSuite(c *C) {
 }
 
 func (s *FileSuite) TestReadsFile(c *C) {
-	inOutTest(c, `{{ file.Read "`+s.tmpDir.Join("one")+`"}}`, "hi")
+	inOutTest(c, "{{ file.Read `"+s.tmpDir.Join("one")+"`}}", "hi")
 }
 
 func (s *FileSuite) TestWrite(c *C) {

--- a/tests/integration/gomplateignore_test.go
+++ b/tests/integration/gomplateignore_test.go
@@ -1,10 +1,10 @@
 //+build integration
-//+build !windows
 
 package integration
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
 
 	. "gopkg.in/check.v1"
@@ -85,6 +85,13 @@ func (s *GomplateignoreSuite) TestGomplateignore_Simple(c *C) {
 	tassert.Equal(c, []string{"rain.txt"}, files)
 }
 
+func fromSlashes(paths ...string) []string {
+	for i, v := range paths {
+		paths[i] = filepath.FromSlash(v)
+	}
+	return paths
+}
+
 func (s *GomplateignoreSuite) TestGomplateignore_Folder(c *C) {
 	s.execute(c, `.gomplateignore
 f[o]o/bar
@@ -104,8 +111,8 @@ f[o]o/bar
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
-		"foo/bar/tool/lex.txt", "foo/tar/2.txt"}, files)
+	tassert.Equal(c, fromSlashes(
+		"foo/bar/tool/lex.txt", "foo/tar/2.txt"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_Root(c *C) {
@@ -120,8 +127,8 @@ func (s *GomplateignoreSuite) TestGomplateignore_Root(c *C) {
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
-		"sub/1.txt", "sub/2.txt"}, files)
+	tassert.Equal(c, fromSlashes(
+		"sub/1.txt", "sub/2.txt"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_Exclusion(c *C) {
@@ -143,8 +150,8 @@ en/e3.txt
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
-		"!", "e2.txt", "en/e1.txt", "en/e2.txt"}, files)
+	tassert.Equal(c, fromSlashes(
+		"!", "e2.txt", "en/e1.txt", "en/e2.txt"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_Nested(c *C) {
@@ -163,10 +170,10 @@ func (s *GomplateignoreSuite) TestGomplateignore_Nested(c *C) {
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{".gomplateignore", "1.txt",
+	tassert.Equal(c, fromSlashes(".gomplateignore", "1.txt",
 		"inner/.gomplateignore",
 		"inner/inner2/.gomplateignore",
-		"inner/inner2/jess.ini"}, files)
+		"inner/inner2/jess.ini"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_ByName(c *C) {
@@ -190,9 +197,9 @@ world.txt`,
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
+	tassert.Equal(c, fromSlashes(
 		"aa/a1/a2/hello.txt", "aa/a1/hello.txt",
-		"aa/hello.txt", "bb/hello.txt", "hello.txt"}, files)
+		"aa/hello.txt", "bb/hello.txt", "hello.txt"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_BothName(c *C) {
@@ -210,8 +217,8 @@ loss.txt
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
-		"foo/bare.txt", "loss.txt/2.log"}, files)
+	tassert.Equal(c, fromSlashes(
+		"foo/bare.txt", "loss.txt/2.log"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_LeadingSpace(c *C) {
@@ -231,8 +238,8 @@ func (s *GomplateignoreSuite) TestGomplateignore_LeadingSpace(c *C) {
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
-		"inner/  dart.log", "inner/  what.txt"}, files)
+	tassert.Equal(c, fromSlashes(
+		"inner/  dart.log", "inner/  what.txt"), files)
 }
 
 func (s *GomplateignoreSuite) TestGomplateignore_WithExcludes(c *C) {
@@ -261,7 +268,7 @@ func (s *GomplateignoreSuite) TestGomplateignore_WithExcludes(c *C) {
 
 	files, err := s.collectOutFiles()
 	tassert.NoError(c, err)
-	tassert.Equal(c, []string{
+	tassert.Equal(c, fromSlashes(
 		"logs/archive.zip", "manifest.json", "rules/index.csv",
-		"sprites/demon.xml", "sprites/human.csv"}, files)
+		"sprites/demon.xml", "sprites/human.csv"), files)
 }

--- a/tests/integration/inputdir_test.go
+++ b/tests/integration/inputdir_test.go
@@ -1,11 +1,11 @@
 //+build integration
-//+build !windows
 
 package integration
 
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 
 	. "gopkg.in/check.v1"
 
@@ -25,9 +25,9 @@ func (s *InputDirSuite) SetUpTest(c *C) {
 	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
 		fs.WithFile("config.yml", "one: eins\ntwo: deux\n"),
 		fs.WithDir("in",
-			fs.WithFile("eins.txt", `{{ (ds "config").one }}`),
+			fs.WithFile("eins.txt", `{{ (ds "config").one }}`, fs.WithMode(0644)),
 			fs.WithDir("inner",
-				fs.WithFile("deux.txt", `{{ (ds "config").two }}`),
+				fs.WithFile("deux.txt", `{{ (ds "config").two }}`, fs.WithMode(0444)),
 			),
 		),
 		fs.WithDir("out"),
@@ -68,7 +68,10 @@ func (s *InputDirSuite) TestInputDir(c *C) {
 	for _, v := range testdata {
 		info, err := os.Stat(v.path)
 		assert.NilError(c, err)
-		assert.Equal(c, v.mode, info.Mode())
+		// chmod support on Windows is pretty weak for now
+		if runtime.GOOS != "windows" {
+			assert.Equal(c, v.mode, info.Mode())
+		}
 		content, err := ioutil.ReadFile(v.path)
 		assert.NilError(c, err)
 		assert.Equal(c, v.content, string(content))
@@ -103,7 +106,10 @@ func (s *InputDirSuite) TestInputDirWithModeOverride(c *C) {
 	for _, v := range testdata {
 		info, err := os.Stat(v.path)
 		assert.NilError(c, err)
-		assert.Equal(c, v.mode, info.Mode())
+		// chmod support on Windows is pretty weak for now
+		if runtime.GOOS != "windows" {
+			assert.Equal(c, v.mode, info.Mode())
+		}
 		content, err := ioutil.ReadFile(v.path)
 		assert.NilError(c, err)
 		assert.Equal(c, v.content, string(content))

--- a/tests/integration/time_test.go
+++ b/tests/integration/time_test.go
@@ -1,9 +1,9 @@
 //+build integration
-//+build !windows
 
 package integration
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/gotestyourself/gotestyourself/icmd"
@@ -20,17 +20,19 @@ func (s *TimeSuite) TestTime(c *C) {
 	inOutTest(c, `{{ (time.Parse "`+f+`" "`+i+`").Format "2006-01-02 15 -0700" }}`,
 		"2009-02-13 23 +0000")
 
-	result := icmd.RunCmd(icmd.Command(GomplateBin, "-i",
-		`{{ (time.ParseLocal time.Kitchen "6:00AM").Format "15:04 MST" }}`), func(cmd *icmd.Cmd) {
-		cmd.Env = []string{"TZ=Africa/Luanda"}
-	})
-	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "06:00 LMT"})
+	if runtime.GOOS != "windows" {
+		result := icmd.RunCmd(icmd.Command(GomplateBin, "-i",
+			`{{ (time.ParseLocal time.Kitchen "6:00AM").Format "15:04 MST" }}`), func(cmd *icmd.Cmd) {
+			cmd.Env = []string{"TZ=Africa/Luanda"}
+		})
+		result.Assert(c, icmd.Expected{ExitCode: 0, Out: "06:00 LMT"})
 
-	result = icmd.RunCmd(icmd.Command(GomplateBin, "-i",
-		`{{ time.ZoneOffset }}`), func(cmd *icmd.Cmd) {
-		cmd.Env = []string{"TZ=UTC"}
-	})
-	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "0"})
+		result = icmd.RunCmd(icmd.Command(GomplateBin, "-i",
+			`{{ time.ZoneOffset }}`), func(cmd *icmd.Cmd) {
+			cmd.Env = []string{"TZ=UTC"}
+		})
+		result.Assert(c, icmd.Expected{ExitCode: 0, Out: "0"})
+	}
 
 	zname, _ := time.Now().Zone()
 	inOutTest(c, `{{ time.ZoneName }}`, zname)

--- a/tests/integration/tmpl_test.go
+++ b/tests/integration/tmpl_test.go
@@ -1,5 +1,4 @@
 //+build integration
-//+build !windows
 
 package integration
 

--- a/vendor/github.com/zealic/xignore/pattern.go
+++ b/vendor/github.com/zealic/xignore/pattern.go
@@ -24,6 +24,9 @@ func NewPattern(strPattern string) *Pattern {
 		return &Pattern{value: ""} // empty
 	}
 
+	// Normlize pattern path with OS, see issue #1
+	strPattern = filepath.FromSlash(strPattern)
+
 	if strPattern[0] == '!' {
 		if len(strPattern) == 1 {
 			return &Pattern{value: ""} // empty
@@ -64,7 +67,7 @@ func (p *Pattern) Match(path string) bool {
 	}
 
 	if !strings.HasPrefix(path, string(os.PathSeparator)) {
-		path = "/" + path
+		path = string(os.PathSeparator) + path
 	}
 
 	return p.regexp.MatchString(path) || p.regexp.MatchString(filepath.Base(path))


### PR DESCRIPTION
Having a bit of a Windows-bug-fixing marathon this weekend. The goal is to get as many of the unit & integration tests passing on Windows, and also to fix #505.

What this does:

- handles Windows drive letters correctly as part of URLs (i.e. `file:///C:/foo/bar` is correctly parsed as the path `C:\foo\bar` instead of `\C:\foo\bar`
  - this makes datasources work (which fixes #505)
- upgrades `github.com/zealic/xignore` to v0.3.3
  - this fixes `.gomplateignore` and `--exclude` support on Windows
- accepts the fact that `os.Chmod` doesn't really work on Windows (well, it _does_, just not the way it works on UNIX, and not in any useful way for our purposes)
  - docs updated to reflect this
- ignores some tests because Windows has no support for the `TZ` environment variable
- enables a pile of unit tests that now work on Windows (some of which may always have worked)
- enables a pile of integration tests that now work on Windows

Signed-off-by: Dave Henderson <dhenderson@gmail.com>