### PR TITLE
Use cobra's built-in --version flag instead of implementing separately

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -21,7 +20,6 @@ import (
 )
 
 var (
-	printVer bool
 	verbose  bool
 	execPipe bool
 	opts     gomplate.Config
@@ -29,10 +27,6 @@ var (
 
 	postRunInput *bytes.Buffer
 )
-
-func printVersion(name string) {
-	fmt.Printf("%s version %s\n", name, version.Version)
-}
 
 // postRunExec - if templating succeeds, the command following a '--' will be executed
 func postRunExec(cmd *cobra.Command, args []string) error {
@@ -101,12 +95,8 @@ func newGomplateCmd() *cobra.Command {
 		Use:     "gomplate",
 		Short:   "Process text files with Go templates",
 		PreRunE: validateOpts,
+		Version: version.Version,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if printVer {
-				printVersion(cmd.Name())
-				return nil
-			}
-
 			if v, _ := cmd.Flags().GetBool("verbose"); v {
 				zerolog.SetGlobalLevel(zerolog.DebugLevel)
 			}
@@ -169,8 +159,6 @@ func initFlags(command *cobra.Command) {
 	command.Flags().StringVar(&opts.RDelim, "right-delim", rdDefault, "override the default right-`delimiter` [$GOMPLATE_RIGHT_DELIM]")
 
 	command.Flags().BoolVarP(&verbose, "verbose", "V", false, "output extra information about what gomplate is doing")
-
-	command.Flags().BoolVarP(&printVer, "version", "v", false, "print the version")
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/afero v1.2.2
-	github.com/spf13/cobra v0.0.6
+	github.com/spf13/cobra v0.0.7-0.20200228181340-95f2f73ed97e
 	github.com/stretchr/testify v1.5.1
 	github.com/ugorji/go/codec v1.1.7
 	github.com/zealic/xignore v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/spf13/afero v1.2.1/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
-github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v0.0.7-0.20200228181340-95f2f73ed97e h1:hPJtePycGk1fr1xu9P0tZH7ovSWENwxYTs05S+YCWoM=
+github.com/spf13/cobra v0.0.7-0.20200228181340-95f2f73ed97e/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=


### PR DESCRIPTION
Saves a bit of effort. Cobra currently only adds a `--version` flag and not a `-v` flag, though I've issued a PR spf13/cobra#996 to solve that. If/when that's merged/released, I'll bring this PR out of draft mode. I don't want to break the command, even for a non-critical flag like this.

(also the integration tests will break until that fix is in)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>