### PR TITLE
Fix AWS Session unknown region bug

### DIFF
--- a/aws/ec2info.go
+++ b/aws/ec2info.go
@@ -85,7 +85,9 @@ func SDKSession(region ...string) *session.Session {
 				panic(errors.Wrap(err, "failed to determine EC2 region"))
 			}
 		}
-		config = config.WithRegion(metaRegion)
+		if metaRegion != "" && metaRegion != unknown {
+			config = config.WithRegion(metaRegion)
+		}
 		config = config.WithCredentialsChainVerboseErrors(true)
 
 		sdkSession = session.Must(session.NewSessionWithOptions(session.Options{


### PR DESCRIPTION
Fixes #795

Turns out the issue was that the region is set to `"unknown"` (as a default from `aws.EC2Region`) and so the config object was initialized incorrectly, and the region from the config was being overridden.

I've tested this locally, and it works fine. Unfortunately this can't easily be unit tested due to how the AWS SDK works.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>