### PR TITLE
Support changing TZ env var in Zone functions

### DIFF
--- a/time/time.go
+++ b/time/time.go
@@ -3,16 +3,31 @@ package time
 
 import (
 	"time"
+
+	"github.com/hairyhenderson/gomplate/v3/env"
 )
 
 // ZoneName - a convenience function for determining the current timezone's name
 func ZoneName() string {
-	n, _ := time.Now().Zone()
+	n, _ := zone()
 	return n
 }
 
 // ZoneOffset - determine the current timezone's offset, in seconds east of UTC
 func ZoneOffset() int {
-	_, o := time.Now().Zone()
+	_, o := zone()
 	return o
+}
+
+func zone() (string, int) {
+	// re-read TZ env var in case it's changed since the process started.
+	// This may happen in certain rare instances when this is being called as a
+	// library, or in a test. It allows for a bit more flexibility too, as
+	// changing time.Local is prone to data races.
+	tz := env.Getenv("TZ", "Local")
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		loc = time.Local
+	}
+	return time.Now().In(loc).Zone()
 }


### PR DESCRIPTION
Ran into this during #1050 - it's sometimes necessary to be able to change `$TZ`, and this helps with that!

Signed-off-by: Dave Henderson <dhenderson@gmail.com>