### PR TITLE
Return first non-empty YAML document when parsing YAML streams

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"io"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -84,13 +85,41 @@ func JSONArray(in string) ([]interface{}, error) {
 // YAML - Unmarshal a YAML Object
 func YAML(in string) (map[string]interface{}, error) {
 	obj := make(map[string]interface{})
-	return unmarshalObj(obj, in, yaml.Unmarshal)
+	s := strings.NewReader(in)
+	d := yaml.NewDecoder(s)
+	for {
+		err := d.Decode(&obj)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if obj != nil {
+			break
+		}
+	}
+	return obj, nil
 }
 
 // YAMLArray - Unmarshal a YAML Array
 func YAMLArray(in string) ([]interface{}, error) {
 	obj := make([]interface{}, 1)
-	return unmarshalArray(obj, in, yaml.Unmarshal)
+	s := strings.NewReader(in)
+	d := yaml.NewDecoder(s)
+	for {
+		err := d.Decode(&obj)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if obj != nil {
+			break
+		}
+	}
+	return obj, nil
 }
 
 // TOML - Unmarshal a TOML Object

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -34,6 +34,15 @@ func TestUnmarshalObj(t *testing.T) {
 one: 1.0
 true: true
 `))
+	test(YAML(`# this comment marks an empty (nil!) document
+---
+# this one too, for good measure
+---
+foo:
+  bar: baz
+one: 1.0
+true: true
+`))
 
 	obj := make(map[string]interface{})
 	_, err := unmarshalObj(obj, "SOMETHING", func(in []byte, out interface{}) error {
@@ -65,6 +74,20 @@ func TestUnmarshalArray(t *testing.T) {
     "42": 18
   corge:
     "false": blah
+`))
+	test(YAMLArray(`---
+# blah blah blah ignore this!
+---
+- foo
+- bar
+- baz:
+    qux: true
+  quux:
+    "42": 18
+  corge:
+    "false": blah
+---
+this shouldn't be reached
 `))
 
 	obj := make([]interface{}, 1)


### PR DESCRIPTION
This relates to #534, and while full multi-document stream support is going to take a bit longer to fully figure out, I think this is a quick win.

Basically this handles the (not uncomment in Helm and Kubernetes-land) case where a file like:

```yaml
# foo
---
foo: bar
```

will get parsed by gomplate as just a single `nil`, which is pretty much never what we _actually_ want.

So now YAML will ignore non-empty documents and return the first one in the stream.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>