### PR TITLE
Prefer env.Getenv to os.Getenv

### DIFF
--- a/aws/ec2info.go
+++ b/aws/ec2info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/pkg/errors"
 )
 
@@ -44,7 +45,7 @@ type InstanceDescriber interface {
 // ... but cannot use in vault/auth.go as different strconv.Atoi error handling
 func GetClientOptions() ClientOptions {
 	coInit.Do(func() {
-		timeout := os.Getenv("AWS_TIMEOUT")
+		timeout := env.Getenv("AWS_TIMEOUT")
 		if timeout == "" {
 			timeout = "500"
 		}
@@ -71,7 +72,7 @@ func SDKSession(region ...string) *session.Session {
 		config := aws.NewConfig()
 		config = config.WithHTTPClient(&http.Client{Timeout: timeout})
 
-		if os.Getenv("AWS_ANON") == "true" {
+		if env.Getenv("AWS_ANON") == "true" {
 			config = config.WithCredentials(credentials.AnonymousCredentials)
 		}
 

--- a/gcp/meta.go
+++ b/gcp/meta.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,7 +32,7 @@ type ClientOptions struct {
 // ... but cannot use in vault/auth.go as different strconv.Atoi error handling
 func GetClientOptions() ClientOptions {
 	coInit.Do(func() {
-		timeout := os.Getenv("GCP_TIMEOUT")
+		timeout := env.Getenv("GCP_TIMEOUT")
 		if timeout == "" {
 			timeout = "500"
 		}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -200,7 +200,7 @@ func createEc2LoginVars(nonce string) (map[string]interface{}, error) {
 	}
 
 	opts := aws.ClientOptions{
-		Timeout: time.Duration(conv.MustAtoi(os.Getenv("AWS_TIMEOUT"))) * time.Millisecond,
+		Timeout: time.Duration(conv.MustAtoi(env.Getenv("AWS_TIMEOUT"))) * time.Millisecond,
 	}
 
 	meta := aws.NewEc2Meta(opts)


### PR DESCRIPTION
Most places that read environment variables used [`env.Getenv`](https://pkg.go.dev/github.com/hairyhenderson/gomplate/v3/env#Getenv). Now, all of them do.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>