### PR TITLE
Allow referencing aws+sm[p] keys that don't start with '/'

### DIFF
--- a/data/datasource_awssmp_test.go
+++ b/data/datasource_awssmp_test.go
@@ -57,33 +57,6 @@ func simpleAWSSourceHelper(dummy awssmpGetter) *Source {
 	}
 }
 
-func TestAWSSMP_ParseArgsSimple(t *testing.T) {
-	u, _ := url.Parse("noddy")
-	_, p, err := parseAWSSMPArgs(u)
-	assert.Equal(t, "noddy", p)
-	assert.Nil(t, err)
-}
-
-func TestAWSSMP_ParseArgsAppend(t *testing.T) {
-	u, _ := url.Parse("base")
-	_, p, err := parseAWSSMPArgs(u, "extra")
-	assert.Equal(t, "base/extra", p)
-	assert.Nil(t, err)
-}
-
-func TestAWSSMP_ParseArgsAppend2(t *testing.T) {
-	u, _ := url.Parse("/foo/")
-	_, p, err := parseAWSSMPArgs(u, "/extra")
-	assert.Equal(t, "/foo/extra", p)
-	assert.Nil(t, err)
-}
-
-func TestAWSSMP_ParseArgsTooMany(t *testing.T) {
-	u, _ := url.Parse("base")
-	_, _, err := parseAWSSMPArgs(u, "extra", "too many!")
-	assert.Error(t, err)
-}
-
 func TestAWSSMP_GetParameterSetup(t *testing.T) {
 	calledOk := false
 	s := simpleAWSSourceHelper(DummyParamGetter{

--- a/data/datasource_env.go
+++ b/data/datasource_env.go
@@ -9,8 +9,7 @@ import (
 func readEnv(source *Source, args ...string) (b []byte, err error) {
 	n := source.URL.Path
 	n = strings.TrimPrefix(n, "/")
-	if n != "" {
-	} else if n == "" {
+	if n == "" {
 		n = source.URL.Opaque
 	}
 

--- a/data/datasource_vault.go
+++ b/data/datasource_vault.go
@@ -1,37 +1,12 @@
 package data
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/hairyhenderson/gomplate/v3/vault"
 )
-
-func parseVaultParams(sourceURL *url.URL, args []string) (params map[string]interface{}, p string, err error) {
-	p = sourceURL.Path
-	params = make(map[string]interface{})
-	for key, val := range sourceURL.Query() {
-		params[key] = strings.Join(val, " ")
-	}
-
-	if len(args) == 1 {
-		parsed, err := url.Parse(args[0])
-		if err != nil {
-			return nil, "", err
-		}
-
-		if parsed.Path != "" {
-			p = p + "/" + parsed.Path
-		}
-
-		for key, val := range parsed.Query() {
-			params[key] = strings.Join(val, " ")
-		}
-	}
-	return params, p, nil
-}
 
 func readVault(source *Source, args ...string) (data []byte, err error) {
 	if source.vc == nil {
@@ -45,7 +20,7 @@ func readVault(source *Source, args ...string) (data []byte, err error) {
 		}
 	}
 
-	params, p, err := parseVaultParams(source.URL, args)
+	params, p, err := parseDatasourceURLArgs(source.URL, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -35,7 +35,7 @@ For our purposes, the _scheme_ and the _path_ components are especially importan
 
 ### Opaque URIs
 
-For some more advanced datasources, such as the [`merge` scheme](#using-merge-datasources), opaque URIs are used (rather than a hierarchical URL):
+For some datasources, such as the [`merge`](#using-merge-datasources), [`aws+sm`](#using-aws-sm-datasources), and [`aws+smp`](#using-aws-smp-datasources) schemes, opaque URIs can be used (rather than a hierarchical URL):
 
 ```pre
 scheme                   path        query   fragment
@@ -160,10 +160,10 @@ See details on how to configure gomplate's AWS support in [_Configuring AWS_](..
 
 ### URL Considerations
 
-The _scheme_ and _path_ URL components are used by this datasource.
+The _scheme_ and _path_ URL components are used by this datasource. This may be an _opaque_ URI instead of an URL, when the key does not begin with a `/` character (e.g. `aws+smp:myparam`).
 
 - the _scheme_ must be `aws+smp`
-- the _path_ component is used to specify the path to the parameter. [Directory](#directory-datasources) semantics are available when the path ends with a `/` character.
+- the _path_ component is used to specify the path to the parameter (this may be a hierarchical path beginning with `/`, or an opaque path). [Directory](#directory-datasources) semantics are available when the path ends with a `/` character.
 
 ### Output
 
@@ -186,6 +186,7 @@ Given your [AWS account's Parameter Store](https://eu-west-1.console.aws.amazon.
 - `/foo/first/others` - `Bill,Ben` (a StringList)
 - `/foo/first/password` - `super-secret` (a SecureString)
 - `/foo/second/p1` - `aaa`
+- `myparameter` - `bar`
 
 ```console
 $ echo '{{ ds "foo" }}' | gomplate -d foo=aws+smp:///foo/first/password
@@ -205,12 +206,19 @@ $ gomplate -d foo=aws+smp:///foo/first/ -i '{{ range (ds "foo") }}
 {{- end }}'
 others: Bill,Ben
 password: super-secret
+
+$ gomplate -d foo=aws+smp:myparameter -i '{{ (ds "foo").Value }}
+bar
 ```
 
 ## Using `aws+sm` datasource
 
 ### URL Considerations
-For `aws+sm`, only the _scheme_ and _path_ components are necessary to be defined. Other URL components are ignored.
+
+For `aws+sm`, only the _scheme_ and _path_ components are necessary to be defined. This may be an _opaque_ URI instead of an URL, when the key does not begin with a `/` character (e.g. `aws+sm:myparam`).
+
+- the _scheme_ must be `aws+sm`
+- the _path_ component is used to specify the path to the secret (this may be a hierarchical path beginning with `/`, or an opaque path)
 
 ### Output
 
@@ -221,6 +229,7 @@ The output will be the SecretString from the `GetSecretValueOutput` object from 
 Given your [AWS account's Secret Manager](https://eu-central-1.console.aws.amazon.com/secretsmanager/home?region=eu-central-1#/listSecrets) has the following data:
 
 - `/foo/bar/password` - `super-secret`
+- `mysecret` - `bar`
 
 ```console
 $ echo '{{ (ds "foo") }}' | gomplate -d foo=aws+sm:///foo/bar/password
@@ -231,6 +240,9 @@ super-secret
 
 $ echo '{{ (ds "foo" "/bar/password") }}' | gomplate -d foo=aws+sm:///foo/
 super-secret
+
+$ echo '{{ (ds "foo") }}' | gomplate -d foo=aws+sm:mysecret
+bar
 ```
 
 ## Using `s3` datasources


### PR DESCRIPTION
Fixes #868

Note that this fixes both `aws+sm` and the `aws+smp` datasources.

Allows referencing parameters/secrets that _don't_ start with `/`.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>