### PR TITLE
refactoring: deduplicating identical URL-parsing functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ gomplate.png: gomplate.svg
 	cloudconvert -f png -c density=288 $^
 
 lint:
-	golangci-lint --version
+	@golangci-lint --version
 	@golangci-lint run --timeout 2m --disable-all \
 		--enable depguard \
 		--enable dupl \

--- a/data/datasource_http.go
+++ b/data/datasource_http.go
@@ -5,7 +5,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -60,41 +59,4 @@ func readHTTP(source *Source, args ...string) ([]byte, error) {
 		source.mediaType = mediatype
 	}
 	return body, nil
-}
-
-func parseHeaderArgs(headerArgs []string) (map[string]http.Header, error) {
-	headers := make(map[string]http.Header)
-	for _, v := range headerArgs {
-		ds, name, value, err := splitHeaderArg(v)
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := headers[ds]; !ok {
-			headers[ds] = make(http.Header)
-		}
-		headers[ds][name] = append(headers[ds][name], strings.TrimSpace(value))
-	}
-	return headers, nil
-}
-
-func splitHeaderArg(arg string) (datasourceAlias, name, value string, err error) {
-	parts := strings.SplitN(arg, "=", 2)
-	if len(parts) != 2 {
-		err = errors.Errorf("Invalid datasource-header option '%s'", arg)
-		return "", "", "", err
-	}
-	datasourceAlias = parts[0]
-	name, value, err = splitHeader(parts[1])
-	return datasourceAlias, name, value, err
-}
-
-func splitHeader(header string) (name, value string, err error) {
-	parts := strings.SplitN(header, ":", 2)
-	if len(parts) != 2 {
-		err = errors.Errorf("Invalid HTTP Header format '%s'", header)
-		return "", "", err
-	}
-	name = http.CanonicalHeaderKey(parts[0])
-	value = parts[1]
-	return name, value, nil
 }

--- a/data/datasource_http_test.go
+++ b/data/datasource_http_test.go
@@ -118,50 +118,6 @@ func TestHTTPFileWithHeaders(t *testing.T) {
 	assert.Equal(t, must(marshalObj(expected, json.Marshal)), must(marshalObj(actual, json.Marshal)))
 }
 
-func TestParseHeaderArgs(t *testing.T) {
-	args := []string{
-		"foo=Accept: application/json",
-		"bar=Authorization: Bearer supersecret",
-	}
-	expected := map[string]http.Header{
-		"foo": {
-			"Accept": {jsonMimetype},
-		},
-		"bar": {
-			"Authorization": {"Bearer supersecret"},
-		},
-	}
-	parsed, err := parseHeaderArgs(args)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, parsed)
-
-	_, err = parseHeaderArgs([]string{"foo"})
-	assert.Error(t, err)
-
-	_, err = parseHeaderArgs([]string{"foo=bar"})
-	assert.Error(t, err)
-
-	args = []string{
-		"foo=Accept: application/json",
-		"foo=Foo: bar",
-		"foo=foo: baz",
-		"foo=fOO: qux",
-		"bar=Authorization: Bearer  supersecret",
-	}
-	expected = map[string]http.Header{
-		"foo": {
-			"Accept": {jsonMimetype},
-			"Foo":    {"bar", "baz", "qux"},
-		},
-		"bar": {
-			"Authorization": {"Bearer  supersecret"},
-		},
-	}
-	parsed, err = parseHeaderArgs(args)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, parsed)
-}
-
 func TestBuildURL(t *testing.T) {
 	expected := "https://example.com/index.html"
 	base := mustParseURL(expected)

--- a/data/datasource_merge.go
+++ b/data/datasource_merge.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/hairyhenderson/gomplate/v3/coll"
+	"github.com/hairyhenderson/gomplate/v3/internal/config"
 
 	"github.com/pkg/errors"
 )
@@ -30,9 +31,13 @@ func (d *Data) readMerge(source *Source, args ...string) ([]byte, error) {
 		subSource, err := d.lookupSource(part)
 		if err != nil {
 			// maybe it's a relative filename?
-			subSource, err = parseSource(part + "=" + part)
+			u, err := config.ParseSourceURL(part)
 			if err != nil {
 				return nil, err
+			}
+			subSource = &Source{
+				Alias: part,
+				URL:   u,
 			}
 		}
 		subSource.inherit(source)

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -98,7 +98,7 @@ func (d *DSConfig) UnmarshalYAML(value *yaml.Node) error {
 	if err != nil {
 		return err
 	}
-	u, err := parseSourceURL(r.URL)
+	u, err := ParseSourceURL(r.URL)
 	if err != nil {
 		return fmt.Errorf("could not parse datasource URL %q: %w", r.URL, err)
 	}
@@ -280,10 +280,10 @@ func parseDatasourceArg(value string) (key string, ds DSConfig, err error) {
 			err = fmt.Errorf("invalid datasource (%s): must provide an alias with files not in working directory", value)
 			return key, ds, err
 		}
-		ds.URL, err = absFileURL(f)
+		ds.URL, err = ParseSourceURL(f)
 	} else if len(parts) == 2 {
 		key = parts[0]
-		ds.URL, err = parseSourceURL(parts[1])
+		ds.URL, err = ParseSourceURL(parts[1])
 	}
 	return key, ds, err
 }
@@ -466,7 +466,11 @@ func (c *Config) String() string {
 	return out.String()
 }
 
-func parseSourceURL(value string) (*url.URL, error) {
+// ParseSourceURL parses a datasource URL value, which may be '-' (for stdin://),
+// or it may be a Windows path (with driver letter and back-slack separators) or
+// UNC, or it may be relative. It also might just be a regular absolute URL...
+// In all cases it returns a correct URL for the value.
+func ParseSourceURL(value string) (*url.URL, error) {
 	if value == "-" {
 		value = "stdin://"
 	}


### PR DESCRIPTION
Only real functional change is uses of `absFileURL` are replaced with `parseSourceURL` which I'm fairly certain is basically the same effect, except with a few added checks up-front which would be skipped in all cases where `absFileURL` would've been called.

Also marks `NewData` as deprecated.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>