### PR TITLE
Push all multi-arch docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,48 +47,32 @@ jobs:
       run: |
         # NOTE: DOCKERHUB_TOKEN and DOCKERHUB_USERNAME must be present in https://github.com/hairyhenderson/gomplate/settings
         echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-    - name: Make/Push temporary Docker images
-      run: make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=localhost:5000/gomplate
-      env:
-        COMMIT: ${{ github.sha }}
-    - name: Pull the temporary images
+    - name: Build & Push (non-master)
       run: |
-        docker pull localhost:5000/gomplate:latest-${{ github.sha }}
-        docker pull localhost:5000/gomplate:slim-${{ github.sha }}
-        docker pull localhost:5000/gomplate:alpine-${{ github.sha }}
-    - name: Re-tag and list images (non-master)
-      run: |
-        docker tag localhost:5000/gomplate:latest-${{ github.sha }} hairyhenderson/gomplate:latest
-        docker tag localhost:5000/gomplate:slim-${{ github.sha }} hairyhenderson/gomplate:slim
-        docker tag localhost:5000/gomplate:alpine-${{ github.sha }} hairyhenderson/gomplate:alpine
+        set -ex
+        make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=localhost:5000/gomplate BUILDX_ACTION=--push
 
-        docker images
+        docker buildx imagetools create --dry-run -t localhost:5000/gomplate:dev localhost:5000/gomplate:latest
+        docker buildx imagetools create --dry-run -t localhost:5000/gomplate:dev-slim localhost:5000/gomplate:slim
+        docker buildx imagetools create --dry-run -t localhost:5000/gomplate:dev-alpine localhost:5000/gomplate:alpine
       if: github.repository != 'hairyhenderson/gomplate' || github.ref != 'refs/heads/master'
-    - name: Re-tag and push (master)
+    - name: Build & Push (master)
       run: |
-        docker tag localhost:5000/gomplate:latest-${{ github.sha }} hairyhenderson/gomplate:latest
-        docker tag localhost:5000/gomplate:slim-${{ github.sha }} hairyhenderson/gomplate:slim
-        docker tag localhost:5000/gomplate:alpine-${{ github.sha }} hairyhenderson/gomplate:alpine
-
-        docker images
-        docker push hairyhenderson/gomplate
+        make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=hairyhenderson/gomplate BUILDX_ACTION=--push
       if: github.repository == 'hairyhenderson/gomplate' && github.ref == 'refs/heads/master'
-    - name: Re-tag and push (tagged release)
+    - name: Build & Push (tagged release)
       run: |
-        docker tag localhost:5000/gomplate:latest-${{ github.sha }} hairyhenderson/gomplate:latest
-        docker tag localhost:5000/gomplate:slim-${{ github.sha }} hairyhenderson/gomplate:slim
-        docker tag localhost:5000/gomplate:alpine-${{ github.sha }} hairyhenderson/gomplate:alpine
+        make docker-multi COMMIT=${{ github.sha }} DOCKER_REPO=hairyhenderson/gomplate BUILDX_ACTION=--push
 
-        docker tag localhost:5000/gomplate:latest-${{ github.sha }} hairyhenderson/gomplate:${git_tag}
-        docker tag localhost:5000/gomplate:latest-${{ github.sha }} hairyhenderson/gomplate:stable
-        docker tag localhost:5000/gomplate:latest-${{ github.sha }} hairyhenderson/gomplate:${major_version}
-        docker tag localhost:5000/gomplate:slim-${{ github.sha }} hairyhenderson/gomplate:${git_tag}-slim
-        docker tag localhost:5000/gomplate:slim-${{ github.sha }} hairyhenderson/gomplate:${major_version}-slim
-        docker tag localhost:5000/gomplate:slim-${{ github.sha }} hairyhenderson/gomplate:stable-slim
-        docker tag localhost:5000/gomplate:alpine-${{ github.sha }} hairyhenderson/gomplate:${git_tag}-alpine
-        docker tag localhost:5000/gomplate:alpine-${{ github.sha }} hairyhenderson/gomplate:${major_version}-alpine
-        docker tag localhost:5000/gomplate:alpine-${{ github.sha }} hairyhenderson/gomplate:stable-alpine
+        docker buildx imagetools create -t localhost:5000/gomplate:stable localhost:5000/gomplate:latest
+        docker buildx imagetools create -t localhost:5000/gomplate:${git_tag} localhost:5000/gomplate:latest
+        docker buildx imagetools create -t localhost:5000/gomplate:${major_version} localhost:5000/gomplate:latest
 
-        docker images
-        docker push hairyhenderson/gomplate
+        docker buildx imagetools create -t localhost:5000/gomplate:stable-slim localhost:5000/gomplate:slim
+        docker buildx imagetools create -t localhost:5000/gomplate:${git_tag}-slim localhost:5000/gomplate:slim
+        docker buildx imagetools create -t localhost:5000/gomplate:${major_version}-slim localhost:5000/gomplate:slim
+
+        docker buildx imagetools create -t localhost:5000/gomplate:stable-alpine localhost:5000/gomplate:alpine
+        docker buildx imagetools create -t localhost:5000/gomplate:${git_tag}-alpine localhost:5000/gomplate:alpine
+        docker buildx imagetools create -t localhost:5000/gomplate:${major_version}-alpine localhost:5000/gomplate:alpine
       if: github.repository == 'hairyhenderson/gomplate' && env.is_tag == 'true'

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ DOCKER_REPO ?= hairyhenderson/$(PKG_NAME)
 PREFIX := .
 DOCKER_LINUX_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
 DOCKER_PLATFORMS ?= $(DOCKER_LINUX_PLATFORMS),windows/amd64
+# we just load by default, as a "dry run"
+BUILDX_ACTION ?= --load
+TAG_LATEST ?= latest
+TAG_SLIM ?= slim
+TAG_ALPINE ?= alpine
 
 ifeq ("$(CI)","true")
 LINT_PROCS ?= 1
@@ -74,21 +79,21 @@ docker-multi: Dockerfile
 	docker buildx build \
 		--build-arg VCS_REF=$(COMMIT) \
 		--platform $(DOCKER_PLATFORMS) \
-		--tag $(DOCKER_REPO):latest-$(COMMIT) \
+		--tag $(DOCKER_REPO):$(TAG_LATEST) \
 		--target gomplate \
-		--push .
+		$(BUILDX_ACTION) .
 	docker buildx build \
 		--build-arg VCS_REF=$(COMMIT) \
 		--platform $(DOCKER_PLATFORMS) \
-		--tag $(DOCKER_REPO):slim-$(COMMIT) \
+		--tag $(DOCKER_REPO):$(TAG_SLIM) \
 		--target gomplate-slim \
-		--push .
+		$(BUILDX_ACTION) .
 	docker buildx build \
 		--build-arg VCS_REF=$(COMMIT) \
 		--platform $(DOCKER_LINUX_PLATFORMS) \
-		--tag $(DOCKER_REPO):alpine-$(COMMIT) \
+		--tag $(DOCKER_REPO):$(TAG_ALPINE) \
 		--target gomplate-alpine \
-		--push .
+		$(BUILDX_ACTION) .
 
 %.cid: %.iid
 	@docker create $(shell cat $<) > $@


### PR DESCRIPTION
In #811 I didn't realize that the `docker pull` was only pulling down the `linux-amd64` image from the temporary local registry, so the pushed images weren't actually multi-arch...

This fixes it by using `docker buildx imagetools create` instead to do a carbon-copy of the images.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>