### PR TITLE
Update misleading 'go get' install instructions

### DIFF
--- a/docs/content/installing.md
+++ b/docs/content/installing.md
@@ -95,7 +95,7 @@ $ gomplate --help
 If you're a Go user already, sometimes it's faster to just use `go get` to install `gomplate`:
 
 ```console
-$ go get github.com/hairyhenderson/gomplate/cmd/gomplate
+$ go get github.com/hairyhenderson/gomplate/v3/cmd/gomplate
 $ gomplate --help
 ...
 ```


### PR DESCRIPTION
This has been wrong for a long time! Thanks to @mcarifio for stumbling on this and reporting the issue!

Fixes #894 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>