### PR TITLE
Fix race condition in signal handling

### DIFF
--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/hairyhenderson/gomplate/v3/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -55,4 +57,18 @@ func TestRunMain(t *testing.T) {
 	err = Main(ctx, []string{"-i", "hello"}, stdin, stdout, stderr)
 	assert.NoError(t, err)
 	assert.Equal(t, "hello", stdout.String())
+}
+
+func TestPostRunExec(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := &config.Config{
+		PostExecInput: strings.NewReader("hello world"),
+		PostExec:      []string{"cat"},
+	}
+	out := &bytes.Buffer{}
+	err := postRunExec(ctx, cfg, out, out)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", out.String())
 }

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,9 +1,12 @@
 package gomplate
 
 import (
+	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
@@ -53,4 +56,21 @@ func TestBuildCommand(t *testing.T) {
 		actual := append([]string{name}, args...)
 		assert.DeepEqual(t, d.expected, actual)
 	}
+}
+
+func TestRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stderr := &bytes.Buffer{}
+	p := &plugin{
+		ctx:     ctx,
+		timeout: 500 * time.Millisecond,
+		stderr:  stderr,
+		path:    "echo",
+	}
+	out, err := p.run("foo")
+	assert.NilError(t, err)
+	assert.Equal(t, "", stderr.String())
+	assert.Equal(t, "foo", strings.TrimSpace(out.(string)))
 }


### PR DESCRIPTION
Found some race conditions while working on #1050. This was due to a goroutine being launched without any way for it to stop (other than receiving a signal).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>