### PR TITLE
Export /v3 from go module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,9 @@ jobs:
           command: |
             trap "go-junit-report < $CIRCLE_TEST_REPORTS/go-test.out > $CIRCLE_TEST_REPORTS/report.xml" EXIT
             make test | tee $CIRCLE_TEST_REPORTS/go-test.out
-            cc-test-reporter after-build --exit-code $?
+            # workaround from https://github.com/codeclimate/test-reporter/issues/378
+            export PREFIX=$(basename $(go list -m))
+            cc-test-reporter after-build -p $PREFIX --exit-code $?
       - store_test_results:
           path: /tmp/test-results
   lint:

--- a/aws/ec2meta.go
+++ b/aws/ec2meta.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/env"
 )
 
 // DefaultEndpoint -

--- a/aws/kms.go
+++ b/aws/kms.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	b64 "github.com/hairyhenderson/gomplate/base64"
+	b64 "github.com/hairyhenderson/gomplate/v3/base64"
 
 	"github.com/aws/aws-sdk-go/service/kms"
 )

--- a/aws/kms_test.go
+++ b/aws/kms_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/kms"
-	b64 "github.com/hairyhenderson/gomplate/base64"
+	b64 "github.com/hairyhenderson/gomplate/v3/base64"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -11,9 +11,9 @@ import (
 	"os/exec"
 	"os/signal"
 
-	"github.com/hairyhenderson/gomplate"
-	"github.com/hairyhenderson/gomplate/env"
-	"github.com/hairyhenderson/gomplate/version"
+	"github.com/hairyhenderson/gomplate/v3"
+	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v3/version"
 	"github.com/spf13/cobra"
 )
 

--- a/coll/coll.go
+++ b/coll/coll.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	iconv "github.com/hairyhenderson/gomplate/internal/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
 )
 
 // Slice creates a slice from a bunch of arguments

--- a/context.go
+++ b/context.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/data"
+	"github.com/hairyhenderson/gomplate/v3/data"
 )
 
 // context for templates

--- a/context_test.go
+++ b/context_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/data"
+	"github.com/hairyhenderson/gomplate/v3/data"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/conv/conv.go
+++ b/conv/conv.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	iconv "github.com/hairyhenderson/gomplate/internal/conv"
+	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
 	"github.com/pkg/errors"
 )
 

--- a/data/data.go
+++ b/data/data.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Shopify/ejson"
 	ejsonJson "github.com/Shopify/ejson/json"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/env"
 
 	// XXX: replace once https://github.com/BurntSushi/toml/pull/179 is merged
 	"github.com/hairyhenderson/toml"

--- a/data/datasource.go
+++ b/data/datasource.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/hairyhenderson/gomplate/libkv"
-	"github.com/hairyhenderson/gomplate/vault"
+	"github.com/hairyhenderson/gomplate/v3/libkv"
+	"github.com/hairyhenderson/gomplate/v3/vault"
 )
 
 // stdin - for overriding in tests

--- a/data/datasource_aws_sm.go
+++ b/data/datasource_aws_sm.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/pkg/errors"
 
-	gaws "github.com/hairyhenderson/gomplate/aws"
+	gaws "github.com/hairyhenderson/gomplate/v3/aws"
 )
 
 // awsSecretsManagerGetter - A subset of Secrets Manager API for use in unit testing

--- a/data/datasource_awssmp.go
+++ b/data/datasource_awssmp.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/pkg/errors"
 
-	gaws "github.com/hairyhenderson/gomplate/aws"
+	gaws "github.com/hairyhenderson/gomplate/v3/aws"
 )
 
 // awssmpGetter - A subset of SSM API for use in unit testing

--- a/data/datasource_blob.go
+++ b/data/datasource_blob.go
@@ -10,8 +10,8 @@ import (
 	"path"
 	"strings"
 
-	gaws "github.com/hairyhenderson/gomplate/aws"
-	"github.com/hairyhenderson/gomplate/env"
+	gaws "github.com/hairyhenderson/gomplate/v3/aws"
+	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/pkg/errors"
 
 	"gocloud.dev/blob"

--- a/data/datasource_consul.go
+++ b/data/datasource_consul.go
@@ -3,7 +3,7 @@ package data
 import (
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/libkv"
+	"github.com/hairyhenderson/gomplate/v3/libkv"
 )
 
 func readConsul(source *Source, args ...string) (data []byte, err error) {

--- a/data/datasource_env.go
+++ b/data/datasource_env.go
@@ -3,7 +3,7 @@ package data
 import (
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/env"
 )
 
 func readEnv(source *Source, args ...string) (b []byte, err error) {

--- a/data/datasource_git.go
+++ b/data/datasource_git.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/base64"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/base64"
+	"github.com/hairyhenderson/gomplate/v3/env"
 
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/memfs"

--- a/data/datasource_merge.go
+++ b/data/datasource_merge.go
@@ -3,7 +3,7 @@ package data
 import (
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/coll"
+	"github.com/hairyhenderson/gomplate/v3/coll"
 
 	"github.com/pkg/errors"
 )

--- a/data/datasource_vault.go
+++ b/data/datasource_vault.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/hairyhenderson/gomplate/vault"
+	"github.com/hairyhenderson/gomplate/v3/vault"
 )
 
 func parseVaultParams(sourceURL *url.URL, args []string) (params map[string]interface{}, p string, err error) {

--- a/data/datasource_vault_test.go
+++ b/data/datasource_vault_test.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/vault"
+	"github.com/hairyhenderson/gomplate/v3/vault"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/foo.go
+++ b/examples/foo.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/hairyhenderson/gomplate/v3/data"
+)
+
+func main() {
+	d, err := data.NewData([]string{"ip=https://ipinfo.io"}, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	response, err := d.Datasource("ip")
+	if err != nil {
+		panic(err)
+	}
+
+	m := response.(map[string]interface{})
+	fmt.Printf("country is %s\n", m["country"])
+}

--- a/funcs.go
+++ b/funcs.go
@@ -3,8 +3,8 @@ package gomplate
 import (
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/data"
-	"github.com/hairyhenderson/gomplate/funcs"
+	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v3/funcs"
 )
 
 // Funcs - The function mappings are defined here!

--- a/funcs/aws.go
+++ b/funcs/aws.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/aws"
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/aws"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 )
 
 var (

--- a/funcs/aws_test.go
+++ b/funcs/aws_test.go
@@ -3,7 +3,7 @@ package funcs
 import (
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/aws"
+	"github.com/hairyhenderson/gomplate/v3/aws"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/funcs/base64.go
+++ b/funcs/base64.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/base64"
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/base64"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 )
 
 var (

--- a/funcs/coll.go
+++ b/funcs/coll.go
@@ -3,9 +3,9 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 
-	"github.com/hairyhenderson/gomplate/coll"
+	"github.com/hairyhenderson/gomplate/v3/coll"
 	"github.com/pkg/errors"
 )
 

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/coll"
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/coll"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 )
 
 var (

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -10,10 +10,10 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/pkg/errors"
 
-	"github.com/hairyhenderson/gomplate/crypto"
+	"github.com/hairyhenderson/gomplate/v3/crypto"
 )
 
 var (

--- a/funcs/data.go
+++ b/funcs/data.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/data"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/data"
 )
 
 var (

--- a/funcs/env.go
+++ b/funcs/env.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/env"
 )
 
 var (

--- a/funcs/file.go
+++ b/funcs/file.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/file"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/file"
 	"github.com/spf13/afero"
 )
 

--- a/funcs/filepath.go
+++ b/funcs/filepath.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 )
 
 var (

--- a/funcs/math.go
+++ b/funcs/math.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 
-	"github.com/hairyhenderson/gomplate/math"
+	"github.com/hairyhenderson/gomplate/v3/math"
 )
 
 var (

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -4,9 +4,9 @@ import (
 	stdnet "net"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 
-	"github.com/hairyhenderson/gomplate/net"
+	"github.com/hairyhenderson/gomplate/v3/net"
 )
 
 var (

--- a/funcs/path.go
+++ b/funcs/path.go
@@ -4,7 +4,7 @@ import (
 	"path"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 )
 
 var (

--- a/funcs/random.go
+++ b/funcs/random.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"unicode/utf8"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	iconv "github.com/hairyhenderson/gomplate/internal/conv"
-	"github.com/hairyhenderson/gomplate/random"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
+	"github.com/hairyhenderson/gomplate/v3/random"
 	"github.com/pkg/errors"
 )
 

--- a/funcs/regexp.go
+++ b/funcs/regexp.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/regexp"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/regexp"
 )
 
 var (

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -12,13 +12,13 @@ import (
 	"unicode/utf8"
 
 	"github.com/Masterminds/goutils"
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/pkg/errors"
 
 	"strings"
 
 	"github.com/gosimple/slug"
-	gompstrings "github.com/hairyhenderson/gomplate/strings"
+	gompstrings "github.com/hairyhenderson/gomplate/v3/strings"
 )
 
 var (

--- a/funcs/test.go
+++ b/funcs/test.go
@@ -3,10 +3,10 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/pkg/errors"
 
-	"github.com/hairyhenderson/gomplate/test"
+	"github.com/hairyhenderson/gomplate/v3/test"
 )
 
 var (

--- a/funcs/time.go
+++ b/funcs/time.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	gotime "time"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/time"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/time"
 )
 
 var (

--- a/funcs/uuid.go
+++ b/funcs/uuid.go
@@ -3,7 +3,7 @@ package funcs
 import (
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/conv"
+	"github.com/hairyhenderson/gomplate/v3/conv"
 
 	"github.com/google/uuid"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hairyhenderson/gomplate
+module github.com/hairyhenderson/gomplate/v3
 
 go 1.13
 

--- a/gomplate.go
+++ b/gomplate.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/data"
+	"github.com/hairyhenderson/gomplate/v3/data"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
 )

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -11,10 +11,10 @@ import (
 
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/aws"
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/data"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/aws"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/libkv/boltdb.go
+++ b/libkv/boltdb.go
@@ -7,8 +7,8 @@ import (
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/pkg/errors"
 )
 

--- a/libkv/consul.go
+++ b/libkv/consul.go
@@ -13,9 +13,9 @@ import (
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/env"
-	"github.com/hairyhenderson/gomplate/vault"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v3/vault"
 	consulapi "github.com/hashicorp/consul/api"
 )
 

--- a/plugins.go
+++ b/plugins.go
@@ -14,8 +14,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/env"
 )
 
 func bindPlugins(plugins []string, funcMap template.FuncMap) error {

--- a/template.go
+++ b/template.go
@@ -9,10 +9,10 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/tmpl"
+	"github.com/hairyhenderson/gomplate/v3/tmpl"
 
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/pkg/errors"
 
 	"github.com/spf13/afero"

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/aws"
-	"github.com/hairyhenderson/gomplate/conv"
-	"github.com/hairyhenderson/gomplate/env"
+	"github.com/hairyhenderson/gomplate/v3/aws"
+	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
I guess I missed this when I switched to go modules originally.

Unfortunately, this will break dependents that import gomplate packages, but that's sort of the general story with go modules these days 😞

Also fixes #674 (at least it will, after v3.6.0 is tagged)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>