### PR TITLE
Adding a few MIME type aliases

### DIFF
--- a/data/datasource.go
+++ b/data/datasource.go
@@ -389,7 +389,7 @@ func (d *Data) Datasource(alias string, args ...string) (interface{}, error) {
 }
 
 func parseData(mimeType, s string) (out interface{}, err error) {
-	switch mimeType {
+	switch mimeAlias(mimeType) {
 	case jsonMimetype:
 		out, err = JSON(s)
 	case jsonArrayMimetype:

--- a/data/mimetypes.go
+++ b/data/mimetypes.go
@@ -9,3 +9,17 @@ const (
 	yamlMimetype      = "application/yaml"
 	envMimetype       = "application/x-env"
 )
+
+// mimeTypeAliases defines a mapping for non-canonical mime types that are
+// sometimes seen in the wild
+var mimeTypeAliases = map[string]string{
+	"application/x-yaml": yamlMimetype,
+	"application/text":   textMimetype,
+}
+
+func mimeAlias(m string) string {
+	if a, ok := mimeTypeAliases[m]; ok {
+		return a
+	}
+	return m
+}

--- a/data/mimetypes_test.go
+++ b/data/mimetypes_test.go
@@ -1,0 +1,22 @@
+package data
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMimeAlias(t *testing.T) {
+	t.Parallel()
+	data := []struct {
+		in, out string
+	}{
+		{csvMimetype, csvMimetype},
+		{yamlMimetype, yamlMimetype},
+		{"application/x-yaml", yamlMimetype},
+	}
+
+	for _, d := range data {
+		assert.Equal(t, d.out, mimeAlias(d.in))
+	}
+}


### PR DESCRIPTION
Fixes #738 

I also added `application/text` as an alias to `text/plain`, as it was mentioned in the same Slack conversation that triggered #738...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>