### PR TITLE
Fix parsing of media types with + character

### DIFF
--- a/data/datasource.go
+++ b/data/datasource.go
@@ -163,6 +163,8 @@ func (s *Source) mimeType() (mimeType string, err error) {
 	if mediatype == "" {
 		mediatype = s.mediaType
 	}
+	// make it so + doesn't need to be escaped
+	mediatype = strings.ReplaceAll(mediatype, " ", "+")
 	if mediatype == "" {
 		ext := filepath.Ext(s.URL.Path)
 		mediatype = mime.TypeByExtension(ext)
@@ -171,7 +173,7 @@ func (s *Source) mimeType() (mimeType string, err error) {
 	if mediatype != "" {
 		t, _, err := mime.ParseMediaType(mediatype)
 		if err != nil {
-			return "", err
+			return "", errors.Wrapf(err, "MIME type was %q", mediatype)
 		}
 		mediatype = t
 		return mediatype, nil

--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -325,6 +325,25 @@ func TestMimeType(t *testing.T) {
 	mt, err = s.mimeType()
 	assert.NoError(t, err)
 	assert.Equal(t, "application/yaml", mt)
+
+	s = &Source{URL: mustParseURL("http://example.com/list?type=application/array%2Bjson"), mediaType: "text/foo"}
+	mt, err = s.mimeType()
+	assert.NoError(t, err)
+	assert.Equal(t, "application/array+json", mt)
+
+	s = &Source{URL: mustParseURL("http://example.com/list?type=application/array+json")}
+	mt, err = s.mimeType()
+	assert.NoError(t, err)
+	assert.Equal(t, "application/array+json", mt)
+
+	s = &Source{URL: mustParseURL("http://example.com/list?type=a/b/c")}
+	_, err = s.mimeType()
+	assert.Error(t, err)
+
+	s = &Source{URL: mustParseURL("http://example.com/unknown")}
+	mt, err = s.mimeType()
+	assert.NoError(t, err)
+	assert.Equal(t, "text/plain", mt)
 }
 
 func TestQueryParse(t *testing.T) {


### PR DESCRIPTION
Fixing a paper cut I've been meaning to for a while 😂

Some composite MIME types can have `+`s in them, for example `application/array+json`. So when overriding in the URL with the `type` param, you get `http://example.com/list?type=application/array+json`, and the `+` character decodes to ` ` (space).

This breaks mime parsing, so I'm fixing it to assume the ` ` can get replaced with a `+`. An encoded `+` (`%2B`) always worked - that's what I've used until now.

Also improving error handling so MIME parsing failures are a bit more obvious. And more tests!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>