### PR TITLE
Add EC2Tags function

### DIFF
--- a/aws/ec2info.go
+++ b/aws/ec2info.go
@@ -163,6 +163,28 @@ func (e *Ec2Info) Tag(tag string, def ...string) (string, error) {
 	return returnDefault(def), nil
 }
 
+func (e *Ec2Info) Tags() (map[string]string, error) {
+	tags := map[string]string{}
+
+	output, err := e.describeInstance()
+	if err != nil {
+		return tags, err
+	}
+	if output == nil {
+		return tags, nil
+	}
+
+	if len(output.Reservations) > 0 &&
+		len(output.Reservations[0].Instances) > 0 &&
+		len(output.Reservations[0].Instances[0].Tags) > 0 {
+		for _, v := range output.Reservations[0].Instances[0].Tags {
+			tags[*v.Key] = *v.Value
+		}
+	}
+
+	return tags, nil
+}
+
 func (e *Ec2Info) describeInstance() (output *ec2.DescribeInstancesOutput, err error) {
 	// cache the InstanceDescriber here
 	d, err := e.describer()

--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -65,6 +65,32 @@ func TestTag_ValidKey(t *testing.T) {
 	assert.Equal(t, "bar", must(e.Tag("foo", "default")))
 }
 
+func TestTags(t *testing.T) {
+	server, ec2meta := MockServer(200, `"i-1234"`)
+	defer server.Close()
+	client := DummyInstanceDescriber{
+		tags: []*ec2.Tag{
+			{
+				Key:   aws.String("foo"),
+				Value: aws.String("bar"),
+			},
+			{
+				Key:   aws.String("baz"),
+				Value: aws.String("qux"),
+			},
+		},
+	}
+	e := &Ec2Info{
+		describer: func() (InstanceDescriber, error) {
+			return client, nil
+		},
+		metaClient: ec2meta,
+		cache:      make(map[string]interface{}),
+	}
+
+	assert.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, must(e.Tags()))
+}
+
 func TestTag_NonEC2(t *testing.T) {
 	server, ec2meta := MockServer(404, "")
 	ec2meta.nonAWS = true

--- a/docs-src/content/functions/aws.yml
+++ b/docs-src/content/functions/aws.yml
@@ -98,6 +98,18 @@ funcs:
       - |
         $ echo 'I am a {{ aws.EC2Tag "classification" "meat popsicle" }}.' | ./gomplate
         I am a meat popsicle.
+  - name: aws.EC2Tags
+    alias: ec2tags
+    description: |
+      Queries the AWS EC2 API to find all the tags/values [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
+    pipeline: false
+    arguments:
+    examples:
+      - |
+        echo '{{ range $key, $value := aws.EC2Tags }}{{(printf "%s=%s\n" $key $value)}}{{ end }}' | ./gomplate
+        Description=foo
+        Name=bar
+        svc:name=foobar
   - name: aws.KMSEncrypt
     description: |
       Encrypt an input string with the AWS Key Management Service (KMS).

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -144,6 +144,32 @@ $ echo 'I am a {{ aws.EC2Tag "classification" "meat popsicle" }}.' | ./gomplate
 I am a meat popsicle.
 ```
 
+## `aws.EC2Tags`
+
+**Alias:** `ec2tags`
+
+Queries the AWS EC2 API to find all the tags/values [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
+
+### Usage
+
+```go
+aws.EC2Tags
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+
+### Examples
+
+```console
+echo '{{ range $key, $value := aws.EC2Tags }}{{(printf "%s=%s\n" $key $value)}}{{ end }}' | ./gomplate
+Description=foo
+Name=bar
+svc:name=foobar
+```
+
 ## `aws.KMSEncrypt`
 
 Encrypt an input string with the AWS Key Management Service (KMS).

--- a/funcs/aws.go
+++ b/funcs/aws.go
@@ -43,6 +43,7 @@ func CreateAWSFuncs(ctx context.Context) map[string]interface{} {
 	f["ec2meta"] = ns.EC2Meta
 	f["ec2dynamic"] = ns.EC2Dynamic
 	f["ec2tag"] = ns.EC2Tag
+	f["ec2tags"] = ns.EC2Tags
 	f["ec2region"] = ns.EC2Region
 	return f
 }
@@ -84,6 +85,12 @@ func (a *Funcs) EC2Dynamic(key string, def ...string) (string, error) {
 func (a *Funcs) EC2Tag(tag string, def ...string) (string, error) {
 	a.infoInit.Do(a.initInfo)
 	return a.info.Tag(tag, def...)
+}
+
+// EC2Tag -
+func (a *Funcs) EC2Tags() (map[string]string, error) {
+	a.infoInit.Do(a.initInfo)
+	return a.info.Tags()
 }
 
 // KMSEncrypt -


### PR DESCRIPTION
This adds a function to get all the EC2 tags. It is useful when we don't know the full tag upfront, but know the prefix/suffix of it.
