### PR TITLE
Refactor Config

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,113 @@
+package gomplate
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Config - values necessary for rendering templates with gomplate.
+// Mainly for use by the CLI
+type Config struct {
+	Input       string
+	InputFiles  []string
+	InputDir    string
+	ExcludeGlob []string
+	OutputFiles []string
+	OutputDir   string
+	OutMode     string
+
+	DataSources       []string
+	DataSourceHeaders []string
+	Contexts          []string
+
+	LDelim string
+	RDelim string
+
+	Templates []string
+}
+
+// defaults - sets any unset fields to their default value (if applicable)
+func (o *Config) defaults() *Config {
+	if o.OutputDir == "" {
+		o.OutputDir = "."
+	}
+	if o.InputFiles == nil {
+		o.InputFiles = []string{"-"}
+	}
+	if o.OutputFiles == nil {
+		o.OutputFiles = []string{"-"}
+	}
+	if o.LDelim == "" {
+		o.LDelim = "{{"
+	}
+	if o.RDelim == "" {
+		o.RDelim = "}}"
+	}
+	return o
+}
+
+// parse an os.FileMode out of the string, and let us know if it's an override or not...
+func (o *Config) getMode() (os.FileMode, bool, error) {
+	modeOverride := o.OutMode != ""
+	m, err := strconv.ParseUint("0"+o.OutMode, 8, 32)
+	if err != nil {
+		return 0, false, err
+	}
+	mode := os.FileMode(m)
+	if mode == 0 && o.Input != "" {
+		mode = 0644
+	}
+	return mode, modeOverride, nil
+}
+
+// nolint: gocyclo
+func (o *Config) String() string {
+	o.defaults()
+
+	c := "input: "
+	if o.Input != "" {
+		c += "<arg>"
+	} else if o.InputDir != "" {
+		c += o.InputDir
+	} else {
+		c += strings.Join(o.InputFiles, ", ")
+	}
+
+	if len(o.ExcludeGlob) > 0 {
+		c += "\nexclude: " + strings.Join(o.ExcludeGlob, ", ")
+	}
+
+	c += "\noutput: "
+	if o.InputDir != "" && o.OutputDir != "." {
+		c += o.OutputDir
+	} else {
+		c += strings.Join(o.OutputFiles, ", ")
+	}
+
+	if o.OutMode != "" {
+		c += "\nchmod: " + o.OutMode
+	}
+
+	if len(o.DataSources) > 0 {
+		c += "\ndatasources: " + strings.Join(o.DataSources, ", ")
+	}
+	if len(o.DataSourceHeaders) > 0 {
+		c += "\ndatasourceheaders: " + strings.Join(o.DataSourceHeaders, ", ")
+	}
+	if len(o.Contexts) > 0 {
+		c += "\ncontexts: " + strings.Join(o.Contexts, ", ")
+	}
+
+	if o.LDelim != "{{" {
+		c += "\nleft_delim: " + o.LDelim
+	}
+	if o.RDelim != "}}" {
+		c += "\nright_delim: " + o.RDelim
+	}
+
+	if len(o.Templates) > 0 {
+		c += "\ntemplates: " + strings.Join(o.Templates, ", ")
+	}
+	return c
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,53 @@
+package gomplate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigString(t *testing.T) {
+	c := &Config{}
+
+	expected := `input: -
+output: -`
+	assert.Equal(t, expected, c.String())
+
+	c = &Config{
+		LDelim:      "{{",
+		RDelim:      "}}",
+		Input:       "{{ foo }}",
+		OutputFiles: []string{"-"},
+		Templates:   []string{"foo=foo.t", "bar=bar.t"},
+	}
+	expected = `input: <arg>
+output: -
+templates: foo=foo.t, bar=bar.t`
+
+	assert.Equal(t, expected, c.String())
+}
+
+func TestGetMode(t *testing.T) {
+	c := &Config{}
+	m, o, err := c.getMode()
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0), m)
+	assert.False(t, o)
+
+	c = &Config{OutMode: "755"}
+	m, o, err = c.getMode()
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0755), m)
+	assert.True(t, o)
+
+	c = &Config{OutMode: "0755"}
+	m, o, err = c.getMode()
+	assert.NoError(t, err)
+	assert.Equal(t, os.FileMode(0755), m)
+	assert.True(t, o)
+
+	c = &Config{OutMode: "foo"}
+	_, _, err = c.getMode()
+	assert.Error(t, err)
+}

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -165,37 +165,13 @@ func TestRunTemplates(t *testing.T) {
 	defer func() { Stdout = os.Stdout }()
 	buf := &bytes.Buffer{}
 	Stdout = &nopWCloser{buf}
-	config := &Config{Input: "foo"}
+	config := &Config{Input: "foo", OutputFiles: []string{"-"}}
 	err := RunTemplates(config)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", buf.String())
 	assert.Equal(t, 1, Metrics.TemplatesGathered)
 	assert.Equal(t, 1, Metrics.TemplatesProcessed)
 	assert.Equal(t, 0, Metrics.Errors)
-}
-
-func TestConfigString(t *testing.T) {
-	c := &Config{}
-
-	expected := `input: 
-output: 
-left_delim: 
-right_delim: `
-
-	assert.Equal(t, expected, c.String())
-
-	c = &Config{
-		LDelim:      "{{",
-		RDelim:      "}}",
-		Input:       "{{ foo }}",
-		OutputFiles: []string{"-"},
-		Templates:   []string{"foo=foo.t", "bar=bar.t"},
-	}
-	expected = `input: <arg>
-output: -
-templates: foo=foo.t, bar=bar.t`
-
-	assert.Equal(t, expected, c.String())
 }
 
 func TestParseTemplateArg(t *testing.T) {

--- a/template.go
+++ b/template.go
@@ -97,6 +97,7 @@ func (t *tplate) addTarget() (err error) {
 // gatherTemplates - gather and prepare input template(s) and output file(s) for rendering
 // nolint: gocyclo
 func gatherTemplates(o *Config) (templates []*tplate, err error) {
+	o.defaults()
 	mode, modeOverride, err := o.getMode()
 	if err != nil {
 		return nil, err
@@ -104,19 +105,13 @@ func gatherTemplates(o *Config) (templates []*tplate, err error) {
 
 	// the arg-provided input string gets a special name
 	if o.Input != "" {
-		if mode == 0 {
-			mode = 0644
-		}
 		templates = []*tplate{{
 			name:         "<arg>",
 			contents:     o.Input,
 			mode:         mode,
 			modeOverride: modeOverride,
+			targetPath:   o.OutputFiles[0],
 		}}
-
-		if len(o.OutputFiles) == 1 {
-			templates[0].targetPath = o.OutputFiles[0]
-		}
 	}
 
 	// input dirs presume output dirs are set too
@@ -125,7 +120,7 @@ func gatherTemplates(o *Config) (templates []*tplate, err error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if len(o.InputFiles) > 0 && o.Input == "" {
+	} else if o.Input == "" {
 		templates = make([]*tplate, len(o.InputFiles))
 		for i := range o.InputFiles {
 			templates[i], err = fileToTemplates(o.InputFiles[i], o.OutputFiles[i], mode, modeOverride)

--- a/template_test.go
+++ b/template_test.go
@@ -94,7 +94,7 @@ func TestGatherTemplates(t *testing.T) {
 
 	templates, err := gatherTemplates(&Config{})
 	assert.NoError(t, err)
-	assert.Len(t, templates, 0)
+	assert.Len(t, templates, 1)
 
 	templates, err = gatherTemplates(&Config{
 		Input: "foo",


### PR DESCRIPTION
Refactoring the `gomplate.Config` struct, and adding a `defaults()` function that helps bring some sanity to code that uses it (not so much need for protecting against situations which should never happen).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>