### PR TITLE
New --exec-pipe output option

### DIFF
--- a/cmd/gomplate/validate.go
+++ b/cmd/gomplate/validate.go
@@ -47,6 +47,10 @@ func validateOpts(cmd *cobra.Command, args []string) (err error) {
 		err = fmt.Errorf("must provide same number of --out (%d) as --file (%d) options", len(opts.OutputFiles), len(opts.InputFiles))
 	}
 
+	if err == nil && cmd.Flag("exec-pipe").Changed && len(args) == 0 {
+		err = fmt.Errorf("--exec-pipe may only be used with a post-exec command after --")
+	}
+
 	if err == nil {
 		err = mustTogether(cmd, "output-dir", "input-dir")
 	}

--- a/cmd/gomplate/validate_test.go
+++ b/cmd/gomplate/validate_test.go
@@ -42,6 +42,41 @@ func TestValidateOpts(t *testing.T) {
 	))
 	assert.Error(t, err)
 
+	err = validateOpts(parseFlags("--exec-pipe"))
+	assert.Error(t, err)
+
+	err = validateOpts(parseFlags("--exec-pipe", "--"))
+	assert.Error(t, err)
+
+	err = validateOpts(parseFlags(
+		"--exec-pipe",
+		"--", "echo", "foo",
+	))
+	assert.NoError(t, err)
+
+	err = validateOpts(parseFlags(
+		"--exec-pipe",
+		"--out", "foo",
+		"--", "echo",
+	))
+	assert.Error(t, err)
+
+	err = validateOpts(parseFlags(
+		"--input-dir", "in",
+		"--exec-pipe",
+		"--output-dir", "foo",
+		"--", "echo",
+	))
+	assert.Error(t, err)
+
+	err = validateOpts(parseFlags(
+		"--input-dir", "in",
+		"--exec-pipe",
+		"--output-map", "foo",
+		"--", "echo",
+	))
+	assert.Error(t, err)
+
 	err = validateOpts(parseFlags(
 		"--input-dir", "in",
 		"--output-map", "bar",

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package gomplate
 
 import (
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ type Config struct {
 	OutputDir   string
 	OutputMap   string
 	OutMode     string
+	Out         io.Writer
 
 	DataSources       []string
 	DataSourceHeaders []string

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -232,6 +232,21 @@ By default, plugins will time out after 5 seconds. To adjust this, set the
 `GOMPLATE_PLUGIN_TIMEOUT` environment variable to a valid [duration](../functions/time/#time-parseduration)
 such as `10s` or `3m`.
 
+### `--exec-pipe`
+
+When using [post-template command execution](#post-template-command-execution),
+it may be useful to pipe gomplate's rendered output directly into the command's
+standard input.
+
+To do this, simply use `--exec-pipe` instead of `--out` or any other output flag:
+
+```console
+$ gomplate -i 'hello world' --exec-pipe -- tr a-z A-Z
+HELLO WORLD
+```
+
+Note that multiple inputs are not yet supported when using this option.
+
 ## Post-template command execution
 
 Gomplate can launch other commands when template execution is successful. Simply
@@ -241,6 +256,9 @@ add the command to the command-line after a `--` argument:
 $ gomplate -i 'hello world' -o out.txt -- cat out.txt
 hello world
 ```
+
+See also [`--exec-pipe`](#exec-pipe) for piping output directly into the
+post-exec command.
 
 ## Suppressing empty output
 

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -2,7 +2,6 @@ package gomplate
 
 import (
 	"bytes"
-	"io"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -18,15 +17,6 @@ import (
 	"github.com/hairyhenderson/gomplate/env"
 	"github.com/stretchr/testify/assert"
 )
-
-// like ioutil.NopCloser(), except for io.WriteClosers...
-type nopWCloser struct {
-	io.Writer
-}
-
-func (n *nopWCloser) Close() error {
-	return nil
-}
 
 func testTemplate(g *gomplate, tmpl string) string {
 	var out bytes.Buffer

--- a/template.go
+++ b/template.go
@@ -103,6 +103,11 @@ func gatherTemplates(o *Config, outFileNamer func(string) (string, error)) (temp
 		return nil, err
 	}
 
+	// --exec-pipe redirects standard out to the out pipe
+	if o.Out != nil {
+		Stdout = &nopWCloser{o.Out}
+	}
+
 	switch {
 	// the arg-provided input string gets a special name
 	case o.Input != "":
@@ -335,4 +340,13 @@ func allWhitespace(p []byte) bool {
 		return false
 	}
 	return true
+}
+
+// like ioutil.NopCloser(), except for io.WriteClosers...
+type nopWCloser struct {
+	io.Writer
+}
+
+func (n *nopWCloser) Close() error {
+	return nil
 }

--- a/tests/integration/basic_test.go
+++ b/tests/integration/basic_test.go
@@ -184,6 +184,17 @@ func (s *BasicSuite) TestExecCommand(c *C) {
 	})
 }
 
+func (s *BasicSuite) TestPostRunExecPipe(c *C) {
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"-i", `{{print "hello world"}}`,
+		"--exec-pipe",
+		"--", "tr", "a-z", "A-Z"))
+	result.Assert(c, icmd.Expected{
+		ExitCode: 0,
+		Out:      "HELLO WORLD",
+	})
+}
+
 func (s *BasicSuite) TestEmptyOutputSuppression(c *C) {
 	out := s.tmpDir.Join("out")
 	result := icmd.RunCmd(icmd.Command(GomplateBin,


### PR DESCRIPTION
New `--exec-pipe` option which redirects output to the post-run exec command's stdin.

Fixes #581 

Currently, only a single input is supported. If there's demand later on, we could discuss use-cases...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>