### PR TITLE
Only print newline with console output

### DIFF
--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -93,7 +93,13 @@ func NewGomplateCmd() *cobra.Command {
 			cmd.SilenceErrors = true
 			cmd.SilenceUsage = true
 
-			fmt.Fprintf(os.Stderr, "\n")
+			// print a newline to stderr for convenience if the output is going
+			// to stdout, since otherwise the shell prompt may look wrong
+			// Note: once stdin/out/err are externalized we should only do this
+			// if stdout isn't ending with its own newline!
+			if len(cfg.OutputFiles) == 0 || (len(cfg.OutputFiles) == 1 && cfg.OutputFiles[0] == "-") && !cfg.ExecPipe {
+				fmt.Fprintf(os.Stderr, "\n")
+			}
 			log.Debug().Int("templatesRendered", gomplate.Metrics.TemplatesProcessed).
 				Int("errors", gomplate.Metrics.Errors).
 				Dur("duration", gomplate.Metrics.TotalRenderDuration).

--- a/internal/tests/integration/basic_test.go
+++ b/internal/tests/integration/basic_test.go
@@ -45,6 +45,7 @@ func (s *BasicSuite) TestTakesStdinByDefault(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
+	assert.Equal(c, "hello world\n", result.Combined())
 }
 
 func (s *BasicSuite) TestTakesStdinWithFileFlag(c *C) {
@@ -52,12 +53,14 @@ func (s *BasicSuite) TestTakesStdinWithFileFlag(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
+	assert.Equal(c, "hello world\n", result.Combined())
 }
 func (s *BasicSuite) TestWritesToStdoutWithOutFlag(c *C) {
 	result := icmd.RunCmd(icmd.Command(GomplateBin, "--out", "-"), func(cmd *icmd.Cmd) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
+	assert.Equal(c, "hello world\n", result.Combined())
 }
 
 func (s *BasicSuite) TestIgnoresStdinWithInFlag(c *C) {
@@ -65,6 +68,7 @@ func (s *BasicSuite) TestIgnoresStdinWithInFlag(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hi"})
+	assert.Equal(c, "hi\n", result.Combined())
 }
 
 func (s *BasicSuite) TestErrorsWithInputOutputImbalance(c *C) {
@@ -91,6 +95,7 @@ func (s *BasicSuite) TestRoutesInputsToProperOutputs(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Success)
+	assert.Equal(c, "", result.Combined())
 
 	testdata := []struct {
 		path    string
@@ -183,6 +188,7 @@ func (s *BasicSuite) TestExecCommand(c *C) {
 		ExitCode: 0,
 		Out:      "hello world",
 	})
+	assert.Equal(c, "hello world", result.Combined())
 }
 
 func (s *BasicSuite) TestPostRunExecPipe(c *C) {
@@ -194,6 +200,7 @@ func (s *BasicSuite) TestPostRunExecPipe(c *C) {
 		ExitCode: 0,
 		Out:      "HELLO WORLD",
 	})
+	assert.Equal(c, "HELLO WORLD", result.Combined())
 }
 
 func (s *BasicSuite) TestEmptyOutputSuppression(c *C) {


### PR DESCRIPTION
Fixes #996 

I need to entirely remove gomplate's use of stdin/stdout/stderr except for at the edges, but until then this'll fix this annoying issue!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>