### PR TITLE
Apply --chmod before opening output file

### DIFF
--- a/internal/tests/integration/basic_nonwindows_test.go
+++ b/internal/tests/integration/basic_nonwindows_test.go
@@ -71,3 +71,21 @@ func (s *BasicSuite) TestOverridesOutputModeWithChmod(c *C) {
 		assert.Equal(c, v.content, string(content))
 	}
 }
+
+func (s *BasicSuite) TestAppliesChmodBeforeWrite(c *C) {
+	// 'broken' was created with mode 0000
+	out := s.tmpDir.Join("broken")
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"-f", s.tmpDir.Join("one"),
+		"-o", out,
+		"--chmod", "0644"), func(cmd *icmd.Cmd) {
+	})
+	result.Assert(c, icmd.Success)
+
+	info, err := os.Stat(out)
+	assert.NilError(c, err)
+	assert.Equal(c, os.FileMode(0644), info.Mode())
+	content, err := ioutil.ReadFile(out)
+	assert.NilError(c, err)
+	assert.Equal(c, "hi\n", string(content))
+}

--- a/internal/tests/integration/basic_test.go
+++ b/internal/tests/integration/basic_test.go
@@ -25,7 +25,8 @@ var _ = Suite(&BasicSuite{})
 func (s *BasicSuite) SetUpTest(c *C) {
 	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
 		fs.WithFile("one", "hi\n", fs.WithMode(0640)),
-		fs.WithFile("two", "hello\n"))
+		fs.WithFile("two", "hello\n"),
+		fs.WithFile("broken", "", fs.WithMode(0000)))
 }
 
 func (s *BasicSuite) TearDownTest(c *C) {

--- a/template.go
+++ b/template.go
@@ -243,12 +243,15 @@ func openOutFile(cfg *config.Config, filename string, mode os.FileMode, modeOver
 }
 
 func createOutFile(filename string, mode os.FileMode, modeOverride bool) (out io.WriteCloser, err error) {
+	if modeOverride {
+		err = fs.Chmod(filename, mode.Perm())
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to chmod output file '%s' with mode %q: %w", filename, mode.Perm(), err)
+		}
+	}
 	out, err = fs.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
 	if err != nil {
 		return out, err
-	}
-	if modeOverride {
-		err = fs.Chmod(filename, mode.Perm())
 	}
 	return out, err
 }


### PR DESCRIPTION
If an output file already exists but is not able to be read or written by the user, gomplate will fail to open it even if the `--chmod` flag is given.

This is because the new mode is only applied after attempting to open the file.

This fixes that behaviour by applying the `--chmod` before opening the file.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>