### PR TITLE
Adding --output-map argument for templating output paths

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -23,6 +23,7 @@ var (
 	opts     gomplate.Config
 )
 
+// nolint: gocyclo
 func validateOpts(cmd *cobra.Command, args []string) error {
 	if cmd.Flag("in").Changed && cmd.Flag("file").Changed {
 		return errors.New("--in and --file may not be used together")
@@ -42,6 +43,15 @@ func validateOpts(cmd *cobra.Command, args []string) error {
 		}
 		if !cmd.Flag("input-dir").Changed {
 			return errors.New("--input-dir must be set when --output-dir is set")
+		}
+	}
+
+	if cmd.Flag("output-map").Changed {
+		if cmd.Flag("out").Changed || cmd.Flag("output-dir").Changed {
+			return errors.New("--output-map can not be used together with --out or --output-dir")
+		}
+		if !cmd.Flag("input-dir").Changed {
+			return errors.New("--input-dir must be set when --output-map is set")
 		}
 	}
 	return nil
@@ -140,6 +150,7 @@ func initFlags(command *cobra.Command) {
 	command.Flags().StringArrayVarP(&opts.OutputFiles, "out", "o", []string{"-"}, "output `file` name. Omit to use standard output.")
 	command.Flags().StringArrayVarP(&opts.Templates, "template", "t", []string{}, "Additional template file(s)")
 	command.Flags().StringVar(&opts.OutputDir, "output-dir", ".", "`directory` to store the processed templates. Only used for --input-dir")
+	command.Flags().StringVar(&opts.OutputMap, "output-map", "", "Template `string` to map the input file to an output path")
 	command.Flags().StringVar(&opts.OutMode, "chmod", "", "set the mode for output file(s). Omit to inherit from input file(s)")
 
 	ldDefault := env.Getenv("GOMPLATE_LEFT_DELIM", "{{")

--- a/cmd/gomplate/main_test.go
+++ b/cmd/gomplate/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateOpts(t *testing.T) {
+	err := validateOpts(parseFlags(), nil)
+	assert.NoError(t, err)
+
+	cmd := parseFlags("-i=foo", "-f", "bar")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("-i=foo", "-o=bar", "-o=baz")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("-i=foo", "--input-dir=baz")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("--input-dir=foo", "-f=bar")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("--output-dir=foo", "-o=bar")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("--output-dir=foo")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("--output-map", "bar")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags("-o", "foo", "--output-map", "bar")
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags(
+		"--input-dir", "in",
+		"--output-dir", "foo",
+		"--output-map", "bar",
+	)
+	err = validateOpts(cmd, nil)
+	assert.Error(t, err)
+
+	cmd = parseFlags(
+		"--input-dir", "in",
+		"--output-map", "bar",
+	)
+	err = validateOpts(cmd, nil)
+	assert.NoError(t, err)
+}
+
+func parseFlags(flags ...string) *cobra.Command {
+	cmd := &cobra.Command{}
+	initFlags(cmd)
+	err := cmd.ParseFlags(flags)
+	if err != nil {
+		panic(err)
+	}
+	return cmd
+}

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	ExcludeGlob []string
 	OutputFiles []string
 	OutputDir   string
+	OutputMap   string
 	OutMode     string
 
 	DataSources       []string
@@ -81,6 +82,8 @@ func (o *Config) String() string {
 	c += "\noutput: "
 	if o.InputDir != "" && o.OutputDir != "." {
 		c += o.OutputDir
+	} else if o.OutputMap != "" {
+		c += o.OutputMap
 	} else {
 		c += strings.Join(o.OutputFiles, ", ")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -15,15 +15,35 @@ output: -`
 	assert.Equal(t, expected, c.String())
 
 	c = &Config{
-		LDelim:      "{{",
-		RDelim:      "}}",
-		Input:       "{{ foo }}",
+		LDelim:      "L",
+		RDelim:      "R",
+		Input:       "foo",
 		OutputFiles: []string{"-"},
 		Templates:   []string{"foo=foo.t", "bar=bar.t"},
 	}
 	expected = `input: <arg>
 output: -
+left_delim: L
+right_delim: R
 templates: foo=foo.t, bar=bar.t`
+
+	assert.Equal(t, expected, c.String())
+
+	c = &Config{
+		InputDir:  "in/",
+		OutputDir: "out/",
+	}
+	expected = `input: in/
+output: out/`
+
+	assert.Equal(t, expected, c.String())
+
+	c = &Config{
+		InputDir:  "in/",
+		OutputMap: "{{ .in }}",
+	}
+	expected = `input: in/
+output: {{ .in }}`
 
 	assert.Equal(t, expected, c.String())
 }

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -237,4 +238,29 @@ func TestParseTemplateArgs(t *testing.T) {
 
 	_, err = parseTemplateArgs([]string{"bogus.t"})
 	assert.Error(t, err)
+}
+
+func TestSimpleNamer(t *testing.T) {
+	n := simpleNamer("out/")
+	out, err := n("file")
+	assert.NoError(t, err)
+	expected := filepath.FromSlash("out/file")
+	assert.Equal(t, expected, out)
+}
+
+func TestMappingNamer(t *testing.T) {
+	g := &gomplate{funcMap: map[string]interface{}{
+		"foo": func() string { return "foo" },
+	}}
+	n := mappingNamer("out/{{ .in }}", g)
+	out, err := n("file")
+	assert.NoError(t, err)
+	expected := filepath.FromSlash("out/file")
+	assert.Equal(t, expected, out)
+
+	n = mappingNamer("out/{{ foo }}{{ .in }}", g)
+	out, err = n("file")
+	assert.NoError(t, err)
+	expected = filepath.FromSlash("out/foofile")
+	assert.Equal(t, expected, out)
 }

--- a/template_test.go
+++ b/template_test.go
@@ -92,13 +92,13 @@ func TestGatherTemplates(t *testing.T) {
 	afero.WriteFile(fs, "in/2", []byte("bar"), 0644)
 	afero.WriteFile(fs, "in/3", []byte("baz"), 0644)
 
-	templates, err := gatherTemplates(&Config{})
+	templates, err := gatherTemplates(&Config{}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, templates, 1)
 
 	templates, err = gatherTemplates(&Config{
 		Input: "foo",
-	})
+	}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, templates, 1)
 	assert.Equal(t, "foo", templates[0].contents)
@@ -107,7 +107,7 @@ func TestGatherTemplates(t *testing.T) {
 	templates, err = gatherTemplates(&Config{
 		Input:       "foo",
 		OutputFiles: []string{"out"},
-	})
+	}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, templates, 1)
 	assert.Equal(t, "out", templates[0].targetPath)
@@ -120,7 +120,7 @@ func TestGatherTemplates(t *testing.T) {
 	templates, err = gatherTemplates(&Config{
 		InputFiles:  []string{"foo"},
 		OutputFiles: []string{"out"},
-	})
+	}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, templates, 1)
 	assert.Equal(t, "bar", templates[0].contents)
@@ -135,7 +135,7 @@ func TestGatherTemplates(t *testing.T) {
 		InputFiles:  []string{"foo"},
 		OutputFiles: []string{"out"},
 		OutMode:     "755",
-	})
+	}, nil)
 	assert.NoError(t, err)
 	assert.Len(t, templates, 1)
 	assert.Equal(t, "bar", templates[0].contents)
@@ -149,7 +149,7 @@ func TestGatherTemplates(t *testing.T) {
 	templates, err = gatherTemplates(&Config{
 		InputDir:  "in",
 		OutputDir: "out",
-	})
+	}, simpleNamer("out"))
 	assert.NoError(t, err)
 	assert.Len(t, templates, 3)
 	assert.Equal(t, "foo", templates[0].contents)

--- a/template_unix_test.go
+++ b/template_unix_test.go
@@ -15,7 +15,7 @@ func TestWalkDir(t *testing.T) {
 	defer func() { fs = origfs }()
 	fs = afero.NewMemMapFs()
 
-	_, err := walkDir("/indir", "/outdir", nil, 0, false)
+	_, err := walkDir("/indir", simpleNamer("/outdir"), nil, 0, false)
 	assert.Error(t, err)
 
 	_ = fs.MkdirAll("/indir/one", 0777)
@@ -24,7 +24,7 @@ func TestWalkDir(t *testing.T) {
 	afero.WriteFile(fs, "/indir/one/bar", []byte("bar"), 0644)
 	afero.WriteFile(fs, "/indir/two/baz", []byte("baz"), 0644)
 
-	templates, err := walkDir("/indir", "/outdir", []string{"*/two"}, 0, false)
+	templates, err := walkDir("/indir", simpleNamer("/outdir"), []string{"*/two"}, 0, false)
 
 	assert.NoError(t, err)
 	expected := []*tplate{

--- a/template_windows_test.go
+++ b/template_windows_test.go
@@ -15,7 +15,7 @@ func TestWalkDir(t *testing.T) {
 	defer func() { fs = origfs }()
 	fs = afero.NewMemMapFs()
 
-	_, err := walkDir(`C:\indir`, `C:\outdir`, nil, 0, false)
+	_, err := walkDir(`C:\indir`, simpleNamer(`C:\outdir`), nil, 0, false)
 	assert.Error(t, err)
 
 	_ = fs.MkdirAll(`C:\indir\one`, 0777)
@@ -24,7 +24,7 @@ func TestWalkDir(t *testing.T) {
 	afero.WriteFile(fs, `C:\indir\one\bar`, []byte("bar"), 0644)
 	afero.WriteFile(fs, `C:\indir\two\baz`, []byte("baz"), 0644)
 
-	templates, err := walkDir(`C:\indir`, `C:\outdir`, []string{`*\two`}, 0, false)
+	templates, err := walkDir(`C:\indir`, simpleNamer(`C:\outdir`), []string{`*\two`}, 0, false)
 
 	assert.NoError(t, err)
 	expected := []*tplate{

--- a/tests/integration/basic_test.go
+++ b/tests/integration/basic_test.go
@@ -140,6 +140,12 @@ func (s *BasicSuite) TestFlagRules(c *C) {
 		ExitCode: 1,
 		Err:      "--output-dir can not be used together with --out",
 	})
+
+	result = icmd.RunCommand(GomplateBin, "--output-map", ".", "--out", "param")
+	result.Assert(c, icmd.Expected{
+		ExitCode: 1,
+		Err:      "--output-map can not be used together with --out or --output-dir",
+	})
 }
 
 func (s *BasicSuite) TestDelimsChangedThroughOpts(c *C) {


### PR DESCRIPTION
Fixes #288 

Adds a new `--output-map` argument, which can be used instead of `--output-dir` to map provide a "mapping template" for choosing what to name each output file.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>