### PR TITLE
Fix precedence bug with L/R Delimiters

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -260,8 +260,12 @@ func applyEnvVars(ctx context.Context, cfg *config.Config) (*config.Config, erro
 		cfg.Experimental = true
 	}
 
-	cfg.LDelim = env.Getenv("GOMPLATE_LEFT_DELIM", cfg.LDelim)
-	cfg.RDelim = env.Getenv("GOMPLATE_RIGHT_DELIM", cfg.RDelim)
+	if cfg.LDelim == "" {
+		cfg.LDelim = env.Getenv("GOMPLATE_LEFT_DELIM")
+	}
+	if cfg.RDelim == "" {
+		cfg.RDelim = env.Getenv("GOMPLATE_RIGHT_DELIM")
+	}
 
 	return cfg, nil
 }

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -274,7 +274,7 @@ func TestApplyEnvVars(t *testing.T) {
 			"GOMPLATE_LEFT_DELIM", "--",
 			false,
 			&config.Config{LDelim: "{{"},
-			&config.Config{LDelim: "--"},
+			&config.Config{LDelim: "{{"},
 		},
 		{
 			"GOMPLATE_RIGHT_DELIM", ")>",
@@ -286,7 +286,7 @@ func TestApplyEnvVars(t *testing.T) {
 			"GOMPLATE_RIGHT_DELIM", ")>",
 			false,
 			&config.Config{RDelim: "}}"},
-			&config.Config{RDelim: ")>"},
+			&config.Config{RDelim: "}}"},
 		},
 		{
 			"GOMPLATE_RIGHT_DELIM", "",

--- a/internal/tests/integration/config_test.go
+++ b/internal/tests/integration/config_test.go
@@ -165,7 +165,7 @@ datasources:
 		s.writeFile("in.yaml", `value: hello world`)
 		result := icmd.RunCmd(icmd.Command(GomplateBin), func(cmd *icmd.Cmd) {
 			cmd.Dir = s.tmpDir.Path()
-			cmd.Env = []string{"GOMPLATE_LEFT_DELIM", "<<"}
+			cmd.Env = []string{"GOMPLATE_LEFT_DELIM=<<"}
 		})
 		result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
 	}
@@ -183,7 +183,7 @@ datasources:
 		s.writeFile("in.yaml", `value: hello world`)
 		result := icmd.RunCmd(icmd.Command(GomplateBin, "--left-delim={{"), func(cmd *icmd.Cmd) {
 			cmd.Dir = s.tmpDir.Path()
-			cmd.Env = []string{"GOMPLATE_LEFT_DELIM", "<<"}
+			cmd.Env = []string{"GOMPLATE_LEFT_DELIM=<<"}
 		})
 		result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
 	}


### PR DESCRIPTION
Both the integration test and unit test for this particular behaviour were broken 🤦‍♂️

The rules of precedence are flags, then config file entries, then finally falling back to environment variables.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>