### PR TITLE
Removing BuildDate to make build more reproducible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,11 @@ CMD [ "/bin/gomplate_linux-amd64" ]
 
 FROM scratch AS gomplate
 
-ARG BUILD_DATE
 ARG VCS_REF
 ARG OS=linux
 ARG ARCH=amd64
 
-LABEL org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.revision=$VCS_REF \
+LABEL org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.source="https://github.com/hairyhenderson/gomplate"
 
 COPY --from=artifacts /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -41,13 +39,11 @@ ENTRYPOINT [ "/gomplate" ]
 
 FROM alpine:3.9 AS gomplate-alpine
 
-ARG BUILD_DATE
 ARG VCS_REF
 ARG OS=linux
 ARG ARCH=amd64
 
-LABEL org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.revision=$VCS_REF \
+LABEL org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.source="https://github.com/hairyhenderson/gomplate"
 
 RUN apk add --no-cache ca-certificates
@@ -57,13 +53,11 @@ ENTRYPOINT [ "/bin/gomplate" ]
 
 FROM scratch AS gomplate-slim
 
-ARG BUILD_DATE
 ARG VCS_REF
 ARG OS=linux
 ARG ARCH=amd64
 
-LABEL org.opencontainers.image.created=$BUILD_DATE \
-      org.opencontainers.image.revision=$VCS_REF \
+LABEL org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.source="https://github.com/hairyhenderson/gomplate"
 
 COPY --from=artifacts /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,9 @@ endif
 
 COMMIT ?= `git rev-parse --short HEAD 2>/dev/null`
 VERSION ?= `git describe --abbrev=0 --tags $(git rev-list --tags --max-count=1) 2>/dev/null | sed 's/v\(.*\)/\1/'`
-BUILD_DATE ?= `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 COMMIT_FLAG := -X `go list ./version`.GitCommit=$(COMMIT)
 VERSION_FLAG := -X `go list ./version`.Version=$(VERSION)
-BUILD_DATE_FLAG := -X `go list ./version`.BuildDate=$(BUILD_DATE)
 
 GOOS ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\1/')
 GOARCH ?= $(shell go version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\2/')
@@ -54,7 +52,6 @@ compress: $(PREFIX)/bin/$(PKG_NAME)_$(GOOS)-$(GOARCH)-slim$(call extension,$(GOO
 
 %.iid: Dockerfile
 	@docker build \
-		--build-arg BUILD_DATE=$(BUILD_DATE) \
 		--build-arg VCS_REF=$(COMMIT) \
 		--target $(subst .iid,,$@) \
 		--iidfile $@ \
@@ -71,7 +68,7 @@ docker-images: gomplate.iid gomplate-slim.iid
 $(PREFIX)/bin/$(PKG_NAME)_%: $(shell find $(PREFIX) -type f -name "*.go")
 	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- | cut -f1 -d.) CGO_ENABLED=0 \
 		$(GO) build \
-			-ldflags "-w -s $(COMMIT_FLAG) $(VERSION_FLAG) $(BUILD_DATE_FLAG)" \
+			-ldflags "-w -s $(COMMIT_FLAG) $(VERSION_FLAG)" \
 			-o $@ \
 			./cmd/gomplate
 

--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -110,8 +110,8 @@ func newGomplateCmd() *cobra.Command {
 			}
 			if verbose {
 				// nolint: errcheck
-				fmt.Fprintf(os.Stderr, "%s version %s, build %s (%v)\nconfig is:\n%s\n\n",
-					cmd.Name(), version.Version, version.GitCommit, version.BuildDate,
+				fmt.Fprintf(os.Stderr, "%s version %s, build %s\nconfig is:\n%s\n\n",
+					cmd.Name(), version.Version, version.GitCommit,
 					&opts)
 			}
 

--- a/hooks/build
+++ b/hooks/build
@@ -4,7 +4,6 @@ set -exuo pipefail
 docker version
 
 echo "======== Build hook running"
-export BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 export VCS_REF=`git rev-parse --short HEAD`
 export DOCKER_REPO=${DOCKER_REPO:-hairyhenderson/gomplate}
 export DOCKER_TAG=${DOCKER_TAG:-latest}
@@ -14,8 +13,7 @@ docker build --target artifacts \
              -t ${DOCKER_REPO}:artifacts .
 
 echo "======== Building $IMAGE_NAME"
-docker build --build-arg BUILD_DATE \
-             --build-arg VCS_REF \
+docker build --build-arg VCS_REF \
              --target gomplate \
              -t ${IMAGE_NAME} .
 
@@ -25,8 +23,7 @@ else
   export SLIM_TAG="${DOCKER_TAG}-slim"
 fi
 echo "======== Building ${DOCKER_REPO}:${SLIM_TAG}"
-docker build --build-arg BUILD_DATE \
-             --build-arg VCS_REF \
+docker build --build-arg VCS_REF \
              --target gomplate-slim \
              -t ${DOCKER_REPO}:${SLIM_TAG} .
 
@@ -36,7 +33,6 @@ else
   export ALPINE_TAG="${DOCKER_TAG}-alpine"
 fi
 echo "======== Building ${DOCKER_REPO}:${ALPINE_TAG}"
-docker build --build-arg BUILD_DATE \
-             --build-arg VCS_REF \
+docker build --build-arg VCS_REF \
              --target gomplate-alpine \
              -t ${DOCKER_REPO}:${ALPINE_TAG} .

--- a/version/version.go
+++ b/version/version.go
@@ -5,6 +5,9 @@ var (
 	Version = "0.0.0"
 	// GitCommit will be overwritten automatically by the build
 	GitCommit = "HEAD"
-	// BuildDate will be overwritten automatically by the build
+
+	// BuildDate -
+	//
+	// Deprecated: this is no longer used. Any external references must be removed
 	BuildDate = ""
 )


### PR DESCRIPTION
This makes the build _slightly_ more reproducible (see https://reproducible-builds.org/docs/timestamps/).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>