### PR TITLE
Only open output files when necessary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/zealic/xignore v0.3.3
 	gocloud.dev v0.20.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
+	golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/hairyhenderson/gomplate/v3/data"
 	"github.com/hairyhenderson/gomplate/v3/env"
-	"github.com/hairyhenderson/gomplate/v3/internal/writers"
+	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -158,7 +158,7 @@ func TestCustomDelim(t *testing.T) {
 func TestRunTemplates(t *testing.T) {
 	defer func() { Stdout = os.Stdout }()
 	buf := &bytes.Buffer{}
-	Stdout = &writers.NopCloser{Writer: buf}
+	Stdout = &iohelpers.NopCloser{Writer: buf}
 	config := &Config{Input: "foo", OutputFiles: []string{"-"}}
 	err := RunTemplates(config)
 	assert.NoError(t, err)

--- a/internal/iohelpers/readers.go
+++ b/internal/iohelpers/readers.go
@@ -1,0 +1,48 @@
+package iohelpers
+
+import (
+	"io"
+	"sync"
+)
+
+// LazyReadCloser provides an interface to a ReadCloser that will open on the
+// first access. The wrapped io.ReadCloser must be provided by 'open'.
+func LazyReadCloser(open func() (io.ReadCloser, error)) io.ReadCloser {
+	return &lazyReadCloser{
+		opened: sync.Once{},
+		open:   open,
+	}
+}
+
+type lazyReadCloser struct {
+	opened sync.Once
+	r      io.ReadCloser
+	// caches the error that came from open(), if any
+	openErr error
+	open    func() (io.ReadCloser, error)
+}
+
+var _ io.ReadCloser = (*lazyReadCloser)(nil)
+
+func (l *lazyReadCloser) openReader() (r io.ReadCloser, err error) {
+	l.opened.Do(func() {
+		l.r, l.openErr = l.open()
+	})
+	return l.r, l.openErr
+}
+
+func (l *lazyReadCloser) Close() error {
+	r, err := l.openReader()
+	if err != nil {
+		return err
+	}
+	return r.Close()
+}
+
+func (l *lazyReadCloser) Read(p []byte) (n int, err error) {
+	r, err := l.openReader()
+	if err != nil {
+		return 0, err
+	}
+	return r.Read(p)
+}

--- a/internal/iohelpers/readers_test.go
+++ b/internal/iohelpers/readers_test.go
@@ -1,0 +1,49 @@
+package iohelpers
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLazyReadCloser(t *testing.T) {
+	r := newBufferCloser(bytes.NewBufferString("hello world"))
+	opened := false
+	l, ok := LazyReadCloser(func() (io.ReadCloser, error) {
+		opened = true
+		return r, nil
+	}).(*lazyReadCloser)
+	assert.True(t, ok)
+
+	assert.False(t, opened)
+	assert.Nil(t, l.r)
+	assert.False(t, r.closed)
+
+	p := make([]byte, 5)
+	n, err := l.Read(p)
+	assert.NoError(t, err)
+	assert.True(t, opened)
+	assert.Equal(t, r, l.r)
+	assert.Equal(t, 5, n)
+
+	err = l.Close()
+	assert.NoError(t, err)
+	assert.True(t, r.closed)
+
+	// test error propagation
+	l = LazyReadCloser(func() (io.ReadCloser, error) {
+		return nil, os.ErrNotExist
+	}).(*lazyReadCloser)
+
+	assert.Nil(t, l.r)
+
+	p = make([]byte, 5)
+	_, err = l.Read(p)
+	assert.Error(t, err)
+
+	err = l.Close()
+	assert.Error(t, err)
+}

--- a/internal/tests/integration/inputdir_test.go
+++ b/internal/tests/integration/inputdir_test.go
@@ -43,10 +43,6 @@ out/{{ .in | strings.ReplaceAll $f (index .filemap $f) }}.out
 	)
 }
 
-func (s *InputDirSuite) TearDownTest(c *C) {
-	s.tmpDir.Remove()
-}
-
 func (s *InputDirSuite) TestInputDir(c *C) {
 	result := icmd.RunCommand(GomplateBin,
 		"--input-dir", s.tmpDir.Join("in"),

--- a/internal/tests/integration/inputdir_unix_test.go
+++ b/internal/tests/integration/inputdir_unix_test.go
@@ -1,0 +1,70 @@
+//+build integration
+//+build !windows
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+func setFileUlimit(b uint64) error {
+	ulimit := unix.Rlimit{
+		Cur: b,
+		Max: math.MaxInt64,
+	}
+	err := unix.Setrlimit(unix.RLIMIT_NOFILE, &ulimit)
+	return err
+}
+
+func (s *InputDirSuite) TestInputDirRespectsUlimit(c *C) {
+	numfiles := 32
+	flist := map[string]string{}
+	for i := 0; i < numfiles; i++ {
+		k := fmt.Sprintf("file_%d", i)
+		flist[k] = fmt.Sprintf("hello world %d\n", i)
+	}
+	testdir := fs.NewDir(c, "ulimittestfiles",
+		fs.WithDir("in", fs.WithFiles(flist)),
+	)
+	defer testdir.Remove()
+
+	// we need another ~11 fds for other various things, so we'd be guaranteed
+	// to hit the limit if we try to have all the input files open
+	// simultaneously
+	setFileUlimit(uint64(numfiles))
+	defer setFileUlimit(8192)
+
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"--input-dir", testdir.Join("in"),
+		"--output-dir", testdir.Join("out"),
+	), func(c *icmd.Cmd) {
+		c.Dir = testdir.Path()
+	})
+	setFileUlimit(8192)
+	result.Assert(c, icmd.Success)
+
+	files, err := ioutil.ReadDir(testdir.Join("out"))
+	assert.NilError(c, err)
+	assert.Equal(c, numfiles, len(files))
+
+	for i := 0; i < numfiles; i++ {
+		f := testdir.Join("out", fmt.Sprintf("file_%d", i))
+		_, err := os.Stat(f)
+		assert.NilError(c, err)
+
+		content, err := ioutil.ReadFile(f)
+		assert.NilError(c, err)
+		expected := fmt.Sprintf("hello world %d\n", i)
+		assert.Equal(c, expected, string(content))
+	}
+}

--- a/template_unix.go
+++ b/template_unix.go
@@ -1,0 +1,17 @@
+//+build !windows
+
+package gomplate
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func isDirError(name string) *os.PathError {
+	return &os.PathError{
+		Op:   "open",
+		Path: name,
+		Err:  unix.EISDIR,
+	}
+}

--- a/template_windows.go
+++ b/template_windows.go
@@ -1,0 +1,17 @@
+//+build windows
+
+package gomplate
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func isDirError(name string) *os.PathError {
+	return &os.PathError{
+		Op:   "open",
+		Path: name,
+		Err:  windows.ERROR_INVALID_HANDLE,
+	}
+}


### PR DESCRIPTION
Fixes #928 

This should streamline resource usage a bunch, especially when templating directories with large numbers of files.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>