### PR TITLE
Fix alpine docker image binary location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ LABEL org.opencontainers.image.revision=$VCS_REF \
       org.opencontainers.image.source="https://github.com/hairyhenderson/gomplate"
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=compress /bin/gomplate_${TARGETOS}-${TARGETARCH}${TARGETVARIANT}-slim /gomplate
+COPY --from=compress /bin/gomplate_${TARGETOS}-${TARGETARCH}${TARGETVARIANT}-slim /bin/gomplate
 
 ENTRYPOINT [ "/bin/gomplate" ]
 


### PR DESCRIPTION
Accidentally moved `/bin/gomplate` to `/gomplate` in #811 😅 

It's a bit odd because every other image has it in `/gomplate`. 🤷‍♂️ 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>