### PR TITLE
Access metadata at API version level

### DIFF
--- a/gcp/meta.go
+++ b/gcp/meta.go
@@ -76,7 +76,7 @@ func NewMetaClient(options ClientOptions) *MetaClient {
 // Meta retrieves a value from the GCP Instance Metadata Service, returning the given default
 // if the service is unavailable or the requested URL does not exist.
 func (c *MetaClient) Meta(key string, def ...string) (string, error) {
-	url := c.endpoint + "/computeMetadata/v1/instance/" + key
+	url := c.endpoint + "/computeMetadata/" + key
 	return c.retrieveMetadata(url, def...)
 }
 


### PR DESCRIPTION
This should allow to fetch additional information from metadata like {{ gcp.Meta "v1/project/numeric-project-id" }} which can be useful when for example the value of numeric-project-id is interpolated in resources like GCS bucket names or access different API versions