### PR TITLE
Implement shell-compatible quoting

### DIFF
--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -252,6 +252,24 @@ funcs:
       - |
         $ echo 'Rock & Roll @ Cafe Wha?' | gomplate -d in=stdin: -i '{{ strings.Slug (include "in") }}'
         rock-and-roll-at-cafe-wha
+  - name: strings.ShellQuote
+    alias: shellQuote
+    description: |
+      Given a string, emits a version of that string that will evaluate to its literal data when expanded by any POSIX-compliant shell.
+
+      Given an array or slice, emit a single string which will evaluate to a series of shell words, one per item in that array or slice.
+    pipeline: true
+    arguments:
+      - name: in
+        required: true
+        description: The input to quote
+    examples:
+      - |
+        $ gomplate -i "{{ slice \"one word\" \"foo='bar baz'\" | shellQuote }}"
+        'one word' 'foo='"'"'bar baz'"'"''
+      - |
+        $ gomplate -i "{{ strings.ShellQuote \"it's a banana\" }}"
+        'it'"'"'s a banana'
   - name: strings.Squote
     alias: squote
     description: |

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -397,6 +397,40 @@ $ echo 'Rock & Roll @ Cafe Wha?' | gomplate -d in=stdin: -i '{{ strings.Slug (in
 rock-and-roll-at-cafe-wha
 ```
 
+## `strings.ShellQuote`
+
+**Alias:** `shellQuote`
+
+Given a string, emits a version of that string that will evaluate to its literal data when expanded by any POSIX-compliant shell.
+
+Given an array or slice, emit a single string which will evaluate to a series of shell words, one per item in that array or slice.
+
+### Usage
+
+```go
+strings.ShellQuote in
+```
+```go
+in | strings.ShellQuote
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `in` | _(required)_ The input to quote |
+
+### Examples
+
+```console
+$ gomplate -i "{{ slice \"one word\" \"foo='bar baz'\" | shellQuote }}"
+'one word' 'foo='"'"'bar baz'"'"''
+```
+```console
+$ gomplate -i "{{ strings.ShellQuote \"it's a banana\" }}"
+'it'"'"'s a banana'
+```
+
 ## `strings.Squote`
 
 **Alias:** `squote`

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -221,26 +221,22 @@ func (f *StringFuncs) Quote(in interface{}) string {
 	return fmt.Sprintf("%q", conv.ToString(in))
 }
 
-func shellQuote(s string) string {
-	return "'" + strings.Replace(s, "'", "'\"'\"'", -1) + "'"
-}
-
 // ShellQuote -
 func (f *StringFuncs) ShellQuote(in interface{}) string {
 	val := reflect.ValueOf(in)
-	var sb strings.Builder
 	switch val.Kind() {
 	case reflect.Array, reflect.Slice:
+		var sb strings.Builder
 		max := val.Len()
 		for n := 0; n < max; n++ {
-			sb.WriteString(shellQuote(conv.ToString(val.Index(n))))
+			sb.WriteString(gompstrings.ShellQuote(conv.ToString(val.Index(n))))
 			if n+1 != max {
 				sb.WriteRune(' ')
 			}
 		}
 		return sb.String()
 	}
-	return shellQuote(conv.ToString(in))
+	return gompstrings.ShellQuote(conv.ToString(in))
 }
 
 // Squote -

--- a/funcs/strings_test.go
+++ b/funcs/strings_test.go
@@ -126,6 +126,31 @@ func TestQuote(t *testing.T) {
 	}
 }
 
+func TestShellQuote(t *testing.T) {
+	sf := &StringFuncs{}
+	testdata := []struct {
+		in  interface{}
+		out string
+	}{
+		// conventional cases
+		{``, `''`},
+		{`foo`, `'foo'`},
+		{nil, `'nil'`},
+		{123.4, `'123.4'`},
+		{`hello "world"`, `'hello "world"'`},
+		{`it's its`, `'it'"'"'s its'`},
+		// array and slice cases
+		{[]string{}, ``},
+		{[]string{"", ""}, `'' ''`},
+		{[...]string{"one'two", "three four"}, `'one'"'"'two' 'three four'`},
+		{[]string{"one'two", "three four"}, `'one'"'"'two' 'three four'`},
+	}
+
+	for _, d := range testdata {
+		assert.Equal(t, d.out, sf.ShellQuote(d.in))
+	}
+}
+
 func TestSquote(t *testing.T) {
 	sf := &StringFuncs{}
 	testdata := []struct {

--- a/funcs/strings_test.go
+++ b/funcs/strings_test.go
@@ -132,13 +132,10 @@ func TestShellQuote(t *testing.T) {
 		in  interface{}
 		out string
 	}{
-		// conventional cases
-		{``, `''`},
-		{`foo`, `'foo'`},
+		// conventional cases are covered in gompstrings.ShellQuote() tests
+		// we cover only cases that require type conversion or array/slice combining here
 		{nil, `'nil'`},
 		{123.4, `'123.4'`},
-		{`hello "world"`, `'hello "world"'`},
-		{`it's its`, `'it'"'"'s its'`},
 		// array and slice cases
 		{[]string{}, ``},
 		{[]string{"", ""}, `'' ''`},

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -30,6 +30,11 @@ func Indent(width int, indent, s string) string {
 	return string(res)
 }
 
+// ShellQuote - generate a POSIX shell literal evaluating to a string
+func ShellQuote(s string) string {
+	return "'" + strings.Replace(s, "'", "'\"'\"'", -1) + "'"
+}
+
 // Trunc - truncate a string to the given length
 func Trunc(length int, s string) string {
 	if length < 0 {

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -27,6 +27,13 @@ func TestTrunc(t *testing.T) {
 	assert.Equal(t, "hello, world", Trunc(-1, "hello, world"))
 }
 
+func TestShellQuote(t *testing.T) {
+	assert.Equal(t, `''`, ShellQuote(``))
+	assert.Equal(t, `'foo'`, ShellQuote(`foo`))
+	assert.Equal(t, `'hello "world"'`, ShellQuote(`hello "world"`))
+	assert.Equal(t, `'it'"'"'s its'`, ShellQuote(`it's its`))
+}
+
 func TestSort(t *testing.T) {
 	in := []string{}
 	expected := []string{}


### PR DESCRIPTION
As discussed in #584. Ended up implementing inline as I don't trust the regex-based approach to deciding which strings need to be quoted to be safe for all possible extended shells.