### PR TITLE
Fix bug where context cancellation doesn't have a chance to run on errors

### DIFF
--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -150,6 +150,11 @@ func initFlags(command *cobra.Command) {
 }
 
 func main() {
+	exitCode := 0
+	// defer the exit first to make sure that other deferred functions have a
+	// chance to run
+	defer func() { os.Exit(exitCode) }()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ctx = initLogger(ctx)
@@ -158,6 +163,7 @@ func main() {
 	initFlags(command)
 	if err := command.ExecuteContext(ctx); err != nil {
 		log := zerolog.Ctx(ctx)
-		log.Fatal().Err(err).Send()
+		log.Error().Err(err).Send()
+		exitCode = 1
 	}
 }

--- a/conv/conv.go
+++ b/conv/conv.go
@@ -260,7 +260,7 @@ func ToFloat64(v interface{}) float64 {
 
 func strToInt64(str string) int64 {
 	if strings.Contains(str, ",") {
-		str = strings.Replace(str, ",", "", -1)
+		str = strings.ReplaceAll(str, ",", "")
 	}
 	iv, err := strconv.ParseInt(str, 0, 64)
 	if err != nil {
@@ -277,7 +277,7 @@ func strToInt64(str string) int64 {
 
 func strToFloat64(str string) float64 {
 	if strings.Contains(str, ",") {
-		str = strings.Replace(str, ",", "", -1)
+		str = strings.ReplaceAll(str, ",", "")
 	}
 	// this is inefficient, but it's the only way I can think of to
 	// properly convert octal integers to floats

--- a/funcs/random.go
+++ b/funcs/random.go
@@ -101,7 +101,7 @@ var rlen = utf8.RuneCountInString
 func toCodePoints(l, u string) (rune, rune, error) {
 	// no way are these representing valid printable codepoints - we'll treat
 	// them as runes
-	if rlen(l) == rlen(u) && rlen(l) == 1 {
+	if rlen(l) == 1 && rlen(u) == 1 {
 		lower, _ := utf8.DecodeRuneInString(l)
 		upper, _ := utf8.DecodeRuneInString(u)
 		return lower, upper, nil

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -99,7 +99,7 @@ func (f *StringFuncs) Abbrev(args ...interface{}) (string, error) {
 
 // ReplaceAll -
 func (f *StringFuncs) ReplaceAll(old, new string, s interface{}) string {
-	return strings.Replace(conv.ToString(s), old, new, -1)
+	return strings.ReplaceAll(conv.ToString(s), old, new)
 }
 
 // Contains -
@@ -258,7 +258,7 @@ func (f *StringFuncs) ShellQuote(in interface{}) string {
 // Squote -
 func (f *StringFuncs) Squote(in interface{}) string {
 	s := conv.ToString(in)
-	s = strings.Replace(s, `'`, `''`, -1)
+	s = strings.ReplaceAll(s, `'`, `''`)
 	return fmt.Sprintf("'%s'", s)
 }
 

--- a/internal/tests/integration/strings_test.go
+++ b/internal/tests/integration/strings_test.go
@@ -67,7 +67,7 @@ things very badly. To wit:
 https://example.com/a/super-long/url/that-shouldnt-be?wrapped=for+fear+of#the-breaking-of-functionality
 should appear on its own line, regardless of the desired word-wrapping width
 that has been set.`
-	text := strings.Replace(out, "\n", " ", -1)
+	text := strings.ReplaceAll(out, "\n", " ")
 	in := `{{ print "` + text + `" | strings.WordWrap 80 }}`
 	inOutTest(c, in, out)
 }

--- a/internal/tests/integration/typeconv_test.go
+++ b/internal/tests/integration/typeconv_test.go
@@ -24,10 +24,10 @@ COBOL	357`
 )
 
 func (s *TypeconvSuite) TestTypeconvFuncs(c *C) {
-	//@test "'has' can handle sub-maps in nested maps" {
 	inOutTest(c, `{{ has ("`+testYAML+`" | yaml).foo.bar "baz"}}`,
 		"true")
 }
+
 func (s *TypeconvSuite) TestJSON(c *C) {
 	inOutTest(c, `{{ "`+testYAML+`" | yaml | toJSON }}`, testJSON)
 

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -32,7 +32,7 @@ func Indent(width int, indent, s string) string {
 
 // ShellQuote - generate a POSIX shell literal evaluating to a string
 func ShellQuote(s string) string {
-	return "'" + strings.Replace(s, "'", "'\"'\"'", -1) + "'"
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
 // Trunc - truncate a string to the given length

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -86,7 +86,7 @@ things very badly. To wit:
 https://example.com/a/super-long/url/that-shouldnt-be?wrapped=for+fear+of#the-breaking-of-functionality
 should appear on its own line, regardless of the desired word-wrapping width
 that has been set.`
-	in = strings.Replace(out, "\n", " ", -1)
+	in = strings.ReplaceAll(out, "\n", " ")
 	assert.Equal(t, out, WordWrap(in, WordWrapOpts{}))
 
 	// TODO: get these working - need to switch to a word-wrapping package that
@@ -102,7 +102,7 @@ that has been set.`
 	// καὶ καιρὸς τοῦ ἐκβαλεῖν, καιρὸς τοῦ ρῆξαι καὶ καιρὸς τοῦ ράψαι, καιρὸς τοῦ
 	// σιγᾶν καὶ καιρὸς τοῦ λαλεῖν, καιρὸς τοῦ φιλῆσαι καὶ καιρὸς τοῦ μισῆσαι, καιρὸς
 	// πολέμου καὶ καιρὸς εἰρήνης.`
-	// 	in = strings.Replace(out, "\n", " ", -1)
+	// 	in = strings.ReplaceAll(out, "\n", " ")
 	// 	assert.Equal(t, out, WordWrap(in, WordWrapOpts{}))
 
 	// TODO: get these working - need to switch to a word-wrapping package that
@@ -119,6 +119,6 @@ that has been set.`
 	// 大切にしまっておく時、遠くに投げ捨てる時、
 	// 引き裂く時、修理する時、黙っている時、口を開く時、
 	// 愛する時、憎む時、戦う時、和解する時。`
-	// 	in = strings.Replace(out, "\n", " ", -1)
+	// 	in = strings.ReplaceAll(out, "\n", " ")
 	// 	assert.Equal(t, out, WordWrap(in, WordWrapOpts{Width: 100}))
 }

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -208,7 +208,7 @@ func createEc2LoginVars(nonce string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	vars["pkcs7"] = strings.Replace(strings.TrimSpace(doc), "\n", "", -1)
+	vars["pkcs7"] = strings.ReplaceAll(strings.TrimSpace(doc), "\n", "")
 	return vars, nil
 }
 


### PR DESCRIPTION
A few fixes for issues caught by the linter, including a bug where the main context would not be cancelled when gomplate errors.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>