### PR TITLE
Fix ignored left/right delim env vars

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -26,7 +26,6 @@ var fs = afero.NewOsFs()
 // - creates a config.Config from the config file (if present)
 // - merges the two (flags take precedence)
 // - validates the final config
-// - converts the config to a *gomplate.Config for further use (TODO: eliminate this part)
 func loadConfig(cmd *cobra.Command, args []string) (*config.Config, error) {
 	ctx := cmd.Context()
 	flagConfig, err := cobraConfig(cmd, args)
@@ -256,6 +255,9 @@ func applyEnvVars(ctx context.Context, cfg *config.Config) (*config.Config, erro
 	if !cfg.Experimental && conv.ToBool(env.Getenv("GOMPLATE_EXPERIMENTAL", "false")) {
 		cfg.Experimental = true
 	}
+
+	cfg.LDelim = env.Getenv("GOMPLATE_LEFT_DELIM", cfg.LDelim)
+	cfg.RDelim = env.Getenv("GOMPLATE_RIGHT_DELIM", cfg.RDelim)
 
 	return cfg, nil
 }

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -252,6 +252,36 @@ func TestApplyEnvVars(t *testing.T) {
 			&config.Config{Experimental: true},
 			&config.Config{Experimental: true},
 		},
+		{
+			"GOMPLATE_LEFT_DELIM", "--",
+			false,
+			&config.Config{},
+			&config.Config{LDelim: "--"},
+		},
+		{
+			"GOMPLATE_LEFT_DELIM", "--",
+			false,
+			&config.Config{LDelim: "{{"},
+			&config.Config{LDelim: "--"},
+		},
+		{
+			"GOMPLATE_RIGHT_DELIM", ")>",
+			false,
+			&config.Config{},
+			&config.Config{RDelim: ")>"},
+		},
+		{
+			"GOMPLATE_RIGHT_DELIM", ")>",
+			false,
+			&config.Config{RDelim: "}}"},
+			&config.Config{RDelim: ")>"},
+		},
+		{
+			"GOMPLATE_RIGHT_DELIM", "",
+			false,
+			&config.Config{RDelim: "}}"},
+			&config.Config{RDelim: "}}"},
+		},
 	}
 
 	for i, d := range data {

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -109,7 +109,10 @@ func NewGomplateCmd() *cobra.Command {
 	return rootCmd
 }
 
-// InitFlags -
+// InitFlags - initialize the various flags and help strings on the command.
+// Note that the defaults set here are ignored, and instead defaults from
+// *config.Config's ApplyDefaults method are used instead. Changes here must be
+// reflected there as well.
 func InitFlags(command *cobra.Command) {
 	command.Flags().SortFlags = false
 
@@ -135,6 +138,7 @@ func InitFlags(command *cobra.Command) {
 
 	command.Flags().Bool("exec-pipe", false, "pipe the output to the post-run exec command")
 
+	// these are only set for the help output - these defaults aren't actually used
 	ldDefault := env.Getenv("GOMPLATE_LEFT_DELIM", "{{")
 	rdDefault := env.Getenv("GOMPLATE_RIGHT_DELIM", "}}")
 	command.Flags().String("left-delim", ldDefault, "override the default left-`delimiter` [$GOMPLATE_LEFT_DELIM]")

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -432,7 +432,8 @@ func isZero(value interface{}) bool {
 	}
 }
 
-// ApplyDefaults -
+// ApplyDefaults - any defaults changed here should be added to cmd.InitFlags as
+// well for proper help/usage display.
 func (c *Config) ApplyDefaults() {
 	if c.InputDir != "" && c.OutputDir == "" && c.OutputMap == "" {
 		c.OutputDir = "."

--- a/internal/tests/integration/basic_test.go
+++ b/internal/tests/integration/basic_test.go
@@ -153,19 +153,19 @@ func (s *BasicSuite) TestDelimsChangedThroughOpts(c *C) {
 	result := icmd.RunCommand(GomplateBin,
 		"--left-delim", "((",
 		"--right-delim", "))",
-		"-i", `((print "hi"))`)
-	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hi"})
+		"-i", `foo((print "hi"))`)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "foohi"})
 }
 
 func (s *BasicSuite) TestDelimsChangedThroughEnvVars(c *C) {
-	result := icmd.RunCmd(icmd.Command(GomplateBin, "-i", `<<print "hi">>`),
+	result := icmd.RunCmd(icmd.Command(GomplateBin, "-i", `foo<<print "hi">>`),
 		func(cmd *icmd.Cmd) {
 			cmd.Env = []string{
 				"GOMPLATE_LEFT_DELIM=<<",
 				"GOMPLATE_RIGHT_DELIM=>>",
 			}
 		})
-	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hi"})
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "foohi"})
 }
 
 func (s *BasicSuite) TestUnknownArgErrors(c *C) {


### PR DESCRIPTION
Fixes #1018

Ever since I added config file support the defaults on the command flags have effectively been only for documentation purposes. This fixes the handling of `GOMPLATE_LEFT_DELIM` and `GOMPLATE_RIGHT_DELIM`.

The integration tests for this only passed by fluke 🤦‍♂️. I've updated them, and added some extra unit tests too.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>