### PR TITLE
Fix broken file datasource URL parsing (query string was ignored)

### DIFF
--- a/data/datasource.go
+++ b/data/datasource.go
@@ -230,7 +230,7 @@ func parseSource(value string) (source *Source, err error) {
 			err = errors.Errorf("Invalid datasource (%s). Must provide an alias with files not in working directory", value)
 			return nil, err
 		}
-		source.URL, err = absURL(f)
+		source.URL, err = absFileURL(f)
 		if err != nil {
 			return nil, err
 		}
@@ -272,7 +272,7 @@ func parseSourceURL(value string) (*url.URL, error) {
 	}
 
 	if !srcURL.IsAbs() {
-		srcURL, err = absURL(value)
+		srcURL, err = absFileURL(value)
 		if err != nil {
 			return nil, err
 		}
@@ -280,7 +280,7 @@ func parseSourceURL(value string) (*url.URL, error) {
 	return srcURL, nil
 }
 
-func absURL(value string) (*url.URL, error) {
+func absFileURL(value string) (*url.URL, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, errors.Wrapf(err, "can't get working directory")
@@ -290,8 +290,9 @@ func absURL(value string) (*url.URL, error) {
 		Scheme: "file",
 		Path:   urlCwd + "/",
 	}
-	relURL := &url.URL{
-		Path: value,
+	relURL, err := url.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse value %s as URL: %w", value, err)
 	}
 	resolved := baseURL.ResolveReference(relURL)
 	// deal with Windows drive letters

--- a/tests/integration/datasources_file_test.go
+++ b/tests/integration/datasources_file_test.go
@@ -19,6 +19,7 @@ func (s *FileDatasourcesSuite) SetUpSuite(c *C) {
 	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
 		fs.WithFiles(map[string]string{
 			"config.json": `{"foo": {"bar": "baz"}}`,
+			"ajsonfile":   `{"foo": {"bar": "baz"}}`,
 			"encrypted.json": `{
   "_public_key": "dfcf98785869cdfc4a59273bbdfe1bfcf6c44850a11ea9d84db21c89a802c057",
   "password": "EJ[1:Cb1AY94Dl76xwHHrnJyh+Y+fAeovijPlFQZXSAuvZBc=:oCGZM6lbeXXOl2ONSKfLQ0AgaltrTpNU:VjegqQPPkOK1hSylMAbmcfusQImfkHCWZw==]"
@@ -96,6 +97,11 @@ func (s *FileDatasourcesSuite) TestFileDatasources(c *C) {
 
 	result = icmd.RunCommand(GomplateBin,
 		"-i", `foo{{defineDatasource "config" `+"`"+s.tmpDir.Join("config.json")+"`"+`}}bar{{(datasource "config").foo.bar}}`,
+	)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "foobarbaz"})
+
+	result = icmd.RunCommand(GomplateBin,
+		"-i", `foo{{defineDatasource "config" `+"`"+s.tmpDir.Join("ajsonfile")+"?type=application/json`"+`}}bar{{(datasource "config").foo.bar}}`,
 	)
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "foobarbaz"})
 


### PR DESCRIPTION
Fixes #809

Turns out paths passed on the commandline would've also suffered from this bug - the query string on non-absolute URLs (i.e. file paths) wasn't getting parsed.

So this wouldn't have been recognized:

```console
$ gomplate -d foo=./foo?type=application/json ...
```

And neither would inline uses of `defineDatasource` (such as reported in #809):

```
{{- defineDatasource "env_file" ".env.staging?type=application/x-env" -}}
```

Incidentally, this also fixes an issue I've experienced before when trying to emulate reads from Vault with a local directory:

```console
$ gomplate -d secrets=./secret_dir/?type=application/json -i '{{ (ds "secrets" "some/key").value }}'
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>