### PR TITLE
Adding in-process integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - checkout
       - run: cc-test-reporter before-build
+      - run: |
+          git config --global user.email "bogus@example.com"
+          git config --global user.name "Someone"
       - run:
           name: make test
           command: |

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,7 @@ github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.17.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.36.1/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.37.6 h1:SWYjRvyZw6DJc3pkZfRWVRD/5wiTDuwOkyb89AAkEBY=
-github.com/aws/aws-sdk-go v1.37.6/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -531,8 +530,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/afero v1.5.1 h1:VHu76Lk0LSP1x254maIu2bplkWpfBWI+B+6fdoZprcg=
 github.com/spf13/afero v1.5.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
-github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -960,8 +958,8 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/internal/tests/inprocess-integration/base64_test.go
+++ b/internal/tests/inprocess-integration/base64_test.go
@@ -1,0 +1,17 @@
+package integration
+
+import (
+	"gopkg.in/check.v1"
+)
+
+type Base64Suite struct{}
+
+var _ = check.Suite(&Base64Suite{})
+
+func (s *Base64Suite) TestBase64Encode(c *check.C) {
+	inOutTest(c, `{{ "foo" | base64.Encode }}`, "Zm9v")
+}
+
+func (s *Base64Suite) TestBase64Decode(c *check.C) {
+	inOutTest(c, `{{ "Zm9v" | base64.Decode }}`, "foo")
+}

--- a/internal/tests/inprocess-integration/basic_test.go
+++ b/internal/tests/inprocess-integration/basic_test.go
@@ -1,0 +1,258 @@
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+	"gotest.tools/v3/fs"
+)
+
+type BasicSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&BasicSuite{})
+
+func (s *BasicSuite) SetUpTest(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("one", "hi\n", fs.WithMode(0640)),
+		fs.WithFile("two", "hello\n"),
+		fs.WithFile("broken", "", fs.WithMode(0000)))
+}
+
+func (s *BasicSuite) TearDownTest(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *BasicSuite) TestReportsVersion(c *C) {
+	o, e, err := cmdTest(c, "-v")
+	assertSuccess(c, o, e, err, "gomplate version 0.0.0\n")
+}
+
+func (s *BasicSuite) TestTakesStdinByDefault(c *C) {
+	o, e, err := cmdWithStdin(c, nil, "hello world")
+	assertSuccess(c, o, e, err, "hello world")
+}
+
+func (s *BasicSuite) TestTakesStdinWithFileFlag(c *C) {
+	o, e, err := cmdWithStdin(c, []string{"--file", "-"}, "hello world")
+	assertSuccess(c, o, e, err, "hello world")
+}
+
+func (s *BasicSuite) TestWritesToStdoutWithOutFlag(c *C) {
+	o, e, err := cmdWithStdin(c, []string{"--out", "-"}, "hello world")
+	assertSuccess(c, o, e, err, "hello world")
+}
+
+func (s *BasicSuite) TestIgnoresStdinWithInFlag(c *C) {
+	o, e, err := cmdWithStdin(c, []string{"--in", "hi"}, "hello world")
+	assertSuccess(c, o, e, err, "hi")
+}
+
+func (s *BasicSuite) TestErrorsWithInputOutputImbalance(c *C) {
+	_, _, err := cmdTest(c,
+		"-f", s.tmpDir.Join("one"),
+		"-f", s.tmpDir.Join("two"),
+		"-o", s.tmpDir.Join("out"),
+	)
+	assert.ErrorContains(c, err, "must provide same number of 'outputFiles' (1) as 'in' or 'inputFiles' (2) options")
+}
+
+func (s *BasicSuite) TestRoutesInputsToProperOutputs(c *C) {
+	oneOut := s.tmpDir.Join("one.out")
+	twoOut := s.tmpDir.Join("two.out")
+
+	o, e, err := cmdTest(c,
+		"-f", s.tmpDir.Join("one"),
+		"-f", s.tmpDir.Join("two"),
+		"-o", oneOut,
+		"-o", twoOut,
+	)
+	assertSuccess(c, o, e, err, "")
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{oneOut, 0640, "hi\n"},
+		{twoOut, 0644, "hello\n"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		m := config.NormalizeFileMode(v.mode)
+		assert.Equal(c, m, info.Mode(), v.path)
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *BasicSuite) TestFlagRules(c *C) {
+	testdata := []struct {
+		args   []string
+		errmsg string
+	}{
+		{
+			[]string{"-f", "-", "-i", "HELLO WORLD"},
+			"only one of these options is supported at a time: 'in', 'inputFiles'",
+		},
+		{
+			[]string{"--output-dir", "."},
+			"these options must be set together: 'outputDir', 'inputDir'",
+		},
+		{
+			[]string{"--input-dir", ".", "--in", "param"},
+			"only one of these options is supported at a time: 'in', 'inputDir'",
+		},
+		{
+			[]string{"--input-dir", ".", "--file", "input.txt"},
+			"only one of these options is supported at a time: 'inputFiles', 'inputDir'",
+		},
+		{
+			[]string{"--output-dir", ".", "--out", "param"},
+			"only one of these options is supported at a time: 'outputFiles', 'outputDir'",
+		},
+		{
+			[]string{"--output-map", ".", "--out", "param"},
+			"only one of these options is supported at a time: 'outputFiles', 'outputMap'",
+		},
+	}
+
+	for _, d := range testdata {
+		_, _, err := cmdTest(c, d.args...)
+		assert.ErrorContains(c, err, d.errmsg)
+	}
+}
+
+func (s *BasicSuite) TestDelimsChangedThroughOpts(c *C) {
+	o, e, err := cmdTest(c,
+		"--left-delim", "((",
+		"--right-delim", "))",
+		"-i", `foo((print "hi"))`,
+	)
+	assertSuccess(c, o, e, err, "foohi")
+}
+
+func (s *BasicSuite) TestDelimsChangedThroughEnvVars(c *C) {
+	o, e, err := cmdWithEnv(c, []string{"-i", `foo<<print "hi">>`}, map[string]string{
+		"GOMPLATE_LEFT_DELIM":  "<<",
+		"GOMPLATE_RIGHT_DELIM": ">>",
+	})
+	assertSuccess(c, o, e, err, "foohi")
+}
+
+func (s *BasicSuite) TestUnknownArgErrors(c *C) {
+	_, e, err := cmdTest(c, "-in", "flibbit")
+	assert.ErrorContains(c, err, "unknown command \"flibbit\" for \"gomplate\"")
+	assert.Assert(c, cmp.Contains(e, "Error: unknown command \"flibbit\" for \"gomplate\"\n"))
+}
+
+func (s *BasicSuite) TestExecCommand(c *C) {
+	out := s.tmpDir.Join("out")
+	o, e, err := cmdTest(c, "-i", `{{print "hello world"}}`,
+		"-o", out,
+		"--", "cat", out)
+	assertSuccess(c, o, e, err, "hello world")
+}
+
+func (s *BasicSuite) TestPostRunExecPipe(c *C) {
+	o, e, err := cmdTest(c,
+		"-i", `{{print "hello world"}}`,
+		"--exec-pipe",
+		"--", "tr", "a-z", "A-Z")
+	assertSuccess(c, o, e, err, "HELLO WORLD")
+}
+
+func (s *BasicSuite) TestEmptyOutputSuppression(c *C) {
+	out := s.tmpDir.Join("out")
+	o, e, err := cmdWithEnv(c, []string{
+		"-i",
+		`{{print "\t  \n\n\r\n\t\t     \v\n"}}`,
+		"-o", out,
+	}, map[string]string{
+		"GOMPLATE_SUPPRESS_EMPTY": "true",
+	})
+	assertSuccess(c, o, e, err, "")
+
+	_, err = os.Stat(out)
+	assert.Equal(c, true, os.IsNotExist(err))
+}
+
+func (s *BasicSuite) TestRoutesInputsToProperOutputsWithChmod(c *C) {
+	oneOut := s.tmpDir.Join("one.out")
+	twoOut := s.tmpDir.Join("two.out")
+	o, e, err := cmdWithStdin(c, []string{
+		"-f", s.tmpDir.Join("one"),
+		"-f", s.tmpDir.Join("two"),
+		"-o", oneOut,
+		"-o", twoOut,
+		"--chmod", "0600"}, "hello world")
+	assertSuccess(c, o, e, err, "")
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{oneOut, 0600, "hi\n"},
+		{twoOut, 0600, "hello\n"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, config.NormalizeFileMode(v.mode), info.Mode())
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *BasicSuite) TestOverridesOutputModeWithChmod(c *C) {
+	out := s.tmpDir.Join("two")
+
+	o, e, err := cmdWithStdin(c, []string{
+		"-f", s.tmpDir.Join("one"),
+		"-o", out,
+		"--chmod", "0600"}, "hello world")
+	assertSuccess(c, o, e, err, "")
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{out, 0600, "hi\n"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, config.NormalizeFileMode(v.mode), info.Mode())
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *BasicSuite) TestAppliesChmodBeforeWrite(c *C) {
+	// 'broken' was created with mode 0000
+	out := s.tmpDir.Join("broken")
+	_, _, err := cmdTest(c,
+		"-f", s.tmpDir.Join("one"),
+		"-o", out,
+		"--chmod", "0644")
+	assert.NilError(c, err)
+
+	info, err := os.Stat(out)
+	assert.NilError(c, err)
+	assert.Equal(c, config.NormalizeFileMode(0644), info.Mode())
+	content, err := ioutil.ReadFile(out)
+	assert.NilError(c, err)
+	assert.Equal(c, "hi\n", string(content))
+}

--- a/internal/tests/inprocess-integration/collection_test.go
+++ b/internal/tests/inprocess-integration/collection_test.go
@@ -1,0 +1,105 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+type CollSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&CollSuite{})
+
+func (s *CollSuite) SetUpTest(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFiles(map[string]string{
+			"defaults.yaml": `values:
+  one: 1
+  two: 2
+  three:
+    - 4
+  four:
+    a: a
+    b: b
+`,
+			"config.json": `{
+				"values": {
+					"one": "uno",
+					"three": [ 5, 6, 7 ],
+					"four": { "a": "eh?" }
+				}
+			}`,
+		}))
+}
+
+func (s *CollSuite) TearDownTest(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *CollSuite) TestCollMerge(c *C) {
+	o, e, err := cmdTest(c,
+		"-d", "defaults="+s.tmpDir.Join("defaults.yaml"),
+		"-d", "config="+s.tmpDir.Join("config.json"),
+		"-i", `{{ $defaults := ds "defaults" -}}
+		{{ $config := ds "config" -}}
+		{{ $merged := coll.Merge $config $defaults -}}
+		{{ $merged | data.ToYAML }}`)
+	assertSuccess(c, o, e, err, `values:
+  four:
+    a: eh?
+    b: b
+  one: uno
+  three:
+    - 5
+    - 6
+    - 7
+  two: 2
+`)
+}
+
+func (s *CollSuite) TestSort(c *C) {
+	inOutTest(c, `{{ $maps := jsonArray "[{\"a\": \"foo\", \"b\": 1}, {\"a\": \"bar\", \"b\": 8}, {\"a\": \"baz\", \"b\": 3}]" -}}
+{{ range coll.Sort "b" $maps -}}
+{{ .a }}
+{{ end -}}
+`, "foo\nbaz\nbar\n")
+
+	inOutTest(c, `
+{{- coll.Sort (slice "b" "a" "c" "aa") }}
+{{ coll.Sort (slice "b" 14 "c" "aa") }}
+{{ coll.Sort (slice 3.14 3.0 4.0) }}
+{{ coll.Sort "Scheme" (coll.Slice (conv.URL "zzz:///") (conv.URL "https:///") (conv.URL "http:///")) }}
+`, `[a aa b c]
+[b 14 c aa]
+[3 3.14 4]
+[http:/// https:/// zzz:///]
+`)
+}
+
+func (s *CollSuite) TestJSONPath(c *C) {
+	o, e, err := cmdTest(c, "-c", "config="+s.tmpDir.Join("config.json"),
+		"-i", `{{ .config | jsonpath ".*.three" }}`)
+	assertSuccess(c, o, e, err, `[5 6 7]`)
+
+	o, e, err = cmdTest(c, "-c", "config="+s.tmpDir.Join("config.json"),
+		"-i", `{{ .config | coll.JSONPath ".values..a" }}`)
+	assertSuccess(c, o, e, err, `eh?`)
+}
+
+func (s *CollSuite) TestFlatten(c *C) {
+	in := "[[1,2],[],[[3,4],[[[5],6],7]]]"
+	inOutTest(c, "{{ `"+in+"` | jsonArray | coll.Flatten | toJSON }}", "[1,2,3,4,5,6,7]")
+	inOutTest(c, "{{ `"+in+"` | jsonArray | flatten 0 | toJSON }}", in)
+	inOutTest(c, "{{ coll.Flatten 1 (`"+in+"` | jsonArray) | toJSON }}", "[1,2,[3,4],[[[5],6],7]]")
+	inOutTest(c, "{{ `"+in+"` | jsonArray | coll.Flatten 2 | toJSON }}", "[1,2,3,4,[[5],6],7]")
+}
+
+func (s *CollSuite) TestPick(c *C) {
+	inOutTest(c, `{{ $data := dict "foo" 1 "bar" 2 "baz" 3 }}{{ coll.Pick "foo" "baz" $data }}`, "map[baz:3 foo:1]")
+}
+
+func (s *CollSuite) TestOmit(c *C) {
+	inOutTest(c, `{{ $data := dict "foo" 1 "bar" 2 "baz" 3 }}{{ coll.Omit "foo" "baz" $data }}`, "map[bar:2]")
+}

--- a/internal/tests/inprocess-integration/config_test.go
+++ b/internal/tests/inprocess-integration/config_test.go
@@ -1,0 +1,226 @@
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+type ConfigSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = check.Suite(&ConfigSuite{})
+
+func (s *ConfigSuite) SetUpTest(c *check.C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithDir("indir"),
+		fs.WithDir("outdir"),
+		fs.WithFile(".gomplate.yaml", "in: hello world\n"),
+		fs.WithFile("sleep.sh", "#!/bin/sh\n\nexec sleep $1\n", fs.WithMode(0755)),
+	)
+}
+
+func (s *ConfigSuite) writeFile(f, content string) {
+	f = s.tmpDir.Join(f)
+	err := ioutil.WriteFile(f, []byte(content), 0600)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (s *ConfigSuite) writeConfig(content string) {
+	s.writeFile(".gomplate.yaml", content)
+}
+
+func (s *ConfigSuite) TearDownTest(c *check.C) {
+	s.tmpDir.Remove()
+}
+
+func (s *ConfigSuite) TestReadsFromSimpleConfigFile(c *check.C) {
+	o, e, err := cmdWithDir(c, s.tmpDir.Path())
+	assertSuccess(c, o, e, err, "hello world")
+}
+
+func (s *ConfigSuite) TestReadsStdin(c *check.C) {
+	s.writeConfig("inputFiles: [-]")
+
+	origWd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() { os.Chdir(origWd) }()
+
+	err = os.Chdir(s.tmpDir.Path())
+	if err != nil {
+		panic(err)
+	}
+
+	o, e, err := cmdWithStdin(c, nil, "foo bar")
+	assertSuccess(c, o, e, err, "foo bar")
+}
+
+func (s *ConfigSuite) TestFlagOverridesConfig(c *check.C) {
+	s.writeConfig("inputFiles: [in]")
+
+	o, e, err := cmdWithDir(c, s.tmpDir.Path(), "-i", "hello from the cli")
+	assertSuccess(c, o, e, err, "hello from the cli")
+}
+
+func (s *ConfigSuite) TestReadsFromInputFile(c *check.C) {
+	s.writeConfig("inputFiles: [in]")
+	s.writeFile("in", "blah blah")
+
+	o, e, err := cmdWithDir(c, s.tmpDir.Path())
+	assertSuccess(c, o, e, err, "blah blah")
+}
+
+func (s *ConfigSuite) TestDatasource(c *check.C) {
+	s.writeConfig(`inputFiles: [in]
+datasources:
+  data:
+    url: in.yaml
+`)
+	s.writeFile("in", `{{ (ds "data").value }}`)
+	s.writeFile("in.yaml", `value: hello world`)
+
+	o, e, err := cmdWithDir(c, s.tmpDir.Path())
+	assertSuccess(c, o, e, err, "hello world")
+}
+
+func (s *ConfigSuite) TestOutputDir(c *check.C) {
+	s.writeConfig(`inputDir: indir/
+outputDir: outdir/
+datasources:
+  data:
+    url: in.yaml
+`)
+	s.writeFile("indir/file", `{{ (ds "data").value }}`)
+	s.writeFile("in.yaml", `value: hello world`)
+
+	o, e, err := cmdWithDir(c, s.tmpDir.Path())
+	assertSuccess(c, o, e, err, "")
+
+	b, err := ioutil.ReadFile(s.tmpDir.Join("outdir", "file"))
+	assert.NilError(c, err)
+	assert.Equal(c, "hello world", string(b))
+}
+
+func (s *ConfigSuite) TestExecPipeOverridesConfigFile(c *check.C) {
+	// make sure exec-pipe works, and outFiles is replaced
+	s.writeConfig(`in: hello world
+outputFiles: ['-']
+`)
+	o, e, err := cmdWithDir(c, s.tmpDir.Path(), "-i", "hi", "--exec-pipe", "--", "tr", "[a-z]", "[A-Z]")
+	assertSuccess(c, o, e, err, "HI")
+}
+
+func (s *ConfigSuite) TestOutFile(c *check.C) {
+	s.writeConfig(`in: hello world
+outputFiles: [out]
+`)
+	o, e, err := cmdWithDir(c, s.tmpDir.Path())
+	assertSuccess(c, o, e, err, "")
+
+	b, err := ioutil.ReadFile(s.tmpDir.Join("out"))
+	assert.NilError(c, err)
+	assert.Equal(c, "hello world", string(b))
+}
+
+func (s *ConfigSuite) TestAlternateConfigFile(c *check.C) {
+	s.writeFile("config.yaml", `in: this is from an alternate config
+`)
+
+	o, e, err := cmdWithDir(c, s.tmpDir.Path(), "--config=config.yaml")
+	assertSuccess(c, o, e, err, "this is from an alternate config")
+}
+
+func (s *ConfigSuite) TestEnvConfigFile(c *check.C) {
+	s.writeFile("envconfig.yaml", `in: yet another alternate config
+`)
+
+	os.Setenv("GOMPLATE_CONFIG", "./envconfig.yaml")
+	defer os.Unsetenv("GOMPLATE_CONFIG")
+
+	o, e, err := cmdWithDir(c, s.tmpDir.Path())
+	assertSuccess(c, o, e, err, "yet another alternate config")
+}
+
+func (s *ConfigSuite) TestConfigOverridesEnvDelim(c *check.C) {
+	if !isWindows {
+		s.writeConfig(`inputFiles: [in]
+leftDelim: (╯°□°）╯︵ ┻━┻
+datasources:
+  data:
+    url: in.yaml
+`)
+		s.writeFile("in", `(╯°□°）╯︵ ┻━┻ (ds "data").value }}`)
+		s.writeFile("in.yaml", `value: hello world`)
+
+		os.Setenv("GOMPLATE_LEFT_DELIM", "<<")
+		defer os.Unsetenv("GOMPLATE_LEFT_DELIM")
+
+		o, e, err := cmdWithDir(c, s.tmpDir.Path())
+		assert.NilError(c, err)
+		assert.Equal(c, "", e)
+		assert.Equal(c, "hello world", o)
+	}
+}
+
+func (s *ConfigSuite) TestFlagOverridesAllDelim(c *check.C) {
+	if !isWindows {
+		s.writeConfig(`inputFiles: [in]
+leftDelim: (╯°□°）╯︵ ┻━┻
+datasources:
+  data:
+    url: in.yaml
+`)
+		s.writeFile("in", `{{ (ds "data").value }}`)
+		s.writeFile("in.yaml", `value: hello world`)
+
+		o, e, err := cmdWithDir(c, s.tmpDir.Path(), "--left-delim={{")
+		assert.NilError(c, err)
+		assert.Equal(c, "", e)
+		assert.Equal(c, "hello world", o)
+	}
+}
+
+func (s *ConfigSuite) TestConfigOverridesEnvPluginTimeout(c *check.C) {
+	if !isWindows {
+		s.writeConfig(`in: hi there {{ sleep 2 }}
+plugins:
+  sleep: echo
+
+pluginTimeout: 500ms
+`)
+		os.Setenv("GOMPLATE_PLUGIN_TIMEOUT", "5s")
+		defer os.Unsetenv("GOMPLATE_PLUGIN_TIMEOUT")
+
+		_, _, err := cmdWithDir(c, s.tmpDir.Path(), "--plugin", "sleep="+s.tmpDir.Join("sleep.sh"))
+		assert.ErrorContains(c, err, "plugin timed out")
+	}
+}
+
+func (s *ConfigSuite) TestConfigOverridesEnvSuppressEmpty(c *check.C) {
+	s.writeConfig(`in: |
+  {{- print "\t  \n\n\r\n\t\t     \v\n" -}}
+
+  {{ print "   " -}}
+out: ./missing
+suppressEmpty: true
+`)
+
+	os.Setenv("GOMPLATE_SUPPRESS_EMPTY", "false")
+	defer os.Unsetenv("GOMPLATE_SUPPRESS_EMPTY")
+
+	_, _, err := cmdWithDir(c, s.tmpDir.Path())
+	assert.NilError(c, err)
+
+	_, err = os.Stat(s.tmpDir.Join("missing"))
+	assert.Equal(c, true, os.IsNotExist(err))
+}

--- a/internal/tests/inprocess-integration/crypto_test.go
+++ b/internal/tests/inprocess-integration/crypto_test.go
@@ -1,0 +1,66 @@
+package integration
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+
+	"gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+type CryptoSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = check.Suite(&CryptoSuite{})
+
+func genTestKeys() (string, string) {
+	rsaPriv, _ := rsa.GenerateKey(rand.Reader, 4096)
+	rsaPub := rsaPriv.PublicKey
+	privBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rsaPriv),
+	}
+	testPrivKey := string(pem.EncodeToMemory(privBlock))
+
+	b, _ := x509.MarshalPKIXPublicKey(&rsaPub)
+	pubBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: b,
+	}
+	testPubKey := string(pem.EncodeToMemory(pubBlock))
+	return testPrivKey, testPubKey
+}
+
+func (s *CryptoSuite) SetUpTest(c *check.C) {
+	testPrivKey, testPubKey := genTestKeys()
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("testPrivKey", testPrivKey),
+		fs.WithFile("testPubKey", testPubKey),
+	)
+}
+
+func (s *CryptoSuite) TearDownTest(c *check.C) {
+	s.tmpDir.Remove()
+}
+
+func (s *CryptoSuite) TestRSACrypt(c *check.C) {
+	o, e, err := cmdWithDir(c, s.tmpDir.Path(),
+		"--experimental",
+		"-i", `{{ crypto.RSAGenerateKey 2048 -}}`,
+		"-o", `key.pem`)
+	assertSuccess(c, o, e, err, "")
+
+	o, e, err = cmdWithDir(c, s.tmpDir.Path(),
+		"--experimental",
+		"-c", "privKey=./key.pem",
+		"-i", `{{ $pub := crypto.RSADerivePublicKey .privKey -}}
+{{ $enc := "hello" | crypto.RSAEncrypt $pub -}}
+{{ crypto.RSADecryptBytes .privKey $enc | conv.ToString }}
+{{ crypto.RSADecrypt .privKey $enc }}
+`)
+	assertSuccess(c, o, e, err, "hello\nhello\n")
+}

--- a/internal/tests/inprocess-integration/datasources_blob_test.go
+++ b/internal/tests/inprocess-integration/datasources_blob_test.go
@@ -1,0 +1,149 @@
+package integration
+
+import (
+	"bytes"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/johannesboyne/gofakes3"
+	"github.com/johannesboyne/gofakes3/backend/s3mem"
+	. "gopkg.in/check.v1"
+)
+
+type BlobDatasourcesSuite struct {
+	l *net.TCPListener
+}
+
+var _ = Suite(&BlobDatasourcesSuite{})
+
+func (s *BlobDatasourcesSuite) SetUpSuite(c *C) {
+	backend := s3mem.New()
+	s3 := gofakes3.New(backend)
+	var err error
+	s.l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	handle(c, err)
+
+	http.Handle("/", s3.Server())
+	go http.Serve(s.l, nil)
+
+	err = backend.CreateBucket("mybucket")
+	handle(c, err)
+	contents := `{"value":"json", "name":"foo"}`
+	_, err = backend.PutObject("mybucket", "foo.json", map[string]string{"Content-Type": "application/json"}, bytes.NewBufferString(contents), int64(len(contents)))
+	handle(c, err)
+
+	contents = `{"value":"json", "name":"bar"}`
+	_, err = backend.PutObject("mybucket", "bar.json", map[string]string{"Content-Type": "application/json"}, bytes.NewBufferString(contents), int64(len(contents)))
+	handle(c, err)
+
+	contents = `hello world`
+	_, err = backend.PutObject("mybucket", "a/b/c/hello.txt", map[string]string{"Content-Type": "text/plain"}, bytes.NewBufferString(contents), int64(len(contents)))
+	handle(c, err)
+
+	contents = `goodbye world`
+	_, err = backend.PutObject("mybucket", "a/b/c/goodbye.txt", map[string]string{"Content-Type": "text/plain"}, bytes.NewBufferString(contents), int64(len(contents)))
+	handle(c, err)
+
+	contents = "a: foo\nb: bar\nc:\n  cc: yay for yaml\n"
+	_, err = backend.PutObject("mybucket", "a/b/c/d", map[string]string{"Content-Type": "application/yaml"}, bytes.NewBufferString(contents), int64(len(contents)))
+	handle(c, err)
+}
+
+func (s *BlobDatasourcesSuite) TearDownSuite(c *C) {
+	s.l.Close()
+}
+
+func (s *BlobDatasourcesSuite) TestS3Datasource(c *C) {
+	o, e, err := cmdWithEnv(c, []string{
+		"-c", "data=s3://ryft-public-sample-data/integration_test_dataset.json?region=us-east-1&type=application/array+json",
+		"-i", "{{ $d := index .data 0 }}{{ $d.firstName }} {{ $d.lastName }}"},
+		map[string]string{
+			"AWS_ANON":    "true",
+			"AWS_TIMEOUT": "5000",
+		})
+	assertSuccess(c, o, e, err, "Petra Mcintyre")
+
+	o, e, err = cmdWithEnv(c, []string{
+		"-c", "data=s3://mybucket/foo.json?" +
+			"region=us-east-1&" +
+			"disableSSL=true&" +
+			"endpoint=" + s.l.Addr().String() + "&" +
+			"s3ForcePathStyle=true",
+		"-i", "{{ .data.value }}"},
+		map[string]string{
+			"AWS_ACCESS_KEY_ID":     "YOUR-ACCESSKEYID",
+			"AWS_SECRET_ACCESS_KEY": "YOUR-SECRETACCESSKEY",
+		})
+	assertSuccess(c, o, e, err, "json")
+
+	o, e, err = cmdWithEnv(c, []string{
+		"-c", "data=s3://mybucket/foo.json?" +
+			"region=us-east-1&" +
+			"disableSSL=true&" +
+			"s3ForcePathStyle=true",
+		"-i", "{{ .data.value }}"},
+		map[string]string{
+			"AWS_ANON":        "true",
+			"AWS_S3_ENDPOINT": s.l.Addr().String(),
+		})
+	assertSuccess(c, o, e, err, "json")
+}
+
+func (s *BlobDatasourcesSuite) TestS3Directory(c *C) {
+	o, e, err := cmdWithEnv(c, []string{"-c", "data=s3://ryft-public-sample-data/?region=us-east-1",
+		"-i", "{{ index .data 0 }}"},
+		map[string]string{
+			"AWS_ANON":    "true",
+			"AWS_TIMEOUT": "15000",
+		})
+	assertSuccess(c, o, e, err, "AWS-x86-AMI-queries.json")
+
+	o, e, err = cmdWithEnv(c, []string{"-c", "data=s3://mybucket/a/b/c/?" +
+		"region=us-east-1&" +
+		"disableSSL=true&" +
+		"endpoint=" + s.l.Addr().String() + "&" +
+		"s3ForcePathStyle=true",
+		"-i", "{{ .data }}"},
+		map[string]string{
+			"AWS_ACCESS_KEY_ID":     "YOUR-ACCESSKEYID",
+			"AWS_SECRET_ACCESS_KEY": "YOUR-SECRETACCESSKEY",
+		})
+	assertSuccess(c, o, e, err, "[d goodbye.txt hello.txt]")
+}
+
+func (s *BlobDatasourcesSuite) TestS3MIMETypes(c *C) {
+	o, e, err := cmdWithEnv(c, []string{"-c", "data=s3://mybucket/a/b/c/d?" +
+		"region=us-east-1&" +
+		"disableSSL=true&" +
+		"endpoint=" + s.l.Addr().String() + "&" +
+		"s3ForcePathStyle=true",
+		"-i", "{{ .data.c.cc }}"},
+		map[string]string{
+			"AWS_ANON": "true",
+		})
+	assertSuccess(c, o, e, err, "yay for yaml")
+}
+
+func (s *BlobDatasourcesSuite) TestGCSDatasource(c *C) {
+	// this only works if we're authed with GCS
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		c.Skip("Not configured to authenticate with Google Cloud - skipping")
+		return
+	}
+	o, e, err := cmdTest(c, "-c", "data=gs://gcp-public-data-landsat/LT08/PRE/015/013/LT80150132013127LGN01/LT80150132013127LGN01_MTL.txt?type=text/plain",
+		"-i", "{{ len .data }}")
+	assertSuccess(c, o, e, err, "3218")
+}
+
+func (s *BlobDatasourcesSuite) TestGCSDirectory(c *C) {
+	// this only works if we're likely to be authed with GCS
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		c.Skip("Not configured to authenticate with Google Cloud - skipping")
+		return
+	}
+
+	o, e, err := cmdTest(c, "-c", "data=gs://gcp-public-data-landsat/",
+		"-i", "{{ coll.Has .data `index.csv.gz` }}")
+	assertSuccess(c, o, e, err, "true")
+}

--- a/internal/tests/inprocess-integration/datasources_boltdb_test.go
+++ b/internal/tests/inprocess-integration/datasources_boltdb_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"go.etcd.io/bbolt"
+	"gotest.tools/v3/fs"
+)
+
+type BoltDBDatasourcesSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&BoltDBDatasourcesSuite{})
+
+func (s *BoltDBDatasourcesSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests")
+	db, err := bbolt.Open(s.tmpDir.Join("config.db"), 0600, nil)
+	handle(c, err)
+	defer db.Close()
+
+	err = db.Update(func(tx *bbolt.Tx) error {
+		var b *bbolt.Bucket
+		b, err = tx.CreateBucket([]byte("Bucket1"))
+		if err != nil {
+			return err
+		}
+		// the first 8 bytes are ignored when read by libkv, so we prefix with gibberish
+		err = b.Put([]byte("foo"), []byte("00000000bar"))
+		if err != nil {
+			return err
+		}
+
+		b, err = tx.CreateBucket([]byte("Bucket2"))
+		if err != nil {
+			return err
+		}
+		err = b.Put([]byte("foobar"), []byte("00000000baz"))
+		return err
+	})
+	handle(c, err)
+}
+
+func (s *BoltDBDatasourcesSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *BoltDBDatasourcesSuite) TestBoltDBDatasource(c *C) {
+	o, e, err := cmdTest(c, "-d", "config=boltdb://"+s.tmpDir.Join("config.db#Bucket1"),
+		"-i", `{{(ds "config" "foo")}}`)
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdTest(c, "-d", "config=boltdb://"+s.tmpDir.Join("config.db#Bucket1"),
+		"-d", "config2=boltdb://"+s.tmpDir.Join("config.db#Bucket2"),
+		"-i", `{{(ds "config" "foo")}}-{{(ds "config2" "foobar")}}`)
+	assertSuccess(c, o, e, err, "bar-baz")
+}

--- a/internal/tests/inprocess-integration/datasources_consul_test.go
+++ b/internal/tests/inprocess-integration/datasources_consul_test.go
@@ -1,0 +1,229 @@
+//+build !windows
+
+package integration
+
+import (
+	"encoding/base64"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+type ConsulDatasourcesSuite struct {
+	tmpDir       *fs.Dir
+	pidDir       *fs.Dir
+	consulAddr   string
+	consulResult *icmd.Result
+	vaultAddr    string
+	vaultResult  *icmd.Result
+}
+
+var _ = Suite(&ConsulDatasourcesSuite{})
+
+const consulRootToken = "00000000-1111-2222-3333-444455556666"
+
+func (s *ConsulDatasourcesSuite) SetUpSuite(c *C) {
+	s.pidDir = fs.NewDir(c, "gomplate-inttests-pid")
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile(
+			"consul.json",
+			`{"acl_datacenter": "dc1", "acl_master_token": "`+consulRootToken+`"}`,
+		),
+		fs.WithFile("vault.json", `{
+			"pid_file": "`+s.pidDir.Join("vault.pid")+`"
+			}`),
+	)
+	var port int
+	port, s.consulAddr = freeport()
+	consul := icmd.Command("consul", "agent",
+		"-dev",
+		"-config-file="+s.tmpDir.Join("consul.json"),
+		"-log-level=err",
+		"-http-port="+strconv.Itoa(port),
+		"-pid-file="+s.pidDir.Join("consul.pid"),
+	)
+	s.consulResult = icmd.StartCmd(consul)
+
+	c.Logf("Fired up Consul: %v", consul)
+
+	err := waitForURL(c, "http://"+s.consulAddr+"/v1/status/leader")
+	handle(c, err)
+
+	s.startVault(c)
+}
+
+func (s *ConsulDatasourcesSuite) startVault(c *C) {
+	// rename any existing token so it doesn't get overridden
+	u, _ := user.Current()
+	homeDir := u.HomeDir
+	tokenFile := path.Join(homeDir, ".vault-token")
+	info, err := os.Stat(tokenFile)
+	if err == nil && info.Mode().IsRegular() {
+		os.Rename(tokenFile, path.Join(homeDir, ".vault-token.bak"))
+	}
+
+	_, s.vaultAddr = freeport()
+	vault := icmd.Command("vault", "server",
+		"-dev",
+		"-dev-root-token-id="+vaultRootToken,
+		"-log-level=err",
+		"-dev-listen-address="+s.vaultAddr,
+		"-config="+s.tmpDir.Join("vault.json"),
+	)
+	s.vaultResult = icmd.StartCmd(vault)
+
+	c.Logf("Fired up Vault: %v", vault)
+
+	err = waitForURL(c, "http://"+s.vaultAddr+"/v1/sys/health")
+	handle(c, err)
+}
+
+func (s *ConsulDatasourcesSuite) TearDownSuite(c *C) {
+	defer s.tmpDir.Remove()
+	defer s.pidDir.Remove()
+
+	err := killByPidFile(s.pidDir.Join("vault.pid"))
+	handle(c, err)
+
+	err = killByPidFile(s.pidDir.Join("consul.pid"))
+	handle(c, err)
+
+	// restore old vault token if it was backed up
+	u, _ := user.Current()
+	homeDir := u.HomeDir
+	tokenFile := path.Join(homeDir, ".vault-token.bak")
+	info, err := os.Stat(tokenFile)
+	if err == nil && info.Mode().IsRegular() {
+		os.Rename(tokenFile, path.Join(homeDir, ".vault-token"))
+	}
+}
+
+func (s *ConsulDatasourcesSuite) consulPut(c *C, k, v string) {
+	result := icmd.RunCmd(icmd.Command("consul", "kv", "put", k, v),
+		func(c *icmd.Cmd) {
+			c.Env = []string{"CONSUL_HTTP_ADDR=http://" + s.consulAddr}
+		})
+	result.Assert(c, icmd.Success)
+}
+
+func (s *ConsulDatasourcesSuite) consulDelete(c *C, k string) {
+	result := icmd.RunCmd(icmd.Command("consul", "kv", "delete", k),
+		func(c *icmd.Cmd) {
+			c.Env = []string{"CONSUL_HTTP_ADDR=http://" + s.consulAddr}
+		})
+	result.Assert(c, icmd.Success)
+}
+
+func (s *ConsulDatasourcesSuite) TestConsulDatasource(c *C) {
+	s.consulPut(c, "foo1", "bar")
+	defer s.consulDelete(c, "foo1")
+
+	o, e, err := cmdWithEnv(c, []string{"-d", "consul=consul://",
+		"-i", `{{(ds "consul" "foo1")}}`},
+		map[string]string{
+			"CONSUL_HTTP_ADDR": "http://" + s.consulAddr,
+		})
+	assertSuccess(c, o, e, err, "bar")
+
+	s.consulPut(c, "foo2", `{"bar": "baz"}`)
+	defer s.consulDelete(c, "foo2")
+
+	o, e, err = cmdWithEnv(c, []string{"-d", "consul=consul://?type=application/json",
+		"-i", `{{(ds "consul" "foo2").bar}}`},
+		map[string]string{
+			"CONSUL_HTTP_ADDR": "http://" + s.consulAddr,
+		})
+	assertSuccess(c, o, e, err, "baz")
+
+	s.consulPut(c, "foo2", `bar`)
+	defer s.consulDelete(c, "foo2")
+
+	o, e, err = cmdTest(c, "-d", "consul=consul://"+s.consulAddr,
+		"-i", `{{(ds "consul" "foo2")}}`)
+	assertSuccess(c, o, e, err, "bar")
+
+	s.consulPut(c, "foo3", `bar`)
+	defer s.consulDelete(c, "foo3")
+
+	o, e, err = cmdTest(c, "-d", "consul=consul+http://"+s.consulAddr,
+		"-i", `{{(ds "consul" "foo3")}}`)
+	assertSuccess(c, o, e, err, "bar")
+}
+
+func (s *ConsulDatasourcesSuite) TestConsulDatasourceListKeys(c *C) {
+	s.consulPut(c, "list-of-keys/foo1", `{"bar1": "bar1"}`)
+	s.consulPut(c, "list-of-keys/foo2", "bar2")
+	defer s.consulDelete(c, "list-of-keys")
+
+	// Get a list of keys using the ds args
+	expectedResult := `[{"key":"foo1","value":"{\"bar1\": \"bar1\"}"},{"key":"foo2","value":"bar2"}]`
+	o, e, err := cmdWithEnv(c, []string{"-d", "consul=consul://",
+		"-i", `{{(ds "consul" "list-of-keys/") | data.ToJSON }}`},
+		map[string]string{
+			"CONSUL_HTTP_ADDR": "http://" + s.consulAddr,
+		})
+	assertSuccess(c, o, e, err, expectedResult)
+
+	// Get a list of keys using the ds uri
+	expectedResult = `[{"key":"foo1","value":"{\"bar1\": \"bar1\"}"},{"key":"foo2","value":"bar2"}]`
+	o, e, err = cmdTest(c, "-d", "consul=consul+http://"+s.consulAddr+"/list-of-keys/",
+		"-i", `{{(ds "consul" ) | data.ToJSON }}`)
+	assertSuccess(c, o, e, err, expectedResult)
+
+	// Get a specific value from the list of Consul keys
+	expectedResult = `{"bar1": "bar1"}`
+	o, e, err = cmdTest(c, "-d", "consul=consul+http://"+s.consulAddr+"/list-of-keys/",
+		"-i", `{{ $data := ds "consul" }}{{ (index $data 0).value }}`)
+	assertSuccess(c, o, e, err, expectedResult)
+}
+
+func (s *ConsulDatasourcesSuite) TestConsulWithVaultAuth(c *C) {
+	v, err := createVaultClient(s.vaultAddr, vaultRootToken)
+	handle(c, err)
+
+	err = v.vc.Sys().Mount("consul/", &vaultapi.MountInput{Type: "consul"})
+	handle(c, err)
+	defer v.vc.Sys().Unmount("consul/")
+
+	_, err = v.vc.Logical().Write("consul/config/access", map[string]interface{}{
+		"address": s.consulAddr, "token": consulRootToken,
+	})
+	handle(c, err)
+	policy := base64.StdEncoding.EncodeToString([]byte(`key "" { policy = "read" }`))
+	_, err = v.vc.Logical().Write("consul/roles/readonly", map[string]interface{}{"policy": policy})
+	handle(c, err)
+
+	s.consulPut(c, "foo", "bar")
+	defer s.consulDelete(c, "foo")
+
+	// result := icmd.RunCmd(icmd.Command(GomplateBin,
+	// 	"-d", "consul=consul://",
+	// 	"-i", `{{(ds "consul" "foo")}}`,
+	// ), func(c *icmd.Cmd) {
+	// 	c.Env = []string{
+	// 		"VAULT_TOKEN=" + vaultRootToken,
+	// 		"VAULT_ADDR=http://" + s.vaultAddr,
+	// 		"CONSUL_VAULT_ROLE=readonly",
+	// 		"CONSUL_HTTP_ADDR=http://" + s.consulAddr,
+	// 	}
+	// })
+	// result.Assert(c, icmd.Expected{ExitCode: 0, Out: "bar"})
+
+	o, e, err := cmdWithEnv(c, []string{
+		"-d", "consul=consul://",
+		"-i", `{{(ds "consul" "foo")}}`,
+	}, map[string]string{
+		"VAULT_TOKEN":       vaultRootToken,
+		"VAULT_ADDR":        "http://" + s.vaultAddr,
+		"CONSUL_VAULT_ROLE": "readonly",
+		"CONSUL_HTTP_ADDR":  "http://" + s.consulAddr,
+	})
+	assertSuccess(c, o, e, err, "bar")
+}

--- a/internal/tests/inprocess-integration/datasources_env_test.go
+++ b/internal/tests/inprocess-integration/datasources_env_test.go
@@ -1,0 +1,45 @@
+package integration
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+)
+
+type EnvDatasourcesSuite struct {
+}
+
+var _ = Suite(&EnvDatasourcesSuite{})
+
+func (s *EnvDatasourcesSuite) SetUpSuite(c *C) {
+	os.Setenv("HELLO_WORLD", "hello world")
+	os.Setenv("HELLO_UNIVERSE", "hello universe")
+	os.Setenv("FOO", "bar")
+	os.Setenv("foo", "baz")
+}
+
+func (s *EnvDatasourcesSuite) TearDownSuite(c *C) {
+	os.Unsetenv("HELLO_WORLD")
+	os.Unsetenv("HELLO_UNIVERSE")
+	os.Unsetenv("FOO")
+	os.Unsetenv("foo")
+}
+
+func (s *EnvDatasourcesSuite) TestEnvDatasources(c *C) {
+	o, e, err := cmdTest(c, "-d", "foo=env:FOO", "-i", `{{ ds "foo" }}`)
+
+	// Windows envvars are case-insensitive
+	if isWindows {
+		assertSuccess(c, o, e, err, "baz")
+	} else {
+		assertSuccess(c, o, e, err, "bar")
+	}
+
+	o, e, err = cmdTest(c, "-d", "foo=env:///foo", "-i", `{{ ds "foo" }}`)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdWithEnv(c, []string{"-d", "e=env:json_value?type=application/json",
+		"-i", `{{ (ds "e").value}}`},
+		map[string]string{"json_value": `{"value":"corge"}`})
+	assertSuccess(c, o, e, err, "corge")
+}

--- a/internal/tests/inprocess-integration/datasources_file_test.go
+++ b/internal/tests/inprocess-integration/datasources_file_test.go
@@ -1,0 +1,153 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+type FileDatasourcesSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&FileDatasourcesSuite{})
+
+func (s *FileDatasourcesSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFiles(map[string]string{
+			"config.json": `{"foo": {"bar": "baz"}}`,
+			"ajsonfile":   `{"foo": {"bar": "baz"}}`,
+			"encrypted.json": `{
+  "_public_key": "dfcf98785869cdfc4a59273bbdfe1bfcf6c44850a11ea9d84db21c89a802c057",
+  "password": "EJ[1:Cb1AY94Dl76xwHHrnJyh+Y+fAeovijPlFQZXSAuvZBc=:oCGZM6lbeXXOl2ONSKfLQ0AgaltrTpNU:VjegqQPPkOK1hSylMAbmcfusQImfkHCWZw==]"
+}`,
+			"config.yml":  "foo:\n bar: baz\n",
+			"config2.yml": "foo: bar\n",
+			"foo.csv": `A,B
+A1,B1
+A2,"foo""
+bar"
+`,
+			"test.env": `FOO=a regular unquoted value
+export BAR=another value, exports are ignored
+
+# comments are totally ignored, as are blank lines
+FOO.BAR = "values can be double-quoted, and shell\nescapes are supported"
+
+BAZ = "variable expansion: ${FOO}"
+QUX='single quotes ignore $variables'
+`,
+		}),
+		fs.WithDir("sortorder", fs.WithFiles(map[string]string{
+			"template": `aws_zones = {
+	{{- range $key, $value := (ds "core").cloud.aws.zones }}
+	{{ $key }} = "{{ $value }}"
+	{{- end }}
+}
+`,
+			"core.yaml": `cloud:
+  aws:
+    zones:
+      zonea: true
+      zoneb: false
+      zonec: true
+      zoned: true
+      zonee: false
+      zonef: false
+`,
+		})),
+	)
+}
+
+func (s *FileDatasourcesSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *FileDatasourcesSuite) TestFileDatasources(c *C) {
+	o, e, err := cmdTest(c,
+		"-d", "config="+s.tmpDir.Join("config.json"),
+		"-i", `{{(datasource "config").foo.bar}}`)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdTest(c, "-d", "dir="+s.tmpDir.Path(),
+		"-i", `{{ (datasource "dir" "config.json").foo.bar }}`)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdWithDir(c, s.tmpDir.Path(), "-d", "config=config.json",
+		"-i", `{{ (ds "config").foo.bar }}`)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdWithDir(c, s.tmpDir.Path(), "-d", "config.json",
+		"-i", `{{ (ds "config").foo.bar }}`)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdTest(c, "-i",
+		`foo{{defineDatasource "config" `+"`"+s.tmpDir.Join("config.json")+"`"+`}}bar{{(datasource "config").foo.bar}}`)
+	assertSuccess(c, o, e, err, "foobarbaz")
+
+	o, e, err = cmdTest(c, "-i",
+		`foo{{defineDatasource "config" `+"`"+s.tmpDir.Join("ajsonfile")+"?type=application/json`"+`}}bar{{(datasource "config").foo.bar}}`)
+	assertSuccess(c, o, e, err, "foobarbaz")
+
+	o, e, err = cmdTest(c, "-d", "config="+s.tmpDir.Join("config.yml"),
+		"-i", `{{(datasource "config").foo.bar}}`)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdTest(c, "-d", "config="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{(ds "config").foo}}`)
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdTest(c, "-c", "config="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{ .config.foo}}`)
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdTest(c, "-c", ".="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{ .foo}} {{ (ds ".").foo }}`)
+	assertSuccess(c, o, e, err, "bar bar")
+
+	o, e, err = cmdTest(c, "-d", "config="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{ if (datasourceReachable "bogus") }}bogus!{{ end -}}
+{{ if (datasourceReachable "config") -}}
+{{ (ds "config").foo -}}
+{{ end }}`)
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdTest(c, "-d", "csv="+s.tmpDir.Join("foo.csv"),
+		"-i", `{{ index (index (ds "csv") 2) 1 }}`)
+	assertSuccess(c, o, e, err, "foo\"\nbar")
+
+	o, e, err = cmdTest(c, "-d", "config="+s.tmpDir.Join("config2.yml"),
+		"-i", `{{ include "config" }}`)
+	assertSuccess(c, o, e, err, "foo: bar\n")
+
+	o, e, err = cmdTest(c, "-d", "dir="+s.tmpDir.Path()+"/",
+		"-i", `{{ range (ds "dir") }}{{ . }} {{ end }}`)
+	assertSuccess(c, o, e, err, "ajsonfile config.json config.yml config2.yml encrypted.json foo.csv sortorder test.env ")
+
+	o, e, err = cmdWithEnv(c, []string{"-d", "enc=" + s.tmpDir.Join("encrypted.json"),
+		"-i", `{{ (ds "enc").password }}`}, map[string]string{
+		"EJSON_KEY": "553da5790efd7ddc0e4829b69069478eec9ddddb17b69eca9801da37445b62bf"})
+	assertSuccess(c, o, e, err, "swordfish")
+
+	o, e, err = cmdTest(c, "-d", "core="+s.tmpDir.Join("sortorder", "core.yaml"),
+		"-f", s.tmpDir.Join("sortorder", "template"))
+	assertSuccess(c, o, e, err, `aws_zones = {
+	zonea = "true"
+	zoneb = "false"
+	zonec = "true"
+	zoned = "true"
+	zonee = "false"
+	zonef = "false"
+}
+`)
+
+	o, e, err = cmdTest(c, "-d", "envfile="+s.tmpDir.Join("test.env"),
+		"-i", `{{ (ds "envfile") | data.ToJSONPretty "  " }}`)
+	assertSuccess(c, o, e, err, `{
+  "BAR": "another value, exports are ignored",
+  "BAZ": "variable expansion: a regular unquoted value",
+  "FOO": "a regular unquoted value",
+  "FOO.BAR": "values can be double-quoted, and shell\nescapes are supported",
+  "QUX": "single quotes ignore $variables"
+}`)
+}

--- a/internal/tests/inprocess-integration/datasources_git_test.go
+++ b/internal/tests/inprocess-integration/datasources_git_test.go
@@ -1,0 +1,128 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+type GitDatasourcesSuite struct {
+	tmpDir          *fs.Dir
+	pidDir          *fs.Dir
+	gitDaemonAddr   string
+	gitDaemonResult *icmd.Result
+}
+
+var _ = Suite(&GitDatasourcesSuite{})
+
+func (s *GitDatasourcesSuite) SetUpSuite(c *C) {
+	s.pidDir = fs.NewDir(c, "gomplate-inttests-pid")
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFiles(map[string]string{
+			"config.json": `{"foo": {"bar": "baz"}}`,
+		}),
+	)
+
+	repoPath := s.tmpDir.Join("repo")
+
+	result := icmd.RunCommand("git", "init", repoPath)
+	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "Initialized empty Git repository"})
+
+	result = icmd.RunCommand("mv", s.tmpDir.Join("config.json"), repoPath)
+	result.Assert(c, icmd.Expected{ExitCode: 0})
+
+	result = icmd.RunCmd(icmd.Command("git", "add", "config.json"), icmd.Dir(repoPath))
+	result.Assert(c, icmd.Expected{ExitCode: 0})
+
+	result = icmd.RunCmd(icmd.Command("git", "commit", "-m", "Initial commit"), icmd.Dir(repoPath))
+	result.Assert(c, icmd.Expected{ExitCode: 0})
+}
+
+func (s *GitDatasourcesSuite) startGitDaemon() {
+	var port int
+	port, s.gitDaemonAddr = freeport()
+	gitDaemon := icmd.Command("git", "daemon",
+		"--verbose",
+		"--port="+strconv.Itoa(port),
+		"--base-path="+s.tmpDir.Path(),
+		"--pid-file="+s.pidDir.Join("git.pid"),
+		"--export-all",
+		s.tmpDir.Join("repo", ".git"),
+	)
+	gitDaemon.Dir = s.tmpDir.Path()
+	s.gitDaemonResult = icmd.StartCmd(gitDaemon)
+}
+
+func (s *GitDatasourcesSuite) TearDownSuite(c *C) {
+	defer s.tmpDir.Remove()
+	defer s.pidDir.Remove()
+
+	if s.gitDaemonResult != nil {
+		err := killByPidFile(s.pidDir.Join("git.pid"))
+		handle(c, err)
+
+		s.gitDaemonResult.Cmd.Wait()
+
+		s.gitDaemonResult.Assert(c, icmd.Expected{ExitCode: 0})
+	}
+}
+
+func (s *GitDatasourcesSuite) TestGitFileDatasource(c *C) {
+	u := filepath.ToSlash(s.tmpDir.Join("repo"))
+	o, e, err := cmdTest(c,
+		"-d", "config=git+file://"+u+"//config.json",
+		"-i", `{{ (datasource "config").foo.bar }}`,
+	)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdTest(c,
+		"-d", "repo=git+file://"+u,
+		"-i", `{{ (datasource "repo" "//config.json?type=application/json" ).foo.bar }}`,
+	)
+	assertSuccess(c, o, e, err, "baz")
+
+	o, e, err = cmdTest(c,
+		"-d", "repo=git+file://"+u,
+		"-i", `{{ (datasource "repo" "//config.json" ).foo.bar }}`,
+	)
+	assertSuccess(c, o, e, err, "baz")
+}
+
+func (s *GitDatasourcesSuite) TestGitDatasource(c *C) {
+	if isWindows {
+		c.Skip("not going to run git daemon on Windows")
+	}
+	s.startGitDaemon()
+	time.Sleep(500 * time.Millisecond)
+
+	o, e, err := cmdTest(c,
+		"-c", "config=git://"+s.gitDaemonAddr+"/repo//config.json",
+		"-i", `{{ .config.foo.bar}}`,
+	)
+	assertSuccess(c, o, e, err, "baz")
+}
+
+func (s *GitDatasourcesSuite) TestGitHTTPDatasource(c *C) {
+	o, e, err := cmdTest(c,
+		"-c", "short=git+https://github.com/git-fixtures/basic//json/short.json",
+		"-i", `{{ .short.glossary.title}}`,
+	)
+	assertSuccess(c, o, e, err, "example glossary")
+}
+
+func (s *GitDatasourcesSuite) TestGitSSHDatasource(c *C) {
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		c.Skip("SSH Agent not running")
+	}
+	o, e, err := cmdTest(c,
+		"-c", "short=git+ssh://git@github.com/git-fixtures/basic//json/short.json",
+		"-i", `{{ .short.glossary.title}}`,
+	)
+	assertSuccess(c, o, e, err, "example glossary")
+}

--- a/internal/tests/inprocess-integration/datasources_http_test.go
+++ b/internal/tests/inprocess-integration/datasources_http_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"net"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+)
+
+type DatasourcesHTTPSuite struct {
+	l *net.TCPListener
+}
+
+var _ = Suite(&DatasourcesHTTPSuite{})
+
+func (s *DatasourcesHTTPSuite) SetUpSuite(c *C) {
+	var err error
+	s.l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	handle(c, err)
+
+	http.HandleFunc("/mirror", mirrorHandler)
+	http.HandleFunc("/not.json", typeHandler("application/yaml", "value: notjson\n"))
+	http.HandleFunc("/foo", typeHandler("application/json", `{"value": "json"}`))
+	http.HandleFunc("/actually.json", typeHandler("", `{"value": "json"}`))
+	http.HandleFunc("/bogus.csv", typeHandler("text/plain", `{"value": "json"}`))
+	http.HandleFunc("/list", typeHandler("application/array+json", `[1, 2, 3, 4, 5]`))
+	go http.Serve(s.l, nil)
+}
+
+func (s *DatasourcesHTTPSuite) TearDownSuite(c *C) {
+	s.l.Close()
+}
+
+func (s *DatasourcesHTTPSuite) TestHTTPDatasource(c *C) {
+	o, e, err := cmdTest(c,
+		"-d", "foo=http://"+s.l.Addr().String()+"/mirror",
+		"-H", "foo=Foo:bar",
+		"-i", "{{ index (ds `foo`).headers.Foo 0 }}")
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdTest(c,
+		"-H", "foo=Foo:bar",
+		"-i", "{{defineDatasource `foo` `http://"+s.l.Addr().String()+"/mirror`}}{{ index (ds `foo`).headers.Foo 0 }}")
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdTest(c,
+		"-i", "{{ $d := ds `http://"+s.l.Addr().String()+"/mirror`}}{{ index (index $d.headers `Accept-Encoding`) 0 }}")
+	assertSuccess(c, o, e, err, "gzip")
+}
+
+func (s *DatasourcesHTTPSuite) TestTypeOverridePrecedence(c *C) {
+	o, e, err := cmdTest(c,
+		"-d", "foo=http://"+s.l.Addr().String()+"/foo",
+		"-i", "{{ (ds `foo`).value }}")
+	assertSuccess(c, o, e, err, "json")
+
+	o, e, err = cmdTest(c,
+		"-d", "foo=http://"+s.l.Addr().String()+"/not.json",
+		"-i", "{{ (ds `foo`).value }}")
+	assertSuccess(c, o, e, err, "notjson")
+
+	o, e, err = cmdTest(c,
+		"-d", "foo=http://"+s.l.Addr().String()+"/actually.json",
+		"-i", "{{ (ds `foo`).value }}")
+	assertSuccess(c, o, e, err, "json")
+
+	o, e, err = cmdTest(c,
+		"-d", "foo=http://"+s.l.Addr().String()+"/bogus.csv?type=application/json",
+		"-i", "{{ (ds `foo`).value }}")
+	assertSuccess(c, o, e, err, "json")
+
+	o, e, err = cmdTest(c,
+		"-c", ".=http://"+s.l.Addr().String()+"/list?type=application/array+json",
+		"-i", "{{ range . }}{{ . }}{{ end }}")
+	assertSuccess(c, o, e, err, "12345")
+}
+
+func (s *DatasourcesHTTPSuite) TestAppendQueryAfterSubPaths(c *C) {
+	o, e, err := cmdTest(c,
+		"-d", "foo=http://"+s.l.Addr().String()+"/?type=application/json",
+		"-i", "{{ (ds `foo` `bogus.csv`).value }}")
+	assertSuccess(c, o, e, err, "json")
+}

--- a/internal/tests/inprocess-integration/datasources_merge_test.go
+++ b/internal/tests/inprocess-integration/datasources_merge_test.go
@@ -1,0 +1,70 @@
+package integration
+
+import (
+	"net"
+	"net/http"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+type MergeDatasourceSuite struct {
+	tmpDir *fs.Dir
+	l      *net.TCPListener
+}
+
+var _ = Suite(&MergeDatasourceSuite{})
+
+func (s *MergeDatasourceSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFiles(map[string]string{
+			"config.json": `{"foo": {"bar": "baz"}, "isDefault": false, "isOverride": true}`,
+			"default.yml": "foo:\n  bar: qux\nother: true\nisDefault: true\nisOverride: false\n",
+		}),
+	)
+
+	var err error
+	s.l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	handle(c, err)
+
+	http.HandleFunc("/foo.json", typeHandler("application/json", `{"foo": "bar"}`))
+	http.HandleFunc("/1.env", typeHandler("application/x-env", "FOO=1\nBAR=2\n"))
+	http.HandleFunc("/2.env", typeHandler("application/x-env", "FOO=3\n"))
+	go http.Serve(s.l, nil)
+}
+
+func (s *MergeDatasourceSuite) TearDownSuite(c *C) {
+	s.l.Close()
+	s.tmpDir.Remove()
+}
+
+func (s *MergeDatasourceSuite) TestMergeDatasource(c *C) {
+	o, e, err := cmdTest(c,
+		"-d", "user="+s.tmpDir.Join("config.json"),
+		"-d", "default="+s.tmpDir.Join("default.yml"),
+		"-d", "config=merge:user|default",
+		"-i", `{{ ds "config" | toJSON }}`,
+	)
+	assertSuccess(c, o, e, err, `{"foo":{"bar":"baz"},"isDefault":false,"isOverride":true,"other":true}`)
+
+	o, e, err = cmdTest(c,
+		"-d", "default="+s.tmpDir.Join("default.yml"),
+		"-d", "config=merge:user|default",
+		"-i", `{{ defineDatasource "user" `+"`"+s.tmpDir.Join("config.json")+"`"+` }}{{ ds "config" | toJSON }}`,
+	)
+	assertSuccess(c, o, e, err, `{"foo":{"bar":"baz"},"isDefault":false,"isOverride":true,"other":true}`)
+
+	o, e, err = cmdTest(c,
+		"-d", "default="+s.tmpDir.Join("default.yml"),
+		"-d", "config=merge:http://"+s.l.Addr().String()+"/foo.json|default",
+		"-i", `{{ ds "config" | toJSON }}`,
+	)
+	assertSuccess(c, o, e, err, `{"foo":"bar","isDefault":true,"isOverride":false,"other":true}`)
+
+	o, e, err = cmdTest(c,
+		"-c", "merged=merge:http://"+s.l.Addr().String()+"/2.env|http://"+s.l.Addr().String()+"/1.env",
+		"-i", `FOO is {{ .merged.FOO }}`,
+	)
+	assertSuccess(c, o, e, err, `FOO is 3`)
+}

--- a/internal/tests/inprocess-integration/datasources_vault_ec2_test.go
+++ b/internal/tests/inprocess-integration/datasources_vault_ec2_test.go
@@ -1,0 +1,119 @@
+//+build !windows
+
+package integration
+
+import (
+	"encoding/pem"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+type VaultEc2DatasourcesSuite struct {
+	tmpDir      *fs.Dir
+	pidDir      *fs.Dir
+	vaultAddr   string
+	vaultResult *icmd.Result
+	v           *vaultClient
+	l           *net.TCPListener
+	cert        []byte
+}
+
+var _ = Suite(&VaultEc2DatasourcesSuite{})
+
+func (s *VaultEc2DatasourcesSuite) SetUpSuite(c *C) {
+	var err error
+	s.l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	handle(c, err)
+	priv, der, _ := certificateGenerate()
+	s.cert = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	http.HandleFunc("/latest/dynamic/instance-identity/pkcs7", pkcsHandler(priv, der))
+	http.HandleFunc("/latest/dynamic/instance-identity/document", instanceDocumentHandler)
+	http.HandleFunc("/sts/", stsHandler)
+	http.HandleFunc("/ec2/", ec2Handler)
+	go http.Serve(s.l, nil)
+
+	s.pidDir, s.tmpDir, s.vaultAddr, s.vaultResult = startVault(c)
+
+	s.v, err = createVaultClient(s.vaultAddr, vaultRootToken)
+	handle(c, err)
+
+	err = s.v.vc.Sys().PutPolicy("writepol", `path "*" {
+  policy = "write"
+}`)
+	handle(c, err)
+	err = s.v.vc.Sys().PutPolicy("readpol", `path "*" {
+  policy = "read"
+}`)
+	handle(c, err)
+}
+
+func (s *VaultEc2DatasourcesSuite) TearDownSuite(c *C) {
+	s.l.Close()
+
+	defer s.tmpDir.Remove()
+	defer s.pidDir.Remove()
+
+	p, err := ioutil.ReadFile(s.pidDir.Join("vault.pid"))
+	handle(c, err)
+	pid, err := strconv.Atoi(string(p))
+	handle(c, err)
+	process, err := os.FindProcess(pid)
+	handle(c, err)
+	err = process.Kill()
+	handle(c, err)
+
+	// restore old token if it was backed up
+	u, _ := user.Current()
+	homeDir := u.HomeDir
+	tokenFile := path.Join(homeDir, ".vault-token.bak")
+	info, err := os.Stat(tokenFile)
+	if err == nil && info.Mode().IsRegular() {
+		os.Rename(tokenFile, path.Join(homeDir, ".vault-token"))
+	}
+}
+
+func (s *VaultEc2DatasourcesSuite) TestEc2Auth(c *C) {
+	s.v.vc.Logical().Write("secret/foo", map[string]interface{}{"value": "bar"})
+	defer s.v.vc.Logical().Delete("secret/foo")
+	err := s.v.vc.Sys().EnableAuth("aws", "aws", "")
+	handle(c, err)
+	defer s.v.vc.Sys().DisableAuth("aws")
+	_, err = s.v.vc.Logical().Write("auth/aws/config/client", map[string]interface{}{
+		"secret_key": "secret", "access_key": "access",
+		"endpoint":     "http://" + s.l.Addr().String() + "/ec2",
+		"iam_endpoint": "http://" + s.l.Addr().String() + "/iam",
+		"sts_endpoint": "http://" + s.l.Addr().String() + "/sts",
+	})
+	handle(c, err)
+
+	_, err = s.v.vc.Logical().Write("auth/aws/config/certificate/testcert", map[string]interface{}{
+		"type": "pkcs7", "aws_public_cert": string(s.cert),
+	})
+	handle(c, err)
+
+	_, err = s.v.vc.Logical().Write("auth/aws/role/ami-00000000", map[string]interface{}{
+		"auth_type": "ec2", "bound_ami_id": "ami-00000000",
+		"policies": "readpol",
+	})
+	handle(c, err)
+
+	o, e, err := cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"HOME":              s.tmpDir.Join("home"),
+		"VAULT_ADDR":        "http://" + s.v.addr,
+		"AWS_META_ENDPOINT": "http://" + s.l.Addr().String(),
+	})
+	assertSuccess(c, o, e, err, "bar")
+}

--- a/internal/tests/inprocess-integration/datasources_vault_test.go
+++ b/internal/tests/inprocess-integration/datasources_vault_test.go
@@ -1,0 +1,356 @@
+//+build !windows
+
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+	"strconv"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+	"gotest.tools/v3/icmd"
+)
+
+type VaultDatasourcesSuite struct {
+	tmpDir      *fs.Dir
+	pidDir      *fs.Dir
+	vaultAddr   string
+	vaultResult *icmd.Result
+	v           *vaultClient
+}
+
+var _ = Suite(&VaultDatasourcesSuite{})
+
+const vaultRootToken = "00000000-1111-2222-3333-444455556666"
+
+func (s *VaultDatasourcesSuite) SetUpSuite(c *C) {
+	s.pidDir, s.tmpDir, s.vaultAddr, s.vaultResult = startVault(c)
+
+	var err error
+	s.v, err = createVaultClient(s.vaultAddr, vaultRootToken)
+	handle(c, err)
+
+	err = s.v.vc.Sys().PutPolicy("writepol", `path "*" {
+  capabilities = ["create","update","delete"]
+}`)
+	handle(c, err)
+	err = s.v.vc.Sys().PutPolicy("readpol", `path "*" {
+  capabilities = ["read","delete"]
+}`)
+	handle(c, err)
+	err = s.v.vc.Sys().PutPolicy("listPol", `path "*" {
+  capabilities = ["read","list","delete"]
+}`)
+	handle(c, err)
+}
+
+func startVault(c *C) (pidDir, tmpDir *fs.Dir, vaultAddr string, vaultResult *icmd.Result) {
+	pidDir = fs.NewDir(c, "gomplate-inttests-vaultpid")
+	tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("config.json", `{
+		"pid_file": "`+pidDir.Join("vault.pid")+`"
+		}`),
+	)
+
+	// rename any existing token so it doesn't get overridden
+	u, _ := user.Current()
+	homeDir := u.HomeDir
+	tokenFile := path.Join(homeDir, ".vault-token")
+	info, err := os.Stat(tokenFile)
+	if err == nil && info.Mode().IsRegular() {
+		os.Rename(tokenFile, path.Join(homeDir, ".vault-token.bak"))
+	}
+
+	_, vaultAddr = freeport()
+	vault := icmd.Command("vault", "server",
+		"-dev",
+		"-dev-root-token-id="+vaultRootToken,
+		"-dev-leased-kv",
+		"-log-level=err",
+		"-dev-listen-address="+vaultAddr,
+		"-config="+tmpDir.Join("config.json"),
+	)
+	vaultResult = icmd.StartCmd(vault)
+
+	c.Logf("Fired up Vault: %v", vault)
+
+	err = waitForURL(c, "http://"+vaultAddr+"/v1/sys/health")
+	handle(c, err)
+
+	return pidDir, tmpDir, vaultAddr, vaultResult
+}
+
+func (s *VaultDatasourcesSuite) TearDownSuite(c *C) {
+	defer s.tmpDir.Remove()
+	defer s.pidDir.Remove()
+
+	p, err := ioutil.ReadFile(s.pidDir.Join("vault.pid"))
+	handle(c, err)
+	pid, err := strconv.Atoi(string(p))
+	handle(c, err)
+	process, err := os.FindProcess(pid)
+	handle(c, err)
+	err = process.Kill()
+	handle(c, err)
+
+	// restore old token if it was backed up
+	u, _ := user.Current()
+	homeDir := u.HomeDir
+	tokenFile := path.Join(homeDir, ".vault-token.bak")
+	info, err := os.Stat(tokenFile)
+	if err == nil && info.Mode().IsRegular() {
+		os.Rename(tokenFile, path.Join(homeDir, ".vault-token"))
+	}
+}
+
+func (s *VaultDatasourcesSuite) TestTokenAuth(c *C) {
+	s.v.vc.Logical().Write("secret/foo", map[string]interface{}{"value": "bar"})
+	defer s.v.vc.Logical().Delete("secret/foo")
+	tok, err := s.v.tokenCreate("readpol", 5)
+	handle(c, err)
+
+	o, e, err := cmdWithEnv(c, []string{"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`},
+		map[string]string{
+			"VAULT_ADDR":  "http://" + s.v.addr,
+			"VAULT_TOKEN": tok,
+		})
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdWithEnv(c, []string{"-d", "vault=vault+http://" + s.v.addr + "/secret",
+		"-i", `{{(ds "vault" "foo").value}}`},
+		map[string]string{
+			"VAULT_TOKEN": tok,
+		})
+	assertSuccess(c, o, e, err, "bar")
+
+	_, _, err = cmdWithEnv(c, []string{"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "bar").value}}`},
+		map[string]string{
+			"VAULT_ADDR":  "http://" + s.v.addr,
+			"VAULT_TOKEN": tok,
+		})
+	assert.ErrorContains(c, err, "error calling ds: Couldn't read datasource 'vault': no value found for path /secret/bar")
+
+	tokFile := fs.NewFile(c, "test-vault-token", fs.WithContent(tok))
+	defer tokFile.Remove()
+
+	o, e, err = cmdWithEnv(c, []string{"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`},
+		map[string]string{
+			"VAULT_ADDR":       "http://" + s.v.addr,
+			"VAULT_TOKEN_FILE": tokFile.Path(),
+		})
+	assertSuccess(c, o, e, err, "bar")
+}
+
+func (s *VaultDatasourcesSuite) TestUserPassAuth(c *C) {
+	s.v.vc.Logical().Write("secret/foo", map[string]interface{}{"value": "bar"})
+	defer s.v.vc.Logical().Delete("secret/foo")
+	err := s.v.vc.Sys().EnableAuth("userpass", "userpass", "")
+	handle(c, err)
+	err = s.v.vc.Sys().EnableAuth("userpass2", "userpass", "")
+	handle(c, err)
+	defer s.v.vc.Sys().DisableAuth("userpass")
+	defer s.v.vc.Sys().DisableAuth("userpass2")
+	_, err = s.v.vc.Logical().Write("auth/userpass/users/dave", map[string]interface{}{
+		"password": "foo", "ttl": "10s", "policies": "readpol"})
+	handle(c, err)
+	_, err = s.v.vc.Logical().Write("auth/userpass2/users/dave", map[string]interface{}{
+		"password": "bar", "ttl": "10s", "policies": "readpol"})
+	handle(c, err)
+
+	o, e, err := cmdWithEnv(c, []string{"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`},
+		map[string]string{
+			"VAULT_ADDR":          "http://" + s.v.addr,
+			"VAULT_AUTH_USERNAME": "dave",
+			"VAULT_AUTH_PASSWORD": "foo",
+		})
+	assertSuccess(c, o, e, err, "bar")
+
+	userFile := fs.NewFile(c, "test-vault-user", fs.WithContent("dave"))
+	passFile := fs.NewFile(c, "test-vault-pass", fs.WithContent("foo"))
+	defer userFile.Remove()
+	defer passFile.Remove()
+	o, e, err = cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"VAULT_ADDR":               "http://" + s.v.addr,
+		"VAULT_AUTH_USERNAME_FILE": userFile.Path(),
+		"VAULT_AUTH_PASSWORD_FILE": passFile.Path(),
+	})
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"VAULT_ADDR":                "http://" + s.v.addr,
+		"VAULT_AUTH_USERNAME":       "dave",
+		"VAULT_AUTH_PASSWORD":       "bar",
+		"VAULT_AUTH_USERPASS_MOUNT": "userpass2",
+	})
+	assertSuccess(c, o, e, err, "bar")
+}
+
+func (s *VaultDatasourcesSuite) TestAppRoleAuth(c *C) {
+	s.v.vc.Logical().Write("secret/foo", map[string]interface{}{"value": "bar"})
+	defer s.v.vc.Logical().Delete("secret/foo")
+	err := s.v.vc.Sys().EnableAuth("approle", "approle", "")
+	handle(c, err)
+	err = s.v.vc.Sys().EnableAuth("approle2", "approle", "")
+	handle(c, err)
+	defer s.v.vc.Sys().DisableAuth("approle")
+	defer s.v.vc.Sys().DisableAuth("approle2")
+	_, err = s.v.vc.Logical().Write("auth/approle/role/testrole", map[string]interface{}{
+		"secret_id_ttl": "10s", "token_ttl": "20s",
+		"secret_id_num_uses": "1", "policies": "readpol",
+	})
+	handle(c, err)
+	_, err = s.v.vc.Logical().Write("auth/approle2/role/testrole", map[string]interface{}{
+		"secret_id_ttl": "10s", "token_ttl": "20s",
+		"secret_id_num_uses": "1", "policies": "readpol",
+	})
+	handle(c, err)
+
+	rid, _ := s.v.vc.Logical().Read("auth/approle/role/testrole/role-id")
+	roleID := rid.Data["role_id"].(string)
+	sid, _ := s.v.vc.Logical().Write("auth/approle/role/testrole/secret-id", nil)
+	secretID := sid.Data["secret_id"].(string)
+	o, e, err := cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"VAULT_ADDR":      "http://" + s.v.addr,
+		"VAULT_ROLE_ID":   roleID,
+		"VAULT_SECRET_ID": secretID,
+	})
+	assertSuccess(c, o, e, err, "bar")
+
+	rid, _ = s.v.vc.Logical().Read("auth/approle2/role/testrole/role-id")
+	roleID = rid.Data["role_id"].(string)
+	sid, _ = s.v.vc.Logical().Write("auth/approle2/role/testrole/secret-id", nil)
+	secretID = sid.Data["secret_id"].(string)
+	o, e, err = cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"VAULT_ADDR":               "http://" + s.v.addr,
+		"VAULT_ROLE_ID":            roleID,
+		"VAULT_SECRET_ID":          secretID,
+		"VAULT_AUTH_APPROLE_MOUNT": "approle2",
+	})
+	assertSuccess(c, o, e, err, "bar")
+}
+
+func (s *VaultDatasourcesSuite) TestAppIDAuth(c *C) {
+	s.v.vc.Logical().Write("secret/foo", map[string]interface{}{"value": "bar"})
+	defer s.v.vc.Logical().Delete("secret/foo")
+	err := s.v.vc.Sys().EnableAuth("app-id", "app-id", "")
+	handle(c, err)
+	err = s.v.vc.Sys().EnableAuth("app-id2", "app-id", "")
+	handle(c, err)
+	defer s.v.vc.Sys().DisableAuth("app-id")
+	defer s.v.vc.Sys().DisableAuth("app-id2")
+	_, err = s.v.vc.Logical().Write("auth/app-id/map/app-id/testappid", map[string]interface{}{
+		"display_name": "test_app_id", "value": "readpol",
+	})
+	handle(c, err)
+	_, err = s.v.vc.Logical().Write("auth/app-id/map/user-id/testuserid", map[string]interface{}{
+		"value": "testappid",
+	})
+	handle(c, err)
+	_, err = s.v.vc.Logical().Write("auth/app-id2/map/app-id/testappid", map[string]interface{}{
+		"display_name": "test_app_id", "value": "readpol",
+	})
+	handle(c, err)
+	_, err = s.v.vc.Logical().Write("auth/app-id2/map/user-id/testuserid", map[string]interface{}{
+		"value": "testappid",
+	})
+	handle(c, err)
+
+	o, e, err := cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"VAULT_ADDR":    "http://" + s.v.addr,
+		"VAULT_APP_ID":  "testappid",
+		"VAULT_USER_ID": "testuserid",
+	})
+	assertSuccess(c, o, e, err, "bar")
+
+	o, e, err = cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret",
+		"-i", `{{(ds "vault" "foo").value}}`,
+	}, map[string]string{
+		"VAULT_ADDR":              "http://" + s.v.addr,
+		"VAULT_APP_ID":            "testappid",
+		"VAULT_USER_ID":           "testuserid",
+		"VAULT_AUTH_APP_ID_MOUNT": "app-id2",
+	})
+	assertSuccess(c, o, e, err, "bar")
+}
+
+func (s *VaultDatasourcesSuite) TestDynamicAuth(c *C) {
+	err := s.v.vc.Sys().Mount("ssh/", &vaultapi.MountInput{Type: "ssh"})
+	handle(c, err)
+	defer s.v.vc.Sys().Unmount("ssh")
+
+	_, err = s.v.vc.Logical().Write("ssh/roles/test", map[string]interface{}{
+		"key_type": "otp", "default_user": "user", "cidr_list": "10.0.0.0/8",
+	})
+	handle(c, err)
+	testCommands := []struct {
+		ds, in string
+	}{
+		{"vault=vault:///", `{{(ds "vault" "ssh/creds/test?ip=10.1.2.3&username=user").ip}}`},
+		{"vault=vault:///ssh/creds/test", `{{(ds "vault" "?ip=10.1.2.3&username=user").ip}}`},
+		{"vault=vault:///ssh/creds/test?ip=10.1.2.3&username=user", `{{(ds "vault").ip}}`},
+		{"vault=vault:///?ip=10.1.2.3&username=user", `{{(ds "vault" "ssh/creds/test").ip}}`},
+	}
+	tok, err := s.v.tokenCreate("writepol", len(testCommands)*2)
+	handle(c, err)
+
+	for _, v := range testCommands {
+		args := []string{"-d", v.ds, "-i", v.in}
+		o, e, err := cmdWithEnv(c, args, map[string]string{
+			"VAULT_ADDR":  "http://" + s.v.addr,
+			"VAULT_TOKEN": tok,
+		})
+		assertSuccess(c, o, e, err, "10.1.2.3")
+	}
+}
+
+func (s *VaultDatasourcesSuite) TestList(c *C) {
+	s.v.vc.Logical().Write("secret/dir/foo", map[string]interface{}{"value": "one"})
+	s.v.vc.Logical().Write("secret/dir/bar", map[string]interface{}{"value": "two"})
+	defer s.v.vc.Logical().Delete("secret/dir/foo")
+	defer s.v.vc.Logical().Delete("secret/dir/bar")
+	tok, err := s.v.tokenCreate("listpol", 5)
+	handle(c, err)
+
+	o, e, err := cmdWithEnv(c, []string{
+		"-d", "vault=vault:///secret/dir/",
+		"-i", `{{ range (ds "vault" ) }}{{ . }}: {{ (ds "vault" .).value }} {{end}}`,
+	}, map[string]string{
+		"VAULT_ADDR":  "http://" + s.v.addr,
+		"VAULT_TOKEN": tok,
+	})
+	assertSuccess(c, o, e, err, "bar: two foo: one ")
+
+	o, e, err = cmdWithEnv(c, []string{
+		"-d", "vault=vault+http://" + s.v.addr + "/secret",
+		"-i", `{{ range (ds "vault" "dir/" ) }}{{ . }} {{end}}`,
+	}, map[string]string{
+		"VAULT_TOKEN": tok,
+	})
+	assertSuccess(c, o, e, err, "bar foo ")
+}

--- a/internal/tests/inprocess-integration/docs_examples_test.go
+++ b/internal/tests/inprocess-integration/docs_examples_test.go
@@ -1,0 +1,31 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+// This suite contains integration tests to make sure that (some of) the examples
+// in the gomplate docs work correctly
+type DocExamplesSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&DocExamplesSuite{})
+
+func (s *DocExamplesSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests")
+}
+
+func (s *DocExamplesSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *DocExamplesSuite) TestDataExamples(c *C) {
+	o, e, err := cmdTest(c,
+		"-i", "{{ $rows := (jsonArray `[[\"first\",\"second\"],[\"1\",\"2\"],[\"3\",\"4\"]]`) }}{{ data.ToCSV \";\" $rows }}",
+	)
+	expected := "first;second\r\n1;2\r\n3;4\r\n"
+	assertSuccess(c, o, e, err, expected)
+}

--- a/internal/tests/inprocess-integration/envvars_test.go
+++ b/internal/tests/inprocess-integration/envvars_test.go
@@ -1,0 +1,51 @@
+package integration
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+)
+
+type EnvvarsSuite struct{}
+
+var _ = Suite(&EnvvarsSuite{})
+
+func (s *EnvvarsSuite) TestNonExistantEnvVar(c *C) {
+	os.Unsetenv("FOO")
+	_, _, err := cmdTest(c, "-i", `{{ .Env.FOO }}`)
+	assert.ErrorContains(c, err, "map has no entry for key")
+
+	o, e, err := cmdTest(c, "-i", `{{ getenv "FOO" }}`)
+	assertSuccess(c, o, e, err, "")
+
+	o, e, err = cmdTest(c, "-i", `{{ getenv "FOO" "foo" }}`)
+	assertSuccess(c, o, e, err, "foo")
+
+	o, e, err = cmdTest(c, "-i", `{{env.ExpandEnv "${BAR}foo"}}`)
+	assertSuccess(c, o, e, err, "foo")
+
+	o, e, err = cmdWithEnv(c, []string{"-i", `{{ getenv "FOO" "foo" }}`},
+		map[string]string{"FOO": ""})
+	assertSuccess(c, o, e, err, "foo")
+}
+
+func (s *EnvvarsSuite) TestExistantEnvVar(c *C) {
+	os.Unsetenv("FOO")
+
+	env := map[string]string{"FOO": "foo"}
+	expected := "foo"
+
+	o, e, err := cmdWithEnv(c, []string{"-i", `{{ .Env.FOO }}`}, env)
+	assertSuccess(c, o, e, err, expected)
+
+	o, e, err = cmdWithEnv(c, []string{"-i", `{{ getenv "FOO" }}`}, env)
+	assertSuccess(c, o, e, err, expected)
+
+	o, e, err = cmdWithEnv(c, []string{"-i", `{{ env.Getenv "FOO" }}`}, env)
+	assertSuccess(c, o, e, err, expected)
+
+	o, e, err = cmdWithEnv(c, []string{"-i", `{{env.ExpandEnv "${FOO}"}}`}, env)
+	assertSuccess(c, o, e, err, expected)
+}

--- a/internal/tests/inprocess-integration/file_test.go
+++ b/internal/tests/inprocess-integration/file_test.go
@@ -1,0 +1,44 @@
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gotest.tools/v3/assert"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+type FileSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&FileSuite{})
+
+func (s *FileSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("one", "hi\n"),
+		fs.WithFile("two", "hello\n"))
+}
+
+func (s *FileSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *FileSuite) TestReadsFile(c *C) {
+	inOutTest(c, "{{ file.Read `"+s.tmpDir.Join("one")+"`}}", "hi\n")
+}
+
+func (s *FileSuite) TestWrite(c *C) {
+	outDir := s.tmpDir.Join("writeOutput")
+	os.MkdirAll(outDir, 0755)
+	o, e, err := cmdWithDir(c, outDir, "-i", `{{ "hello world" | file.Write "./out" }}`)
+	assertSuccess(c, o, e, err, "")
+
+	out, err := ioutil.ReadFile(filepath.Join(outDir, "out"))
+	assert.NilError(c, err)
+	assert.Equal(c, "hello world", string(out))
+}

--- a/internal/tests/inprocess-integration/gomplateignore_test.go
+++ b/internal/tests/inprocess-integration/gomplateignore_test.go
@@ -1,0 +1,295 @@
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/spf13/afero"
+	tassert "github.com/stretchr/testify/assert"
+	"gotest.tools/v3/fs"
+)
+
+type GomplateignoreSuite struct {
+	inBuilder func(inFileOps ...fs.PathOp)
+	tmpDir    *fs.Dir
+}
+
+var _ = Suite(&GomplateignoreSuite{})
+
+func (s *GomplateignoreSuite) SetUpTest(c *C) {
+	const basedir = "gomplate-gomplateignore-tests"
+	s.inBuilder = func(inFileOps ...fs.PathOp) {
+		s.tmpDir = fs.NewDir(c, basedir,
+			fs.WithDir("in", inFileOps...),
+			fs.WithDir("out"),
+		)
+	}
+}
+
+func (s *GomplateignoreSuite) TearDownTest(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *GomplateignoreSuite) execute(c *C, ignoreContent string, inFileOps ...fs.PathOp) {
+	s.executeOpts(c, ignoreContent, []string{}, inFileOps...)
+}
+
+func (s *GomplateignoreSuite) executeOpts(c *C, ignoreContent string, opts []string, inFileOps ...fs.PathOp) {
+	inFileOps = append(inFileOps, fs.WithFile(".gomplateignore", ignoreContent))
+	s.inBuilder(inFileOps...)
+
+	argv := []string{}
+	argv = append(argv, opts...)
+	argv = append(argv,
+		"--input-dir", s.tmpDir.Join("in"),
+		"--output-dir", s.tmpDir.Join("out"),
+	)
+	o, e, err := cmdTest(c, argv...)
+	assertSuccess(c, o, e, err, "")
+}
+
+func (s *GomplateignoreSuite) collectOutFiles() (files []string, err error) {
+	files = []string{}
+
+	fs := afero.NewBasePathFs(afero.NewOsFs(), s.tmpDir.Join("out"))
+	afero.Walk(fs, "", func(path string, info os.FileInfo, werr error) error {
+		if werr != nil {
+			err = werr
+			return nil
+		}
+		if path != "" && !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	sort.Strings(files)
+	return
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_Simple(c *C) {
+	s.execute(c, `# all dot files
+.*
+*.log`,
+		fs.WithFile("empty.log", ""),
+		fs.WithFile("rain.txt", ""))
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, []string{"rain.txt"}, files)
+}
+
+func fromSlashes(paths ...string) []string {
+	for i, v := range paths {
+		paths[i] = filepath.FromSlash(v)
+	}
+	return paths
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_Folder(c *C) {
+	s.execute(c, `.gomplateignore
+f[o]o/bar
+!foo/bar/tool`,
+		fs.WithDir("foo",
+			fs.WithDir("bar",
+				fs.WithDir("tool",
+					fs.WithFile("lex.txt", ""),
+				),
+				fs.WithFile("1.txt", ""),
+			),
+			fs.WithDir("tar",
+				fs.WithFile("2.txt", ""),
+			),
+		),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"foo/bar/tool/lex.txt", "foo/tar/2.txt"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_Root(c *C) {
+	s.execute(c, `.gomplateignore
+/1.txt`,
+		fs.WithDir("sub",
+			fs.WithFile("1.txt", ""),
+			fs.WithFile("2.txt", ""),
+		),
+		fs.WithFile("1.txt", ""),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"sub/1.txt", "sub/2.txt"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_Exclusion(c *C) {
+	s.execute(c, `.gomplateignore
+/e*.txt
+!/e2.txt
+en/e3.txt
+!`,
+		fs.WithFile("!", ""),
+		fs.WithFile("e1.txt", ""),
+		fs.WithFile("e2.txt", ""),
+		fs.WithFile("e3.txt", ""),
+		fs.WithDir("en",
+			fs.WithFile("e1.txt", ""),
+			fs.WithFile("e2.txt", ""),
+			fs.WithFile("e3.txt", ""),
+		),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"!", "e2.txt", "en/e1.txt", "en/e2.txt"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_Nested(c *C) {
+	s.execute(c, `inner/foo.md`,
+		fs.WithDir("inner",
+			fs.WithDir("inner2",
+				fs.WithFile(".gomplateignore", "moss.ini\n!/jess.ini"),
+				fs.WithFile("jess.ini", ""),
+				fs.WithFile("moss.ini", "")),
+			fs.WithFile(".gomplateignore", "*.lst\njess.ini"),
+			fs.WithFile("2.lst", ""),
+			fs.WithFile("foo.md", ""),
+		),
+		fs.WithFile("1.txt", ""),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(".gomplateignore", "1.txt",
+		"inner/.gomplateignore",
+		"inner/inner2/.gomplateignore",
+		"inner/inner2/jess.ini"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_ByName(c *C) {
+	s.execute(c, `.gomplateignore
+world.txt`,
+		fs.WithDir("aa",
+			fs.WithDir("a1",
+				fs.WithDir("a2",
+					fs.WithFile("hello.txt", ""),
+					fs.WithFile("world.txt", "")),
+				fs.WithFile("hello.txt", ""),
+				fs.WithFile("world.txt", "")),
+			fs.WithFile("hello.txt", ""),
+			fs.WithFile("world.txt", "")),
+		fs.WithDir("bb",
+			fs.WithFile("hello.txt", ""),
+			fs.WithFile("world.txt", "")),
+		fs.WithFile("hello.txt", ""),
+		fs.WithFile("world.txt", ""),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"aa/a1/a2/hello.txt", "aa/a1/hello.txt",
+		"aa/hello.txt", "bb/hello.txt", "hello.txt"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_BothName(c *C) {
+	s.execute(c, `.gomplateignore
+loss.txt
+!2.log
+`,
+		fs.WithDir("loss.txt",
+			fs.WithFile("1.log", ""),
+			fs.WithFile("2.log", "")),
+		fs.WithDir("foo",
+			fs.WithFile("loss.txt", ""),
+			fs.WithFile("bare.txt", "")),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"foo/bare.txt", "loss.txt/2.log"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_LeadingSpace(c *C) {
+	s.execute(c, `.gomplateignore
+  what.txt
+!inner/  what.txt
+*.log
+!  dart.log
+`,
+		fs.WithDir("inner",
+			fs.WithFile("  what.txt", ""),
+			fs.WithFile("  dart.log", "")),
+		fs.WithDir("inner2",
+			fs.WithFile("  what.txt", "")),
+		fs.WithFile("  what.txt", ""),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"inner/  dart.log", "inner/  what.txt"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_WithExcludes(c *C) {
+	s.executeOpts(c, `.gomplateignore
+*.log
+`, []string{
+		"--exclude", "crash.bin",
+		"--exclude", "rules/*.txt",
+		"--exclude", "sprites/*.ini",
+	},
+		fs.WithDir("logs",
+			fs.WithFile("archive.zip", ""),
+			fs.WithFile("engine.log", ""),
+			fs.WithFile("skills.log", "")),
+		fs.WithDir("rules",
+			fs.WithFile("index.csv", ""),
+			fs.WithFile("fire.txt", ""),
+			fs.WithFile("earth.txt", "")),
+		fs.WithDir("sprites",
+			fs.WithFile("human.csv", ""),
+			fs.WithFile("demon.xml", ""),
+			fs.WithFile("alien.ini", "")),
+		fs.WithFile("manifest.json", ""),
+		fs.WithFile("crash.bin", ""),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes(
+		"logs/archive.zip", "manifest.json", "rules/index.csv",
+		"sprites/demon.xml", "sprites/human.csv"), files)
+}
+
+func (s *GomplateignoreSuite) TestGomplateignore_WithIncludes(c *C) {
+	s.executeOpts(c, `.gomplateignore
+*.log
+`, []string{
+		"--include", "rules/*",
+		"--exclude", "rules/*.txt",
+	},
+		fs.WithDir("logs",
+			fs.WithFile("archive.zip", ""),
+			fs.WithFile("engine.log", ""),
+			fs.WithFile("skills.log", "")),
+		fs.WithDir("rules",
+			fs.WithFile("index.csv", ""),
+			fs.WithFile("fire.txt", ""),
+			fs.WithFile("earth.txt", "")),
+		fs.WithFile("manifest.json", ""),
+		fs.WithFile("crash.bin", ""),
+	)
+
+	files, err := s.collectOutFiles()
+	tassert.NoError(c, err)
+	tassert.Equal(c, fromSlashes("rules/index.csv"), files)
+}

--- a/internal/tests/inprocess-integration/inputdir_test.go
+++ b/internal/tests/inprocess-integration/inputdir_test.go
@@ -1,0 +1,235 @@
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	tassert "github.com/stretchr/testify/assert"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+type InputDirSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&InputDirSuite{})
+
+func (s *InputDirSuite) SetUpTest(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("config.yml", "one: eins\ntwo: deux\n"),
+		fs.WithFile("filemap.json", `{"eins.txt":"uno","deux.txt":"dos","drei.sh":"tres","vier.txt":"quatro"}`),
+		fs.WithFile("out.t", `{{- /* .in may contain a directory name - we want to preserve that */ -}}
+{{ $f := filepath.Base .in -}}
+out/{{ .in | strings.ReplaceAll $f (index .filemap $f) }}.out
+`),
+		fs.WithDir("in",
+			fs.WithFile("eins.txt", `{{ (ds "config").one }}`, fs.WithMode(0644)),
+			fs.WithDir("inner",
+				fs.WithFile("deux.txt", `{{ (ds "config").two }}`, fs.WithMode(0444)),
+			),
+			fs.WithFile("drei.sh", `#!/bin/sh\necho "hello world"\n`, fs.WithMode(0755)),
+			fs.WithFile("vier.txt", `{{ (ds "config").two }} * {{ (ds "config").two }}`, fs.WithMode(0544)),
+		),
+		fs.WithDir("out"),
+		fs.WithDir("bad_in",
+			fs.WithFile("bad.tmpl", "{{end}}"),
+		),
+	)
+}
+
+func (s *InputDirSuite) TestInputDir(c *C) {
+	o, e, err := cmdTest(c,
+		"--input-dir", s.tmpDir.Join("in"),
+		"--output-dir", s.tmpDir.Join("out"),
+		"-d", "config="+s.tmpDir.Join("config.yml"),
+	)
+	assertSuccess(c, o, e, err, "")
+
+	files, err := ioutil.ReadDir(s.tmpDir.Join("out"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 4)
+
+	files, err = ioutil.ReadDir(s.tmpDir.Join("out", "inner"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 1)
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{s.tmpDir.Join("out", "eins.txt"), 0644, "eins"},
+		{s.tmpDir.Join("out", "inner", "deux.txt"), 0444, "deux"},
+		{s.tmpDir.Join("out", "drei.sh"), 0755, `#!/bin/sh\necho "hello world"\n`},
+		{s.tmpDir.Join("out", "vier.txt"), 0544, "deux * deux"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		m := config.NormalizeFileMode(v.mode)
+		assert.Equal(c, m, info.Mode(), v.path)
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *InputDirSuite) TestInputDirWithModeOverride(c *C) {
+	o, e, err := cmdTest(c,
+		"--input-dir", s.tmpDir.Join("in"),
+		"--output-dir", s.tmpDir.Join("out"),
+		"--chmod", "0601",
+		"-d", "config="+s.tmpDir.Join("config.yml"),
+	)
+	assertSuccess(c, o, e, err, "")
+
+	files, err := ioutil.ReadDir(s.tmpDir.Join("out"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 4)
+
+	files, err = ioutil.ReadDir(s.tmpDir.Join("out", "inner"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 1)
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{s.tmpDir.Join("out", "eins.txt"), 0601, "eins"},
+		{s.tmpDir.Join("out", "inner", "deux.txt"), 0601, "deux"},
+		{s.tmpDir.Join("out", "drei.sh"), 0601, `#!/bin/sh\necho "hello world"\n`},
+		{s.tmpDir.Join("out", "vier.txt"), 0601, "deux * deux"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		m := config.NormalizeFileMode(v.mode)
+		assert.Equal(c, m, info.Mode(), v.path)
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *InputDirSuite) TestOutputMapInline(c *C) {
+	o, e, err := cmdWithDir(c, s.tmpDir.Path(),
+		"--input-dir", s.tmpDir.Join("in"),
+		"--output-map", `OUT/{{ strings.ToUpper .in }}`,
+		"-d", "config.yml",
+	)
+	assertSuccess(c, o, e, err, "")
+
+	files, err := ioutil.ReadDir(s.tmpDir.Join("OUT"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 4)
+
+	files, err = ioutil.ReadDir(s.tmpDir.Join("OUT", "INNER"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 1)
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{s.tmpDir.Join("OUT", "EINS.TXT"), 0644, "eins"},
+		{s.tmpDir.Join("OUT", "INNER", "DEUX.TXT"), 0444, "deux"},
+		{s.tmpDir.Join("OUT", "DREI.SH"), 0755, `#!/bin/sh\necho "hello world"\n`},
+		{s.tmpDir.Join("OUT", "VIER.TXT"), 0544, "deux * deux"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		m := config.NormalizeFileMode(v.mode)
+		assert.Equal(c, m, info.Mode(), v.path)
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *InputDirSuite) TestOutputMapExternal(c *C) {
+	o, e, err := cmdWithDir(c, s.tmpDir.Path(),
+		"--input-dir", s.tmpDir.Join("in"),
+		"--output-map", `{{ template "out" . }}`,
+		"-t", "out=out.t",
+		"-c", "filemap.json",
+		"-d", "config.yml",
+	)
+	assertSuccess(c, o, e, err, "")
+
+	files, err := ioutil.ReadDir(s.tmpDir.Join("out"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 4)
+
+	files, err = ioutil.ReadDir(s.tmpDir.Join("out", "inner"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 1)
+
+	testdata := []struct {
+		path    string
+		mode    os.FileMode
+		content string
+	}{
+		{s.tmpDir.Join("out", "uno.out"), 0644, "eins"},
+		{s.tmpDir.Join("out", "inner", "dos.out"), 0444, "deux"},
+		{s.tmpDir.Join("out", "tres.out"), 0755, `#!/bin/sh\necho "hello world"\n`},
+		{s.tmpDir.Join("out", "quatro.out"), 0544, "deux * deux"},
+	}
+	for _, v := range testdata {
+		info, err := os.Stat(v.path)
+		assert.NilError(c, err)
+		m := config.NormalizeFileMode(v.mode)
+		assert.Equal(c, m, info.Mode(), v.path)
+		content, err := ioutil.ReadFile(v.path)
+		assert.NilError(c, err)
+		assert.Equal(c, v.content, string(content))
+	}
+}
+
+func (s *InputDirSuite) TestDefaultOutputDir(c *C) {
+	o, e, err := cmdWithDir(c, s.tmpDir.Join("out"),
+		"--input-dir", s.tmpDir.Join("in"),
+		"-d", "config="+s.tmpDir.Join("config.yml"),
+	)
+	assertSuccess(c, o, e, err, "")
+
+	files, err := ioutil.ReadDir(s.tmpDir.Join("out"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 4)
+
+	files, err = ioutil.ReadDir(s.tmpDir.Join("out", "inner"))
+	assert.NilError(c, err)
+	tassert.Len(c, files, 1)
+
+	content, err := ioutil.ReadFile(s.tmpDir.Join("out", "eins.txt"))
+	assert.NilError(c, err)
+	assert.Equal(c, "eins", string(content))
+
+	content, err = ioutil.ReadFile(s.tmpDir.Join("out", "inner", "deux.txt"))
+	assert.NilError(c, err)
+	assert.Equal(c, "deux", string(content))
+
+	content, err = ioutil.ReadFile(s.tmpDir.Join("out", "drei.sh"))
+	assert.NilError(c, err)
+	assert.Equal(c, `#!/bin/sh\necho "hello world"\n`, string(content))
+
+	content, err = ioutil.ReadFile(s.tmpDir.Join("out", "vier.txt"))
+	assert.NilError(c, err)
+	assert.Equal(c, `deux * deux`, string(content))
+}
+
+func (s *InputDirSuite) TestReportsFilenameWithBadInputFile(c *C) {
+	o, _, err := cmdTest(c,
+		"--input-dir", s.tmpDir.Join("bad_in"),
+		"--output-dir", s.tmpDir.Join("out"),
+		"-d", "config="+s.tmpDir.Join("config.yml"),
+	)
+	assert.ErrorContains(c, err, "bad.tmpl:1: unexpected {{end}}")
+	assert.Equal(c, "", o)
+}

--- a/internal/tests/inprocess-integration/inputdir_unix_test.go
+++ b/internal/tests/inprocess-integration/inputdir_unix_test.go
@@ -1,0 +1,66 @@
+//+build !windows
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"golang.org/x/sys/unix"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+func setFileUlimit(b uint64) error {
+	ulimit := unix.Rlimit{
+		Cur: b,
+		Max: math.MaxInt64,
+	}
+	err := unix.Setrlimit(unix.RLIMIT_NOFILE, &ulimit)
+	return err
+}
+
+func (s *InputDirSuite) TestInputDirRespectsUlimit(c *C) {
+	numfiles := 32
+	flist := map[string]string{}
+	for i := 0; i < numfiles; i++ {
+		k := fmt.Sprintf("file_%d", i)
+		flist[k] = fmt.Sprintf("hello world %d\n", i)
+	}
+	testdir := fs.NewDir(c, "ulimittestfiles",
+		fs.WithDir("in", fs.WithFiles(flist)),
+	)
+	defer testdir.Remove()
+
+	// we need another ~11 fds for other various things, so we'd be guaranteed
+	// to hit the limit if we try to have all the input files open
+	// simultaneously
+	setFileUlimit(uint64(numfiles))
+	defer setFileUlimit(8192)
+
+	o, e, err := cmdWithDir(c, testdir.Path(),
+		"--input-dir", testdir.Join("in"),
+		"--output-dir", testdir.Join("out"),
+	)
+	setFileUlimit(8192)
+	assertSuccess(c, o, e, err, "")
+
+	files, err := ioutil.ReadDir(testdir.Join("out"))
+	assert.NilError(c, err)
+	assert.Equal(c, numfiles, len(files))
+
+	for i := 0; i < numfiles; i++ {
+		f := testdir.Join("out", fmt.Sprintf("file_%d", i))
+		_, err := os.Stat(f)
+		assert.NilError(c, err)
+
+		content, err := ioutil.ReadFile(f)
+		assert.NilError(c, err)
+		expected := fmt.Sprintf("hello world %d\n", i)
+		assert.Equal(c, expected, string(content))
+	}
+}

--- a/internal/tests/inprocess-integration/integration.go
+++ b/internal/tests/inprocess-integration/integration.go
@@ -1,0 +1,10 @@
+// Package integration contains integration tests.
+//
+// These should be run from the root of the repo as:
+//
+//	$ make integration
+//
+// or:
+//
+//	$ go test -tags=integration ./tests/integration
+package integration

--- a/internal/tests/inprocess-integration/integration_test.go
+++ b/internal/tests/inprocess-integration/integration_test.go
@@ -1,0 +1,215 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hairyhenderson/gomplate/v3/internal/cmd"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/check.v1"
+)
+
+const isWindows = runtime.GOOS == "windows"
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+// a convenience...
+func inOutTest(c *check.C, i, o string) {
+	stdout, stderr, err := cmdTest(c, "-i", i)
+	assert.NoError(c, err)
+	assert.Equal(c, "", stderr)
+	assert.Equal(c, o, stdout)
+}
+
+func inOutContains(c *check.C, i, o string) {
+	stdout, stderr, err := cmdTest(c, "-i", i)
+	assert.NoError(c, err)
+	assert.Equal(c, "", stderr)
+	assert.Contains(c, stdout, o)
+}
+
+func cmdTest(c *check.C, args ...string) (o, e string, err error) {
+	ctx := context.Background()
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err = cmd.Main(ctx, args, nil, stdout, stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func cmdWithStdin(c *check.C, args []string, in string) (o, e string, err error) {
+	ctx := context.Background()
+	stdin := strings.NewReader(in)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err = cmd.Main(ctx, args, stdin, stdout, stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func cmdWithDir(c *check.C, dir string, args ...string) (o, e string, err error) {
+	origWd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	defer func() { os.Chdir(origWd) }()
+	err = os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+
+	return cmdTest(c, args...)
+}
+
+func cmdWithEnv(c *check.C, args []string, env map[string]string) (o, e string, err error) {
+	origEnviron := map[string]string{}
+	for k, v := range env {
+		origEnviron[k] = os.Getenv(k)
+		os.Setenv(k, v)
+	}
+
+	defer func() {
+		for k, v := range origEnviron {
+			os.Setenv(k, v)
+		}
+	}()
+
+	ctx := context.Background()
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err = cmd.Main(ctx, args, nil, stdout, stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func assertSuccess(c *check.C, o, e string, err error, expected string) {
+	assert.NoError(c, err)
+	assert.Equal(c, "", e)
+	assert.Equal(c, expected, o)
+}
+
+func handle(c *check.C, err error) {
+	if err != nil {
+		c.Fatal(err)
+	}
+}
+
+// mirrorHandler - reflects back the HTTP headers from the request
+func mirrorHandler(w http.ResponseWriter, r *http.Request) {
+	type Req struct {
+		Headers http.Header `json:"headers"`
+	}
+	req := Req{r.Header}
+	b, err := json.Marshal(req)
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+}
+
+func typeHandler(t, body string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", t)
+		w.Write([]byte(body))
+	}
+}
+
+// freeport - find a free TCP port for immediate use. No guarantees!
+func freeport() (port int, addr string) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	a := l.Addr().(*net.TCPAddr)
+	port = a.Port
+	return port, a.String()
+}
+
+// waitForURL - waits up to 20s for a given URL to respond with a 200
+func waitForURL(c *check.C, url string) error {
+	client := http.DefaultClient
+	retries := 100
+	for retries > 0 {
+		retries--
+		time.Sleep(200 * time.Millisecond)
+		resp, err := client.Get(url)
+		if err != nil {
+			c.Logf("Got error, retries left: %d (error: %v)", retries, err)
+			continue
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		c.Logf("Body is: %s", body)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == 200 {
+			return nil
+		}
+	}
+	return nil
+}
+
+type vaultClient struct {
+	addr      string
+	rootToken string
+	vc        *vaultapi.Client
+}
+
+func createVaultClient(addr string, rootToken string) (*vaultClient, error) {
+	config := vaultapi.DefaultConfig()
+	config.Address = "http://" + addr
+	client, err := vaultapi.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+	v := &vaultClient{
+		addr:      addr,
+		rootToken: rootToken,
+		vc:        client,
+	}
+	client.SetToken(rootToken)
+	return v, nil
+}
+
+func (v *vaultClient) tokenCreate(policy string, uses int) (string, error) {
+	opts := &vaultapi.TokenCreateRequest{
+		Policies: []string{policy},
+		TTL:      "1m",
+		NumUses:  uses,
+	}
+	token, err := v.vc.Auth().Token().Create(opts)
+	if err != nil {
+		return "", err
+	}
+	return token.Auth.ClientToken, nil
+}
+
+func killByPidFile(pidFile string) error {
+	p, err := ioutil.ReadFile(pidFile)
+	if err != nil {
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(p)))
+	if err != nil {
+		return err
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	err = process.Kill()
+	return err
+}

--- a/internal/tests/inprocess-integration/math_test.go
+++ b/internal/tests/inprocess-integration/math_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type MathSuite struct{}
+
+var _ = Suite(&MathSuite{})
+
+func (s *MathSuite) TestMath(c *C) {
+	inOutTest(c, `{{ math.Add 1 2 3 4 }} {{ add -5 5 }}`, "10 0")
+	inOutTest(c, `{{ math.Sub 10 5 }} {{ sub -5 5 }}`, "5 -10")
+	inOutTest(c, `{{ math.Mul 1 2 3 4 }} {{ mul -5 5 }}`, "24 -25")
+	inOutTest(c, `{{ math.Div 5 2 }} {{ div -5 5 }}`, "2.5 -1")
+	inOutTest(c, `{{ math.Rem 5 3 }} {{ rem 2 2 }}`, "2 0")
+	inOutTest(c, `{{ math.Pow 8 4 }} {{ pow 2 2 }}`, "4096 4")
+	inOutTest(c, `{{ math.Seq 0 }}, {{ seq 0 3 }}, {{ seq -5 -10 2 }}`,
+		`[1 0], [0 1 2 3], [-5 -7 -9]`)
+	inOutTest(c, `{{ math.Round 0.99 }}, {{ math.Round "foo" }}, {{math.Round 3.5}}`,
+		`1, 0, 4`)
+	inOutTest(c, `{{ math.Max -0 "+Inf" "NaN" }}, {{ math.Max 3.4 3.401 3.399 }}`,
+		`+Inf, 3.401`)
+}

--- a/internal/tests/inprocess-integration/nested_templates_test.go
+++ b/internal/tests/inprocess-integration/nested_templates_test.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/fs"
+)
+
+type NestedTemplatesSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&NestedTemplatesSuite{})
+
+func (s *NestedTemplatesSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("hello.t", `Hello {{ . }}!`),
+		fs.WithDir("templates",
+			fs.WithFile("one.t", `{{ . }}`),
+			fs.WithFile("two.t", `{{ range $n := (seq 2) }}{{ $n }}: {{ $ }} {{ end }}`),
+		),
+	)
+}
+
+func (s *NestedTemplatesSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *NestedTemplatesSuite) TestNestedTemplates(c *C) {
+	o, e, err := cmdTest(c,
+		"-t", "hello="+s.tmpDir.Join("hello.t"),
+		"-i", `{{ template "hello" "World"}}`,
+	)
+	assertSuccess(c, o, e, err, "Hello World!")
+
+	o, e, err = cmdWithDir(c, s.tmpDir.Path(),
+		"-t", "hello.t",
+		"-i", `{{ template "hello.t" "World"}}`)
+	assertSuccess(c, o, e, err, "Hello World!")
+
+	o, e, err = cmdWithDir(c, s.tmpDir.Path(),
+		"-t", "templates/",
+		"-i", `{{ template "templates/one.t" "one"}}
+{{ template "templates/two.t" "two"}}`,
+	)
+	assertSuccess(c, o, e, err, "one\n1: two 2: two ")
+}

--- a/internal/tests/inprocess-integration/net_test.go
+++ b/internal/tests/inprocess-integration/net_test.go
@@ -1,0 +1,13 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type NetSuite struct{}
+
+var _ = Suite(&NetSuite{})
+
+func (s *NetSuite) TestLookupIP(c *C) {
+	inOutTest(c, `{{ net.LookupIP "localhost" }}`, "127.0.0.1")
+}

--- a/internal/tests/inprocess-integration/plugins_test.go
+++ b/internal/tests/inprocess-integration/plugins_test.go
@@ -1,0 +1,76 @@
+//+build !windows
+
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+type PluginsSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&PluginsSuite{})
+
+func (s *PluginsSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("foo.sh", "#!/bin/sh\n\necho $*\n", fs.WithMode(0755)),
+		fs.WithFile("foo.ps1", "echo $args\r\n", fs.WithMode(0755)),
+		fs.WithFile("bar.sh", "#!/bin/sh\n\neval \"echo $*\"\n", fs.WithMode(0755)),
+		fs.WithFile("fail.sh", "#!/bin/sh\n\n>&2 echo $1\nexit $2\n", fs.WithMode(0755)),
+		fs.WithFile("fail.ps1", `param (
+	[Parameter(Position=0)]
+	[string]$msg,
+
+	[Parameter(Position=1)]
+	[int]$code
+)
+write-error $msg
+exit $code
+`, fs.WithMode(0755)),
+		fs.WithFile("sleep.sh", "#!/bin/sh\n\nexec sleep $1\n", fs.WithMode(0755)),
+	)
+}
+
+func (s *PluginsSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *PluginsSuite) TestPlugins(c *C) {
+	o, e, err := cmdTest(c, "--plugin", "hi="+s.tmpDir.Join("foo.sh"),
+		"-i", `{{ hi "hello world" }}`)
+	assertSuccess(c, o, e, err, "hello world\n")
+
+	cmdWithEnv(c, []string{
+		"--plugin", "echo=" + s.tmpDir.Join("bar.sh"),
+		"-i", `{{ echo "$HELLO" }}`,
+	}, map[string]string{"HELLO": "hello world"})
+	assertSuccess(c, o, e, err, "hello world\n")
+}
+
+func (s *PluginsSuite) TestPluginErrors(c *C) {
+	_, _, err := cmdTest(c, "--plugin", "f=false",
+		"-i", `{{ f }}`)
+	assert.ErrorContains(c, err, "exit status 1")
+
+	_, _, err = cmdTest(c, "--plugin", "f="+s.tmpDir.Join("fail.sh"),
+		"-i", `{{ f "all is lost" 5 }}`)
+	assert.ErrorContains(c, err, "all is lost")
+	assert.ErrorContains(c, err, "error calling f: exit status 5")
+}
+
+func (s *PluginsSuite) TestPluginTimeout(c *C) {
+	_, _, err := cmdTest(c, "--plugin", "sleep="+s.tmpDir.Join("sleep.sh"),
+		"-i", `{{ sleep 10 }}`,
+	)
+	assert.ErrorContains(c, err, "plugin timed out")
+
+	_, _, err = cmdWithEnv(c, []string{
+		"--plugin", "sleep=" + s.tmpDir.Join("sleep.sh"),
+		"-i", `{{ sleep 2 }}`,
+	}, map[string]string{"GOMPLATE_PLUGIN_TIMEOUT": "500ms"})
+	assert.ErrorContains(c, err, "plugin timed out")
+}

--- a/internal/tests/inprocess-integration/plugins_windows_test.go
+++ b/internal/tests/inprocess-integration/plugins_windows_test.go
@@ -1,0 +1,62 @@
+//+build windows
+
+package integration
+
+import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+type PluginsSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&PluginsSuite{})
+
+func (s *PluginsSuite) SetUpSuite(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-inttests",
+		fs.WithFile("foo.ps1", "echo $args\r\nexit 0\r\n", fs.WithMode(0644)),
+		fs.WithFile("foo.bat", "@ECHO OFF\r\nECHO %1\r\n", fs.WithMode(0644)),
+		fs.WithFile("fail.bat", `@ECHO OFF
+ECHO %1 1>&2
+EXIT /B %2
+`, fs.WithMode(0755)),
+		fs.WithFile("fail.ps1", `param (
+       [Parameter(Position=0)]
+       [string]$msg,
+
+       [Parameter(Position=1)]
+       [int]$code
+)
+$host.ui.WriteErrorLine($msg)
+$host.SetShouldExit($code)
+`, fs.WithMode(0755)),
+	)
+}
+
+func (s *PluginsSuite) TearDownSuite(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *PluginsSuite) TestPlugins(c *C) {
+	o, e, err := cmdTest(c,
+		"--plugin", "foo="+s.tmpDir.Join("foo.bat"),
+		"-i", `{{ foo "hello world" }}`,
+	)
+	assertSuccess(c, strings.TrimSpace(o), e, err, `"hello world"`)
+}
+
+func (s *PluginsSuite) TestPluginErrors(c *C) {
+	_, _, err := cmdTest(c, "--plugin", "f=false",
+		"-i", `{{ f }}`)
+	assert.ErrorContains(c, err, "exit status 1")
+
+	_, _, err = cmdTest(c, "--plugin", "f="+s.tmpDir.Join("fail.bat"),
+		"-i", `{{ f "bat failed" 42 }}`)
+	assert.ErrorContains(c, err, "bat failed")
+	assert.ErrorContains(c, err, "error calling f: exit status 42")
+}

--- a/internal/tests/inprocess-integration/regexp_test.go
+++ b/internal/tests/inprocess-integration/regexp_test.go
@@ -1,0 +1,17 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type RegexpSuite struct{}
+
+var _ = Suite(&RegexpSuite{})
+
+func (s *RegexpSuite) TestReplace(c *C) {
+	inOutTest(c, `{{ "1.2.3-59" | regexp.Replace "-([0-9]*)" ".$1" }}`, "1.2.3.59")
+}
+
+func (s *RegexpSuite) TestQuoteMeta(c *C) {
+	inOutTest(c, "{{ regexp.QuoteMeta `foo{(\\` }}", `foo\{\(\\`)
+}

--- a/internal/tests/inprocess-integration/sockaddr_test.go
+++ b/internal/tests/inprocess-integration/sockaddr_test.go
@@ -1,0 +1,15 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type SockaddrSuite struct{}
+
+var _ = Suite(&SockaddrSuite{})
+
+func (s *SockaddrSuite) TestSockaddr(c *C) {
+	inOutContains(c, `{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ipv4") -}}
+{{ . | sockaddr.Attr "address" }}
+{{end}}`, "127.0.0.1")
+}

--- a/internal/tests/inprocess-integration/strings_test.go
+++ b/internal/tests/inprocess-integration/strings_test.go
@@ -1,0 +1,62 @@
+package integration
+
+import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+)
+
+type StringsSuite struct{}
+
+var _ = Suite(&StringsSuite{})
+
+func (s *StringsSuite) TestIndent(c *C) {
+	inOutTest(c, `{{ strings.Indent "   " "hello world" }}
+{{ "hello\nmultiline\nworld" | indent 2 "-" }}
+{{ "foo\nbar" | strings.Indent 2 }}
+    {{"hello\nworld" | strings.Indent 5 | strings.TrimSpace }}
+`, `   hello world
+--hello
+--multiline
+--world
+  foo
+  bar
+    hello
+     world
+`)
+}
+
+func (s *StringsSuite) TestRepeat(c *C) {
+	inOutTest(c, `ba{{ strings.Repeat 2 "na" }}`, `banana`)
+
+	_, _, err := cmdTest(c, "-i", `ba{{ strings.Repeat 9223372036854775807 "na" }}`)
+	assert.ErrorContains(c, err, `too long: causes overflow`)
+
+	_, _, err = cmdTest(c, "-i", `ba{{ strings.Repeat -1 "na" }}`)
+	assert.ErrorContains(c, err, `negative count`)
+}
+
+func (s *StringsSuite) TestSlug(c *C) {
+	inOutTest(c, `{{ strings.Slug "Hellö, Wôrld! Free @ last..." }}`, `hello-world-free-at-last`)
+}
+
+func (s *StringsSuite) TestCaseFuncs(c *C) {
+	inOutTest(c, `{{ strings.CamelCase "Hellö, Wôrld! Free @ last..." }}
+{{ strings.SnakeCase "Hellö, Wôrld! Free @ last..." }}
+{{ strings.KebabCase "Hellö, Wôrld! Free @ last..." }}`, `HellöWôrldFreeLast
+Hellö_wôrld_free_last
+Hellö-wôrld-free-last`)
+}
+
+func (s *StringsSuite) TestWordWrap(c *C) {
+	out := `There shouldn't be any wrapping of long words or URLs because that would break
+things very badly. To wit:
+https://example.com/a/super-long/url/that-shouldnt-be?wrapped=for+fear+of#the-breaking-of-functionality
+should appear on its own line, regardless of the desired word-wrapping width
+that has been set.`
+	text := strings.ReplaceAll(out, "\n", " ")
+	in := `{{ print "` + text + `" | strings.WordWrap 80 }}`
+	inOutTest(c, in, out)
+}

--- a/internal/tests/inprocess-integration/test_ec2_utils.go
+++ b/internal/tests/inprocess-integration/test_ec2_utils.go
@@ -1,0 +1,248 @@
+package integration
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log"
+	"math/big"
+	"net/http"
+
+	"github.com/fullsailor/pkcs7"
+)
+
+const instanceDocument = `{
+    "devpayProductCodes" : null,
+    "availabilityZone" : "xx-test-1b",
+    "privateIp" : "10.1.2.3",
+    "version" : "2010-08-31",
+    "instanceId" : "i-00000000000000000",
+    "billingProducts" : null,
+    "instanceType" : "t2.micro",
+    "accountId" : "1",
+    "imageId" : "ami-00000000",
+    "pendingTime" : "2000-00-01T0:00:00Z",
+    "architecture" : "x86_64",
+    "kernelId" : null,
+    "ramdiskId" : null,
+    "region" : "xx-test-1"
+}`
+
+func instanceDocumentHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, err := w.Write([]byte(instanceDocument))
+	if err != nil {
+		w.WriteHeader(500)
+	}
+}
+
+func certificateGenerate() (priv *rsa.PrivateKey, derBytes []byte, err error) {
+	priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatalf("failed to generate private key: %s", err)
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		log.Fatalf("failed to generate serial number: %s", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+	}
+
+	derBytes, err = x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	return priv, derBytes, err
+}
+
+func pkcsHandler(priv *rsa.PrivateKey, derBytes []byte) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cert, err := x509.ParseCertificate(derBytes)
+		if err != nil {
+			log.Fatalf("Cannot decode certificate: %s", err)
+		}
+
+		// Initialize a SignedData struct with content to be signed
+		signedData, err := pkcs7.NewSignedData([]byte(instanceDocument))
+		if err != nil {
+			log.Fatalf("Cannot initialize signed data: %s", err)
+		}
+
+		// Add the signing cert and private key
+		if err = signedData.AddSigner(cert, priv, pkcs7.SignerInfoConfig{}); err != nil {
+			log.Fatalf("Cannot add signer: %s", err)
+		}
+
+		// Finish() to obtain the signature bytes
+		detachedSignature, err := signedData.Finish()
+		if err != nil {
+			log.Fatalf("Cannot finish signing data: %s", err)
+		}
+
+		encoded := pem.EncodeToMemory(&pem.Block{Type: "PKCS7", Bytes: detachedSignature})
+
+		encoded = bytes.TrimPrefix(encoded, []byte("-----BEGIN PKCS7-----\n"))
+		encoded = bytes.TrimSuffix(encoded, []byte("\n-----END PKCS7-----\n"))
+
+		w.Header().Set("Content-Type", "text/plain")
+		_, err = w.Write(encoded)
+		if err != nil {
+			w.WriteHeader(500)
+		}
+	}
+}
+
+func stsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/xml")
+	_, err := w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+   <Arn>arn:aws:iam::1:user/Test</Arn>
+    <UserId>AKIAI44QH8DHBEXAMPLE</UserId>
+    <Account>1</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata>
+    <RequestId>01234567-89ab-cdef-0123-456789abcdef</RequestId>
+  </ResponseMetadata>
+</GetCallerIdentityResponse>`))
+	if err != nil {
+		w.WriteHeader(500)
+	}
+}
+
+func ec2Handler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/xml")
+	_, err := w.Write([]byte(`<DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+    <requestId>8f7724cf-496f-496e-8fe3-example</requestId>
+    <reservationSet>
+        <item>
+            <reservationId>r-1234567890abcdef0</reservationId>
+            <ownerId>123456789012</ownerId>
+            <groupSet/>
+            <instancesSet>
+                <item>
+                    <instanceId>i-00000000000000000</instanceId>
+                    <imageId>ami-00000000</imageId>
+                    <instanceState>
+                        <code>16</code>
+                        <name>running</name>
+                    </instanceState>
+                    <privateDnsName>ip-192-168-1-88.eu-west-1.compute.internal</privateDnsName>
+                    <dnsName>ec2-54-194-252-215.eu-west-1.compute.amazonaws.com</dnsName>
+                    <reason/>
+                    <keyName>my_keypair</keyName>
+                    <amiLaunchIndex>0</amiLaunchIndex>
+                    <productCodes/>
+                    <instanceType>t2.micro</instanceType>
+                    <launchTime>2015-12-22T10:44:05.000Z</launchTime>
+                    <placement>
+                        <availabilityZone>eu-west-1c</availabilityZone>
+                        <groupName/>
+                        <tenancy>default</tenancy>
+                    </placement>
+                    <monitoring>
+                        <state>disabled</state>
+                    </monitoring>
+                    <subnetId>subnet-56f5f633</subnetId>
+                    <vpcId>vpc-11112222</vpcId>
+                    <privateIpAddress>192.168.1.88</privateIpAddress>
+                    <ipAddress>54.194.252.215</ipAddress>
+                    <sourceDestCheck>true</sourceDestCheck>
+                    <groupSet>
+                        <item>
+                            <groupId>sg-e4076980</groupId>
+                            <groupName>SecurityGroup1</groupName>
+                        </item>
+                    </groupSet>
+                    <architecture>x86_64</architecture>
+                    <rootDeviceType>ebs</rootDeviceType>
+                    <rootDeviceName>/dev/xvda</rootDeviceName>
+                    <blockDeviceMapping>
+                        <item>
+                            <deviceName>/dev/xvda</deviceName>
+                            <ebs>
+                                <volumeId>vol-1234567890abcdef0</volumeId>
+                                <status>attached</status>
+                                <attachTime>2015-12-22T10:44:09.000Z</attachTime>
+                                <deleteOnTermination>true</deleteOnTermination>
+                            </ebs>
+                        </item>
+                    </blockDeviceMapping>
+                    <virtualizationType>hvm</virtualizationType>
+                    <clientToken>xMcwG14507example</clientToken>
+                    <tagSet>
+                        <item>
+                            <key>Name</key>
+                            <value>Server_1</value>
+                        </item>
+                    </tagSet>
+                    <hypervisor>xen</hypervisor>
+                    <networkInterfaceSet>
+                        <item>
+                            <networkInterfaceId>eni-551ba033</networkInterfaceId>
+                            <subnetId>subnet-56f5f633</subnetId>
+                            <vpcId>vpc-11112222</vpcId>
+                            <description>Primary network interface</description>
+                            <ownerId>123456789012</ownerId>
+                            <status>in-use</status>
+                            <macAddress>02:dd:2c:5e:01:69</macAddress>
+                            <privateIpAddress>192.168.1.88</privateIpAddress>
+                            <privateDnsName>ip-192-168-1-88.eu-west-1.compute.internal</privateDnsName>
+                            <sourceDestCheck>true</sourceDestCheck>
+                            <groupSet>
+                                <item>
+                                    <groupId>sg-e4076980</groupId>
+                                    <groupName>SecurityGroup1</groupName>
+                                </item>
+                            </groupSet>
+                            <attachment>
+                                <attachmentId>eni-attach-39697adc</attachmentId>
+                                <deviceIndex>0</deviceIndex>
+                                <status>attached</status>
+                                <attachTime>2015-12-22T10:44:05.000Z</attachTime>
+                                <deleteOnTermination>true</deleteOnTermination>
+                            </attachment>
+                            <association>
+                                <publicIp>54.194.252.215</publicIp>
+                                <publicDnsName>ec2-54-194-252-215.eu-west-1.compute.amazonaws.com</publicDnsName>
+                                <ipOwnerId>amazon</ipOwnerId>
+                            </association>
+                            <privateIpAddressesSet>
+                                <item>
+                                    <privateIpAddress>192.168.1.88</privateIpAddress>
+                                    <privateDnsName>ip-192-168-1-88.eu-west-1.compute.internal</privateDnsName>
+                                    <primary>true</primary>
+                                    <association>
+                                    <publicIp>54.194.252.215</publicIp>
+                                    <publicDnsName>ec2-54-194-252-215.eu-west-1.compute.amazonaws.com</publicDnsName>
+                                    <ipOwnerId>amazon</ipOwnerId>
+                                    </association>
+                                </item>
+                            </privateIpAddressesSet>
+                            <ipv6AddressesSet>
+                               <item>
+                                   <ipv6Address>2001:db8:1234:1a2b::123</ipv6Address>
+                               </item>
+                           </ipv6AddressesSet>
+                        </item>
+                    </networkInterfaceSet>
+                    <ebsOptimized>false</ebsOptimized>
+                </item>
+            </instancesSet>
+        </item>
+    </reservationSet>
+</DescribeInstancesResponse>`))
+	if err != nil {
+		w.WriteHeader(500)
+	}
+}

--- a/internal/tests/inprocess-integration/test_test.go
+++ b/internal/tests/inprocess-integration/test_test.go
@@ -1,0 +1,67 @@
+package integration
+
+import (
+	"os"
+
+	. "gopkg.in/check.v1"
+
+	"gotest.tools/v3/assert"
+)
+
+type TestSuite struct {
+}
+
+var _ = Suite(&TestSuite{})
+
+func (s *TestSuite) SetUpTest(c *C) {
+}
+
+func (s *TestSuite) TearDownTest(c *C) {
+}
+
+func (s *TestSuite) TestFail(c *C) {
+	_, _, err := cmdTest(c, "-i", "{{ fail }}")
+	assert.ErrorContains(c, err, `template generation failed`)
+
+	_, _, err = cmdTest(c, "-i", "{{ fail `some message` }}")
+	assert.ErrorContains(c, err, `some message`)
+}
+
+func (s *TestSuite) TestRequired(c *C) {
+	os.Unsetenv("FOO")
+	_, _, err := cmdTest(c, "-i", `{{getenv "FOO" | required "FOO missing" }}`)
+	assert.ErrorContains(c, err, "FOO missing")
+
+	o, e, err := cmdWithEnv(c, []string{"-i", `{{getenv "FOO" | required "FOO missing" }}`},
+		map[string]string{"FOO": "bar"})
+	assertSuccess(c, o, e, err, "bar")
+
+	_, _, err = cmdWithStdin(c, []string{"-d", "in=stdin:///?type=application/yaml",
+		"-i", `{{ (ds "in").foo | required "foo should not be null" }}`},
+		`foo: null`)
+	assert.ErrorContains(c, err, "foo should not be null")
+
+	o, e, err = cmdWithStdin(c, []string{
+		"-d", "in=stdin:///?type=application/yaml",
+		"-i", `{{ (ds "in").foo | required }}`},
+		`foo: []`)
+	assertSuccess(c, o, e, err, "[]")
+
+	o, e, err = cmdWithStdin(c, []string{
+		"-d", "in=stdin:///?type=application/yaml",
+		"-i", `{{ (ds "in").foo | required }}`},
+		`foo: {}`)
+	assertSuccess(c, o, e, err, "map[]")
+
+	o, e, err = cmdWithStdin(c, []string{
+		"-d", "in=stdin:///?type=application/yaml",
+		"-i", `{{ (ds "in").foo | required }}`},
+		`foo: 0`)
+	assertSuccess(c, o, e, err, "0")
+
+	o, e, err = cmdWithStdin(c, []string{
+		"-d", "in=stdin:///?type=application/yaml",
+		"-i", `{{ (ds "in").foo | required }}`},
+		`foo: false`)
+	assertSuccess(c, o, e, err, "false")
+}

--- a/internal/tests/inprocess-integration/time_test.go
+++ b/internal/tests/inprocess-integration/time_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"os"
+	"time"
+	_ "time/tzdata"
+
+	. "gopkg.in/check.v1"
+)
+
+type TimeSuite struct{}
+
+var _ = Suite(&TimeSuite{})
+
+// convenience function to run a test in a specific timezone
+func runWithTZ(c *C, tz string, f func(c *C)) {
+	origTZ := os.Getenv("TZ")
+	defer func() { os.Setenv("TZ", origTZ) }()
+	os.Setenv("TZ", tz)
+
+	f(c)
+}
+
+func (s *TimeSuite) TestTime(c *C) {
+	f := `Mon Jan 02 15:04:05 MST 2006`
+	i := `Fri Feb 13 23:31:30 UTC 2009`
+	inOutTest(c, `{{ (time.Parse "`+f+`" "`+i+`").Format "2006-01-02 15 -0700" }}`,
+		"2009-02-13 23 +0000")
+
+	if !isWindows {
+
+		runWithTZ(c, "UTC", func(c *C) {
+			inOutTest(c, `{{ time.ZoneName }}`, "UTC")
+			inOutTest(c, `{{ time.ZoneOffset }}`, "0")
+		})
+
+		runWithTZ(c, "Africa/Luanda", func(c *C) {
+			inOutTest(c, `{{ (time.ParseLocal time.Kitchen "6:00AM").Format "15:04 MST" }}`,
+				"06:00 LMT")
+		})
+	}
+
+	zname, _ := time.Now().Zone()
+	inOutTest(c, `{{ time.ZoneName }}`, zname)
+
+	inOutTest(c, `{{ (time.Now).Format "2006-01-02 15 -0700" }}`,
+		time.Now().Format("2006-01-02 15 -0700"))
+
+	inOutTest(c, `{{ (time.ParseInLocation time.Kitchen "Africa/Luanda" "6:00AM").Format "15:04 MST" }}`,
+		"06:00 LMT")
+
+	inOutTest(c, `{{ (time.Unix 1234567890).UTC.Format "2006-01-02 15 -0700" }}`,
+		"2009-02-13 23 +0000")
+
+	inOutTest(c, `{{ (time.Unix "1234567890").UTC.Format "2006-01-02 15 -0700" }}`,
+		"2009-02-13 23 +0000")
+}

--- a/internal/tests/inprocess-integration/tmpl_test.go
+++ b/internal/tests/inprocess-integration/tmpl_test.go
@@ -1,0 +1,95 @@
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "gopkg.in/check.v1"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/fs"
+)
+
+type TmplSuite struct {
+	tmpDir *fs.Dir
+}
+
+var _ = Suite(&TmplSuite{})
+
+func (s *TmplSuite) SetUpTest(c *C) {
+	s.tmpDir = fs.NewDir(c, "gomplate-tmpltests",
+		fs.WithFiles(map[string]string{
+			"toyaml.tmpl": `{{ . | data.ToYAML }}{{"\n"}}`,
+			"services.yaml": `services:
+  - name: users
+    config:
+      replicas: 2
+  - name: products
+    config:
+      replicas: 18
+`,
+		}),
+	)
+}
+
+func (s *TmplSuite) TearDownTest(c *C) {
+	s.tmpDir.Remove()
+}
+
+func (s *TmplSuite) TestInline(c *C) {
+	inOutTest(c, `
+		{{- $nums := dict "first" 5 "second" 10 }}
+		{{- tpl "{{ add .first .second }}" $nums }}`,
+		"15")
+
+	inOutTest(c, `
+		{{- $nums := dict "first" 5 "second" 10 }}
+		{{- $othernums := dict "first" 18 "second" -8 }}
+		{{- tmpl.Inline "T" "{{ add .first .second }}" $nums }}
+		{{- template "T" $othernums }}`,
+		"1510")
+}
+
+func (s *TmplSuite) TestExec(c *C) {
+	_, _, err := cmdTest(c, "-i", `{{ tmpl.Exec "Nope" }}`)
+	assert.ErrorContains(c, err, `template "Nope" not defined`)
+
+	inOutTest(c, `{{define "T1"}}hello world{{end}}{{ tmpl.Exec "T1" | strings.ToUpper }}`, `HELLO WORLD`)
+
+	o, e, err := cmdWithStdin(c, []string{
+		"-c", "in=stdin:///in.json",
+		"-t", "toyaml=" + s.tmpDir.Join("toyaml.tmpl"),
+		"-i", `foo:
+{{ tmpl.Exec "toyaml" .in | strings.Indent 2 }}`},
+		`{"a":{"nested": "object"},"b":true}`)
+	assertSuccess(c, o, e, err, `foo:
+  a:
+    nested: object
+  b: true
+
+`)
+
+	outDir := s.tmpDir.Join("out")
+	err = os.MkdirAll(outDir, 0755)
+	if err != nil {
+		assert.NilError(c, err)
+	}
+	o, e, err = cmdWithDir(c, outDir,
+		"-d", "services="+s.tmpDir.Join("services.yaml"),
+		"-i", `{{- define "config" }}{{ .config | data.ToJSONPretty " " }}{{ end }}
+{{- range (ds "services").services -}}
+{{- $outPath := path.Join .name "config.json" }}
+{{- tmpl.Exec "config" . | file.Write $outPath }}
+{{- end -}}`)
+	assertSuccess(c, o, e, err, "")
+
+	out, err := ioutil.ReadFile(s.tmpDir.Join("out", "users", "config.json"))
+	assert.NilError(c, err)
+	assert.Equal(c, `{
+ "replicas": 2
+}`, string(out))
+	out, err = ioutil.ReadFile(s.tmpDir.Join("out", "products", "config.json"))
+	assert.NilError(c, err)
+	assert.Equal(c, `{
+ "replicas": 18
+}`, string(out))
+}

--- a/internal/tests/inprocess-integration/typeconv_test.go
+++ b/internal/tests/inprocess-integration/typeconv_test.go
@@ -1,0 +1,91 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type TypeconvSuite struct{}
+
+var _ = Suite(&TypeconvSuite{})
+
+const (
+	testYAML = "foo:\\n bar:\\n  baz: qux"
+	testJSON = `{"foo":{"bar":{"baz":"qux"}}}`
+	testCsv  = `lang,keywords
+C,32
+Go,25
+COBOL,357`
+	testTsv = `lang	keywords
+C	32
+Go	25
+COBOL	357`
+)
+
+func (s *TypeconvSuite) TestTypeconvFuncs(c *C) {
+	inOutTest(c, `{{ has ("`+testYAML+`" | yaml).foo.bar "baz"}}`,
+		"true")
+}
+
+func (s *TypeconvSuite) TestJSON(c *C) {
+	inOutTest(c, `{{ "`+testYAML+`" | yaml | toJSON }}`, testJSON)
+
+	inOutTest(c, `{{ `+"`"+testJSON+"`"+` | json | toJSONPretty "   " }}
+{{ toJSONPretty "" (`+"`"+testJSON+"`"+` | json) }}`,
+		`{
+   "foo": {
+      "bar": {
+         "baz": "qux"
+      }
+   }
+}
+{
+"foo": {
+"bar": {
+"baz": "qux"
+}
+}
+}`)
+}
+
+func (s *TypeconvSuite) TestJoin(c *C) {
+	inOutTest(c, `{{ $a := "[1, 2, 3]" | jsonArray }}{{ join $a "-" }}`,
+		"1-2-3")
+}
+
+func (s *TypeconvSuite) TestCSV(c *C) {
+	inOutTest(c, `{{ $c := `+"`"+testCsv+"`"+` | csv -}}
+{{ index (index $c 0) 1 }}`,
+		"keywords")
+
+	inOutTest(c, `{{ $c := `+"`"+testCsv+"`"+` | csvByRow -}}
+{{ range $c }}{{ .lang }} has {{ .keywords }} keywords.
+{{end}}`,
+		`C has 32 keywords.
+Go has 25 keywords.
+COBOL has 357 keywords.
+`)
+
+	inOutTest(c, `{{ $c := `+"`"+testTsv+"`"+` | csvByColumn "\t" -}}
+Languages are: {{ join $c.lang " and " }}`,
+		"Languages are: C and Go and COBOL")
+}
+
+func (s *TypeconvSuite) TestTOML(c *C) {
+	inOutTest(c, `{{ $t := `+"`"+`# comment
+foo = "bar"
+
+[baz]
+qux = "quux"`+"`"+` | toml -}}
+{{ $t.baz.qux }}`, "quux")
+
+	inOutTest(c, `{{ "foo:\n bar:\n  baz: qux" | yaml | toTOML }}`,
+		`[foo]
+  [foo.bar]
+    baz = "qux"
+`)
+}
+
+func (s *TypeconvSuite) TestDict(c *C) {
+	inOutTest(c, `{{ $d := dict true false "foo" "bar" }}{{ data.ToJSON $d }}`,
+		`{"foo":"bar","true":false}`)
+}


### PR DESCRIPTION
Now that the command can be launched fully programatically, there's a potential to simplify the integration tests by not launching the gomplate binary hundreds of times...

I've also found a few subtle bugs this way (race conditions! yikes!)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>