### PR TITLE
Tag stable and major docker images

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,21 +1,18 @@
 #!/bin/bash
 set -exuo pipefail
 
-docker version
-
 echo "======== Build hook running"
 export VCS_REF=`git rev-parse --short HEAD`
 export DOCKER_REPO=${DOCKER_REPO:-hairyhenderson/gomplate}
 export DOCKER_TAG=${DOCKER_TAG:-latest}
 export IMAGE_NAME=${IMAGE_NAME:-${DOCKER_REPO}:${DOCKER_TAG}}
 
-docker build --target artifacts \
-             -t ${DOCKER_REPO}:artifacts .
+make artifacts.iid
+docker tag $(< artifacts.iid) ${DOCKER_REPO}:artifacts
 
 echo "======== Building $IMAGE_NAME"
-docker build --build-arg VCS_REF \
-             --target gomplate \
-             -t ${IMAGE_NAME} .
+make gomplate.iid
+docker tag $(< gomplate.iid) ${IMAGE_NAME}
 
 if [ "$DOCKER_TAG" == "latest" ]; then
   export SLIM_TAG="slim"
@@ -23,9 +20,8 @@ else
   export SLIM_TAG="${DOCKER_TAG}-slim"
 fi
 echo "======== Building ${DOCKER_REPO}:${SLIM_TAG}"
-docker build --build-arg VCS_REF \
-             --target gomplate-slim \
-             -t ${DOCKER_REPO}:${SLIM_TAG} .
+make gomplate-slim.iid
+docker tag $(< gomplate-slim.iid) ${DOCKER_REPO}:${SLIM_TAG}
 
 if [ "$DOCKER_TAG" == "latest" ]; then
   export ALPINE_TAG="alpine"
@@ -33,6 +29,5 @@ else
   export ALPINE_TAG="${DOCKER_TAG}-alpine"
 fi
 echo "======== Building ${DOCKER_REPO}:${ALPINE_TAG}"
-docker build --build-arg VCS_REF \
-             --target gomplate-alpine \
-             -t ${DOCKER_REPO}:${ALPINE_TAG} .
+make gomplate-alpine.iid
+docker tag $(< gomplate-alpine.iid) ${DOCKER_REPO}:${ALPINE_TAG}

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -23,10 +23,26 @@ docker push $DOCKER_REPO:${ALPINE_TAG}
 # We only want to have special tags for releases.
 if (git describe --abbrev=0 --exact-match &>/dev/null); then
   tag=$(git describe --abbrev=0 --exact-match)
-  docker tag $IMAGE_NAME $DOCKER_REPO:$tag
+  # splits the major version from $tag - assumes it's a 3-part semver
+  major=${tag%%\.*}
+  # if we ever want minor tags, this is how
+  # minor=${tag%\.*}
+  docker tag $IMAGE_NAME $DOCKER_REPO:${tag}
+  docker tag $IMAGE_NAME $DOCKER_REPO:stable
+  docker tag $IMAGE_NAME $DOCKER_REPO:${major}
   docker tag $DOCKER_REPO:${SLIM_TAG} $DOCKER_REPO:${tag}-slim
+  docker tag $DOCKER_REPO:${SLIM_TAG} $DOCKER_REPO:${major}-slim
+  docker tag $DOCKER_REPO:${SLIM_TAG} $DOCKER_REPO:stable-slim
   docker tag $DOCKER_REPO:${ALPINE_TAG} $DOCKER_REPO:${tag}-alpine
-  docker push $DOCKER_REPO:$tag
+  docker tag $DOCKER_REPO:${ALPINE_TAG} $DOCKER_REPO:${major}-alpine
+  docker tag $DOCKER_REPO:${ALPINE_TAG} $DOCKER_REPO:stable-alpine
+  docker push $DOCKER_REPO:${tag}
+  docker push $DOCKER_REPO:${major}
+  docker push $DOCKER_REPO:stable
   docker push $DOCKER_REPO:${tag}-slim
+  docker push $DOCKER_REPO:${major}-slim
+  docker push $DOCKER_REPO:stable-slim
   docker push $DOCKER_REPO:${tag}-alpine
+  docker push $DOCKER_REPO:${major}-alpine
+  docker push $DOCKER_REPO:stable-alpine
 fi


### PR DESCRIPTION
Fixes #648

Produces 6 new tags for the [hairyhenderson/gomplate](https://hub.docker.com/r/hairyhenderson/gomplate) image:

- `stable`, `v3` (currently equal to `v3.5.0`)
- `stable-slim`, `v3-slim` (currently equal to `v3.5.0-slim`)
- `stable-alpine`, `v3-alpine` (currently equal to `v3.5.0-alpine`)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>