### PR TITLE
pin actions/checkout action to v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - run: |
           git config --global user.email "bogus@example.com"
           git config --global user.name "Someone"
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           path: ./src/github.com/${{ github.repository }}
       - run: make build
@@ -39,7 +39,7 @@ jobs:
       - run: |
           git config --global user.email "bogus@example.com"
           git config --global user.name "Someone"
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           path: ./src/github.com/${{ github.repository }}
       - run: make build
@@ -56,7 +56,7 @@ jobs:
     container:
       image: 'hairyhenderson/gomplate-ci-build:latest'
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v1
         with:
           path: ./src/github.com/${{ github.repository }}
       - run: make lint

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Make Docker images
       run: make docker-images
       env:


### PR DESCRIPTION
`actions/checkout` has recently bumped to v2 (beta) in `master`, which breaks some stuff. Pinning to `v1`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>