### PR TITLE
Updates upx to 3.96

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.1.7-experimental
-FROM --platform=linux/amd64 hairyhenderson/upx:3.94 AS upx
+FROM --platform=linux/amd64 hairyhenderson/upx:3.96 AS upx
 
 FROM --platform=linux/amd64 golang:1.15.0-alpine3.12 AS build
 


### PR DESCRIPTION
**Motivation**
I'm having issues running gomplate's docker image on arm64. The binary failes to execute properly:
```
/ # /bin/gomplate
PROT_EXEC|PROT_WRITE failed.
```

I've traced this down to upx. If I decompress the binary, it works just fine.
```
/ # /tmp/upx/upx-3.96-arm64_linux/upx -d /bin/gomplate 
                       Ultimate Packer for eXecutables
                          Copyright (C) 1996 - 2020
UPX 3.96        Markus Oberhumer, Laszlo Molnar & John Reiser   Jan 23rd 2020

        File size         Ratio      Format      Name
   --------------------   ------   -----------   -----------
  35061760 <-   6503964   18.55%   linux/arm64   gomplate

Unpacked 1 file.
/ # /bin/gomplate
^C
/ # /bin/gomplate --version
gomplate version 3.8.0
```

Moreover, if I recompress the binary with the original cli options (I believe you're using '--lzma'), it still works. I'm using upx 3.96 though, so I believe there was probably a bug that they fixed between 3.94 and 3.96, that is causing this.
Can't really confirm if compressing with upx 3.94 will reproduce the issue, since 3.94 doesn't seem to have an arm64 binary yet :(  But I'm still hoping this PR will fix it.