### PR TITLE
Allow data.ToCSV to handle more general input types

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -336,6 +336,24 @@ func TestToCSV(t *testing.T) {
 
 	_, err = ToCSV([][]int{{1, 2}})
 	assert.Error(t, err)
+
+	expected = "first,second,third\r\n1,2,3\r\n4,5,6\r\n"
+	out, err = ToCSV([][]interface{}{
+		{"first", "second", "third"},
+		{"1", "2", "3"},
+		{"4", "5", "6"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
+
+	expected = "first|second|third\r\n1|2|3\r\n4|5|6\r\n"
+	out, err = ToCSV("|", []interface{}{
+		[]interface{}{"first", "second", "third"},
+		[]interface{}{1, "2", 3},
+		[]interface{}{"4", 5, "6"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, expected, out)
 }
 
 func TestTOML(t *testing.T) {

--- a/tests/integration/docs_examples_test.go
+++ b/tests/integration/docs_examples_test.go
@@ -1,0 +1,34 @@
+//+build integration
+
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+// This suite contains integration tests to make sure that (some of) the examples
+// in the gomplate docs work correctly
+type DocExamplesSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&DocExamplesSuite{})
+
+func (s *DocExamplesSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests")
+}
+
+func (s *DocExamplesSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *DocExamplesSuite) TestDataExamples(c *C) {
+	result := icmd.RunCommand(GomplateBin,
+		"-i", "{{ $rows := (jsonArray `[[\"first\",\"second\"],[\"1\",\"2\"],[\"3\",\"4\"]]`) }}{{ data.ToCSV \";\" $rows }}",
+	)
+	expected := "first;second\r\n1;2\r\n3;4\r\n"
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: expected})
+}


### PR DESCRIPTION
Fixes #804 

Slices are a bit of a pain in Go (`[][]interface{}` is not an `[]interface{}`, and `[]interface{}` is not an `interface{}`)...

This should cover the majority of the use-cases, though it won't handle `[]interface{}`s that contain different types of slices (something like `[]interface{}{[]string{"first", "second", "third"},[]interface{}{1, "2", 3}}` won't work). I'm not sure how common that would be, and certainly wouldn't be something that YAML or JSON parsing would create. If anyone runs into that kind of data structure, I can obviously add it though!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>