### PR TITLE
Plugins for custom functions

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -160,6 +160,8 @@ func initFlags(command *cobra.Command) {
 
 	command.Flags().StringArrayVarP(&opts.Contexts, "context", "c", nil, "pre-load a `datasource` into the context, in alias=URL form. Use the special alias `.` to set the root context.")
 
+	command.Flags().StringArrayVar(&opts.Plugins, "plugin", nil, "plug in an external command as a function in name=path form. Can be specified multiple times")
+
 	command.Flags().StringArrayVarP(&opts.InputFiles, "file", "f", []string{"-"}, "Template `file` to process. Omit to use standard input, or use --in or --input-dir")
 	command.Flags().StringVarP(&opts.Input, "in", "i", "", "Template `string` to process (alternative to --file and --input-dir)")
 	command.Flags().StringVar(&opts.InputDir, "input-dir", "", "`directory` which is examined recursively for templates (alternative to --file and --in)")

--- a/config.go
+++ b/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	DataSourceHeaders []string
 	Contexts          []string
 
+	Plugins []string
+
 	LDelim string
 	RDelim string
 
@@ -102,6 +104,10 @@ func (o *Config) String() string {
 	}
 	if len(o.Contexts) > 0 {
 		c += "\ncontexts: " + strings.Join(o.Contexts, ", ")
+	}
+
+	if len(o.Plugins) > 0 {
+		c += "\nplugins: " + strings.Join(o.Plugins, ", ")
 	}
 
 	if o.LDelim != "{{" {

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -207,6 +207,31 @@ A few different forms are valid:
     here are the contents of the template: [ hello, world! ]
     ```
 
+### `--plugin`
+
+Some specialized use cases may need functionality that gomplate isn't capable
+of on its own. If you have a command or script to perform this functionality,
+you can plug in your own custom functions with the `--plugin` flag:
+
+```console
+$ gomplate --plugin echo=/bin/echo -i 'Hello {{ echo "World" }}'
+Hello World
+```
+
+All arguments provided to the function will be passed through to the plugin, and
+the plugin's standard output stream will be printed to the rendered output.
+
+If the plugin exits with a non-zero exit code, gomplate will also fail. All signals
+caught by gomplate will be passed through to the plugin. Any output on the standard
+error stream will be printed to gomplate's standard error stream.
+
+Plugins can also be written as PowerShell or CMD scripts (`.ps1`, `.bat`, or `.cmd`
+extensions) on Windows.
+
+By default, plugins will time out after 5 seconds. To adjust this, set the
+`GOMPLATE_PLUGIN_TIMEOUT` environment variable to a valid [duration](../functions/time/#time-parseduration)
+such as `10s` or `3m`.
+
 ## Post-template command execution
 
 Gomplate can launch other commands when template execution is successful. Simply

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,7 @@ github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.17.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.19.45/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.25.11 h1:wUivbsVOH3LpHdC3Rl5i+FLHfg4sOmYgv4bvHe7+/Pg=
-github.com/aws/aws-sdk-go v1.25.11/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.16 h1:k7Fy6T/uNuLX6zuayU/TJoP7yMgGcJSkZpF7QVjwYpA=
 github.com/aws/aws-sdk-go v1.25.16/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/gomplate.go
+++ b/gomplate.go
@@ -49,11 +49,11 @@ func (g *gomplate) runTemplate(t *tplate) error {
 type templateAliases map[string]string
 
 // newGomplate -
-func newGomplate(d *data.Data, leftDelim, rightDelim string, nested templateAliases, context interface{}) *gomplate {
+func newGomplate(funcMap template.FuncMap, leftDelim, rightDelim string, nested templateAliases, context interface{}) *gomplate {
 	return &gomplate{
 		leftDelim:       leftDelim,
 		rightDelim:      rightDelim,
-		funcMap:         Funcs(d),
+		funcMap:         funcMap,
 		nestedTemplates: nested,
 		context:         context,
 	}
@@ -126,7 +126,12 @@ func RunTemplates(o *Config) error {
 	if err != nil {
 		return err
 	}
-	g := newGomplate(d, o.LDelim, o.RDelim, nested, c)
+	funcMap := Funcs(d)
+	err = bindPlugins(o.Plugins, funcMap)
+	if err != nil {
+		return err
+	}
+	g := newGomplate(funcMap, o.LDelim, o.RDelim, nested, c)
 
 	return g.runTemplates(o)
 }

--- a/plugins.go
+++ b/plugins.go
@@ -1,0 +1,121 @@
+package gomplate
+
+import (
+	"bytes"
+	gcontext "context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/env"
+)
+
+func bindPlugins(plugins []string, funcMap template.FuncMap) error {
+	for _, p := range plugins {
+		plugin, err := newPlugin(p)
+		if err != nil {
+			return err
+		}
+		if _, ok := funcMap[plugin.name]; ok {
+			return fmt.Errorf("function %q is already bound, and can not be overridden", plugin.name)
+		}
+		funcMap[plugin.name] = plugin.run
+	}
+	return nil
+}
+
+// plugin represents a custom function that binds to an external process to be executed
+type plugin struct {
+	name, path string
+}
+
+func newPlugin(value string) (*plugin, error) {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) < 2 {
+		return nil, errors.New("plugin requires both name and path")
+	}
+
+	p := &plugin{
+		name: parts[0],
+		path: parts[1],
+	}
+	return p, nil
+}
+
+// builds a command that's appropriate for running scripts
+// nolint: gosec
+func (p *plugin) buildCommand(a []string) (name string, args []string) {
+	switch filepath.Ext(p.path) {
+	case ".ps1":
+		a = append([]string{"-File", p.path}, a...)
+		return findPowershell(), a
+	case ".cmd", ".bat":
+		a = append([]string{"/c", p.path}, a...)
+		return "cmd.exe", a
+	default:
+		return p.path, a
+	}
+}
+
+// finds the appropriate powershell command for the platform - prefers
+// PowerShell Core (`pwsh`), but on Windows if it's not found falls back to
+// Windows PowerShell (`powershell`).
+func findPowershell() string {
+	if runtime.GOOS != "windows" {
+		return "pwsh"
+	}
+
+	_, err := exec.LookPath("pwsh")
+	if err != nil {
+		return "powershell"
+	}
+	return "pwsh"
+}
+
+func (p *plugin) run(args ...interface{}) (interface{}, error) {
+	a := conv.ToStrings(args...)
+
+	name, a := p.buildCommand(a)
+
+	t, err := time.ParseDuration(env.Getenv("GOMPLATE_PLUGIN_TIMEOUT", "5s"))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := gcontext.WithTimeout(gcontext.Background(), t)
+	defer cancel()
+	c := exec.CommandContext(ctx, name, a...)
+	c.Stdin = nil
+	c.Stderr = os.Stderr
+	outBuf := &bytes.Buffer{}
+	c.Stdout = outBuf
+
+	// make sure all signals are propagated
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs)
+	go func() {
+		// Pass signals to the sub-process
+		sig := <-sigs
+		if c.Process != nil {
+			// nolint: gosec
+			_ = c.Process.Signal(sig)
+		}
+	}()
+	start := time.Now()
+	err = c.Run()
+	elapsed := time.Since(start)
+
+	if ctx.Err() != nil {
+		err = fmt.Errorf("plugin timed out after %v: %w", elapsed, ctx.Err())
+	}
+
+	return outBuf.String(), err
+}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,0 +1,58 @@
+package gomplate
+
+import (
+	"testing"
+	"text/template"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestNewPlugin(t *testing.T) {
+	in := "foo"
+	_, err := newPlugin(in)
+	assert.ErrorContains(t, err, "")
+
+	in = "foo=/bin/bar"
+	out, err := newPlugin(in)
+	assert.NilError(t, err)
+	assert.Equal(t, "foo", out.name)
+	assert.Equal(t, "/bin/bar", out.path)
+}
+
+func TestBindPlugins(t *testing.T) {
+	fm := template.FuncMap{}
+	in := []string{}
+	err := bindPlugins(in, fm)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, template.FuncMap{}, fm)
+
+	in = []string{"foo=bar"}
+	err = bindPlugins(in, fm)
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Contains(fm, "foo"))
+
+	err = bindPlugins(in, fm)
+	assert.ErrorContains(t, err, "already bound")
+}
+
+func TestBuildCommand(t *testing.T) {
+	data := []struct {
+		plugin   string
+		args     []string
+		expected []string
+	}{
+		{"foo=foo", nil, []string{"foo"}},
+		{"foo=foo", []string{"bar"}, []string{"foo", "bar"}},
+		{"foo=foo.bat", nil, []string{"cmd.exe", "/c", "foo.bat"}},
+		{"foo=foo.cmd", []string{"bar"}, []string{"cmd.exe", "/c", "foo.cmd", "bar"}},
+		{"foo=foo.ps1", []string{"bar", "baz"}, []string{"pwsh", "-File", "foo.ps1", "bar", "baz"}},
+	}
+	for _, d := range data {
+		p, err := newPlugin(d.plugin)
+		assert.NilError(t, err)
+		name, args := p.buildCommand(d.args)
+		actual := append([]string{name}, args...)
+		assert.DeepEqual(t, d.expected, actual)
+	}
+}

--- a/tests/integration/plugins_test.go
+++ b/tests/integration/plugins_test.go
@@ -1,0 +1,90 @@
+//+build integration
+//+build !windows
+
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+type PluginsSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&PluginsSuite{})
+
+func (s *PluginsSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("foo.sh", "#!/bin/sh\n\necho $*\n", fs.WithMode(0755)),
+		fs.WithFile("foo.ps1", "echo $args\r\n", fs.WithMode(0755)),
+		fs.WithFile("bar.sh", "#!/bin/sh\n\neval \"echo $*\"\n", fs.WithMode(0755)),
+		fs.WithFile("fail.sh", "#!/bin/sh\n\n>&2 echo $1\nexit $2\n", fs.WithMode(0755)),
+		fs.WithFile("fail.ps1", `param (
+	[Parameter(Position=0)]
+	[string]$msg,
+
+	[Parameter(Position=1)]
+	[int]$code
+)
+write-error $msg
+exit $code
+`, fs.WithMode(0755)),
+		fs.WithFile("sleep.sh", "#!/bin/sh\n\nexec sleep $1\n", fs.WithMode(0755)),
+	)
+}
+
+func (s *PluginsSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *PluginsSuite) TestPlugins(c *C) {
+	result := icmd.RunCommand(GomplateBin,
+		"--plugin", "hi="+s.tmpDir.Join("foo.sh"),
+		"-i", `{{ hi "hello world" }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "echo="+s.tmpDir.Join("bar.sh"),
+		"-i", `{{ echo "$HELLO" }}`,
+	), func(c *icmd.Cmd) {
+		c.Env = []string{
+			"HELLO=hello world",
+		}
+	})
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
+}
+
+func (s *PluginsSuite) TestPluginErrors(c *C) {
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "f=false",
+		"-i", `{{ f }}`,
+	), func(c *icmd.Cmd) {})
+	result.Assert(c, icmd.Expected{ExitCode: 1})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "f="+s.tmpDir.Join("fail.sh"),
+		"-i", `{{ f "all is lost" 5 }}`,
+	), func(c *icmd.Cmd) {})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "all is lost"})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "error calling f: exit status 5"})
+}
+
+func (s *PluginsSuite) TestPluginTimeout(c *C) {
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "sleep="+s.tmpDir.Join("sleep.sh"),
+		"-i", `{{ sleep 10 }}`,
+	), func(c *icmd.Cmd) {})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "plugin timed out"})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "sleep="+s.tmpDir.Join("sleep.sh"),
+		"-i", `{{ sleep 2 }}`,
+	), func(c *icmd.Cmd) {
+		c.Env = []string{"GOMPLATE_PLUGIN_TIMEOUT=500ms"}
+	})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "plugin timed out"})
+}

--- a/tests/integration/plugins_windows_test.go
+++ b/tests/integration/plugins_windows_test.go
@@ -1,0 +1,65 @@
+//+build integration
+//+build windows
+
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+type PluginsSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&PluginsSuite{})
+
+func (s *PluginsSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("foo.ps1", "echo $args\r\nexit 0\r\n", fs.WithMode(0644)),
+		fs.WithFile("foo.bat", "@ECHO OFF\r\nECHO %1\r\n", fs.WithMode(0644)),
+		fs.WithFile("fail.bat", `@ECHO OFF
+ECHO %1 1>&2
+EXIT /B %2
+`, fs.WithMode(0755)),
+		fs.WithFile("fail.ps1", `param (
+       [Parameter(Position=0)]
+       [string]$msg,
+
+       [Parameter(Position=1)]
+       [int]$code
+)
+$host.ui.WriteErrorLine($msg)
+$host.SetShouldExit($code)
+`, fs.WithMode(0755)),
+	)
+}
+
+func (s *PluginsSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *PluginsSuite) TestPlugins(c *C) {
+	result := icmd.RunCommand(GomplateBin,
+		"--plugin", "foo="+s.tmpDir.Join("foo.bat"),
+		"-i", `{{ foo "hello world" }}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
+}
+
+func (s *PluginsSuite) TestPluginErrors(c *C) {
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "f=false",
+		"-i", `{{ f }}`,
+	), func(c *icmd.Cmd) {})
+	result.Assert(c, icmd.Expected{ExitCode: 1})
+
+	result = icmd.RunCmd(icmd.Command(GomplateBin,
+		"--plugin", "f="+s.tmpDir.Join("fail.bat"),
+		"-i", `{{ f "bat failed" 42 }}`,
+	), func(c *icmd.Cmd) {})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "bat failed"})
+	result.Assert(c, icmd.Expected{ExitCode: 1, Err: "error calling f: exit status 42"})
+}


### PR DESCRIPTION
Fixes #580 

Implements a new `--plugin` command line flag. It's a pretty straightforward feature - just adds new functions on the command line that will cause external processes to be run. Stdout is rendered 
into the template, and Stderr is passed through to the main Stderr. Arguments are passed through as positional args to the given process.

Scripts are also supported on all OSes, including Powershell (`.ps1`) and CMD (`.cmd` and `.bat`) scripts (on Windows), where the `powershell` or `pwsh` or `cmd.exe` command will be used.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>