### PR TITLE
Placed a newline before the start of a list

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -127,6 +127,7 @@ Data sources referenced in this way are lazy-loaded: they will not be read until
 See [Datasources](../datasources) for full details.
 
 A few different forms are valid:
+
 - `mydata=file:///tmp/my/file.json`
   - Create a data source named `mydata` which is read from `/tmp/my/file.json`. This form is valid for any file in any path.
 - `mydata=file.json`

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -169,6 +169,7 @@ A few different forms are valid:
 - `--template mytemplate.t`
   - References a file `mytemplate.t` in the current working directory.
   - It will be available as a template named `mytemplate.t`:
+
     ```console
     $ gomplate --template helloworld.tmpl -i 'here are the contents of the template: [ {{ template "helloworld.tmpl" }} ]'
     here are the contents of the template: [ hello, world! ]
@@ -176,6 +177,7 @@ A few different forms are valid:
 - `--template path/to/mytemplate.t`
   - References a file `mytemplate.t` in the path `path/to/`.
   - It will be available as a template named `path/to/mytemplate.t`:
+
     ```console
     $ gomplate --template foo/bar/helloworld.tmpl -i 'here are the contents of the template: [ {{ template "foo/bar/helloworld.tmpl" }} ]'
     here are the contents of the template: [ hello, world! ]
@@ -183,6 +185,7 @@ A few different forms are valid:
 - `--template path/to/`
   - Makes available all files in the path `path/to/`.
   - Any files within this path can be referenced:
+
     ```console
     $ gomplate --template foo/bar/ -i 'here are the contents of the template: [ {{ template "foo/bar/helloworld.tmpl" }} ]'
     here are the contents of the template: [ hello, world! ]
@@ -190,6 +193,7 @@ A few different forms are valid:
 - `--template alias=path/to/mytemplate.t`
   - References a file `mytemplate.t` in the path `path/to/`
   - It will be available as a template named `alias`:
+
     ```console
     $ gomplate --template t=foo/bar/helloworld.tmpl -i 'here are the contents of the template: [ {{ template "t" }} ]'
     here are the contents of the template: [ hello, world! ]
@@ -197,6 +201,7 @@ A few different forms are valid:
 - `--template alias=path/to/`
   - Makes available all files in the path `path/to/`.
   - Any files within this path can be referenced, with the path replaced with `alias`:
+
     ```console
     $ gomplate --template dir=foo/bar/ -i 'here are the contents of the template: [ {{ template "dir/helloworld.tmpl" }} ]'
     here are the contents of the template: [ hello, world! ]


### PR DESCRIPTION
Placed a (missing) newline before the start of a list so it renders the list good.

Currently shown as:
![Screenshot 2019-10-20 at 16 24 44](https://user-images.githubusercontent.com/2445415/67160958-309f6400-f356-11e9-9b5c-8fe94e1f0fbe.png)
