### PR TITLE
[WIP] Handle multi-document YAML streams

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -56,7 +56,7 @@ func TestUnmarshalArray(t *testing.T) {
 		assert.EqualValues(t, expected, actual)
 	}
 	test(JSONArray(`["foo","bar",{"baz":{"qux": true},"quux":{"42":18},"corge":{"false":"blah"}}]`))
-	test(YAMLArray(`
+	test(YAMLArray(`---
 - foo
 - bar
 - baz:

--- a/tests/integration/datasources_file_test.go
+++ b/tests/integration/datasources_file_test.go
@@ -39,6 +39,14 @@ FOO.BAR = "values can be double-quoted, and shell\nescapes are supported"
 BAZ = "variable expansion: ${FOO}"
 QUX='single quotes ignore $variables'
 `,
+			"multidoc.yaml": `---
+# empty document
+---
+foo: bar
+---
+foo: baz
+...
+`,
 		}),
 		fs.WithDir("sortorder", fs.WithFiles(map[string]string{
 			"template": `aws_zones = {
@@ -179,4 +187,12 @@ bar`})
   "FOO.BAR": "values can be double-quoted, and shell\nescapes are supported",
   "QUX": "single quotes ignore $variables"
 }`})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"-c=multidoc.yaml",
+		"-i", `{{ .multidoc.foo }}`,
+	), func(c *icmd.Cmd) {
+		c.Dir = s.tmpDir.Path()
+	})
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar"})
 }


### PR DESCRIPTION
_Note: This probably won't work for a while - I just want to park this here so I don't forget about it_ 😉

YAML files (or "streams") can contain multiple documents, where the `---` sequence denotes the start of a document. Currently `gomplate` will only parse the first document in the stream, ignoring others.

Usually this isn't a big deal, because most YAML files only contain one document, but multi-document streams are becoming more common (like with Kubernetes).

Consider:

```yaml
# ignored comment
---
# empty document, but not ignored due to the ---
---
foo: bar
---
foo: baz
```

```console
$ gomplate -c in.yaml -i '{{ .in | toJSON }}'
{}
```

I think the behaviour should be:

- when parsing with `data.YAML` (MIME `application/yaml`), the value should be the first _non-empty_ document
- when parsing with `data.YAMLArray`, the value should be an array of maps (empty ones should be `null`)

```console
$ gomplate -c in.yaml -i '{{ .in | toJSON }}'
{"foo":"bar"}
$ gomplate -d in.yaml -i '{{ include "in" | YAMLArray | toJSON }}'
[null,{"foo":"bar"},{"foo":"baz"}]
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>