### PR TITLE
Avoid outputting newline to console when using --input-dir

### DIFF
--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -108,10 +108,7 @@ func NewGomplateCmd() *cobra.Command {
 
 			// print a newline to stderr for convenience if the output is going
 			// to stdout, since otherwise the shell prompt may look wrong
-			// TODO: consider only doing this if stdout doesn't have a trailing
-			// newline already.
-			if len(cfg.OutputFiles) == 0 || (len(cfg.OutputFiles) == 1 && cfg.OutputFiles[0] == "-") &&
-				!cfg.ExecPipe && cfg.Stdout == os.Stdout {
+			if consoleOutput(cfg) {
 				fmt.Fprintf(cmd.ErrOrStderr(), "\n")
 			}
 
@@ -128,6 +125,14 @@ func NewGomplateCmd() *cobra.Command {
 		Args: optionalExecArgs,
 	}
 	return rootCmd
+}
+
+// TODO: consider only doing this if stdout doesn't have a trailing newline
+// already.
+func consoleOutput(cfg *config.Config) bool {
+	consoleOnly := len(cfg.OutputFiles) == 0 || (len(cfg.OutputFiles) == 1 && cfg.OutputFiles[0] == "-")
+	usingDirs := cfg.InputDir != "" && cfg.OutputDir != ""
+	return consoleOnly && !usingDirs && !cfg.ExecPipe && cfg.Stdout == os.Stdout
 }
 
 // InitFlags - initialize the various flags and help strings on the command.

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
@@ -461,7 +460,7 @@ func (c *Config) ApplyDefaults() {
 		c.OutputFiles = []string{"-"}
 
 		// --exec-pipe redirects standard out to the out pipe
-		c.Stdout = &iohelpers.NopCloser{Writer: pipe}
+		c.Stdout = pipe
 	} else {
 		c.PostExecInput = c.Stdin
 	}

--- a/internal/iohelpers/writers.go
+++ b/internal/iohelpers/writers.go
@@ -10,10 +10,10 @@ import (
 )
 
 type emptySkipper struct {
-	open func() (io.WriteCloser, error)
+	open func() (io.Writer, error)
 
 	// internal
-	w   io.WriteCloser
+	w   io.Writer
 	buf *bytes.Buffer
 	nw  bool
 }
@@ -21,7 +21,7 @@ type emptySkipper struct {
 // NewEmptySkipper creates an io.WriteCloser that will only start writing once a
 // non-whitespace byte has been encountered. The wrapped io.WriteCloser must be
 // provided by the `open` func.
-func NewEmptySkipper(open func() (io.WriteCloser, error)) io.WriteCloser {
+func NewEmptySkipper(open func() (io.Writer, error)) io.WriteCloser {
 	return &emptySkipper{
 		w:    nil,
 		buf:  &bytes.Buffer{},
@@ -58,8 +58,8 @@ func (f *emptySkipper) Write(p []byte) (n int, err error) {
 
 // Close - implements io.Closer
 func (f *emptySkipper) Close() error {
-	if f.w != nil {
-		return f.w.Close()
+	if wc, ok := f.w.(io.WriteCloser); ok {
+		return wc.Close()
 	}
 	return nil
 }

--- a/internal/iohelpers/writers_test.go
+++ b/internal/iohelpers/writers_test.go
@@ -40,7 +40,7 @@ func TestEmptySkipper(t *testing.T) {
 	for _, d := range testdata {
 		w := newBufferCloser(&bytes.Buffer{})
 		opened := false
-		f, ok := NewEmptySkipper(func() (io.WriteCloser, error) {
+		f, ok := NewEmptySkipper(func() (io.Writer, error) {
 			opened = true
 			return w, nil
 		}).(*emptySkipper)

--- a/internal/tests/integration/basic_test.go
+++ b/internal/tests/integration/basic_test.go
@@ -59,8 +59,9 @@ func (s *BasicSuite) TestWritesToStdoutWithOutFlag(c *C) {
 	result := icmd.RunCmd(icmd.Command(GomplateBin, "--out", "-"), func(cmd *icmd.Cmd) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
-	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
-	assert.Equal(c, "hello world\n", result.Combined())
+	assert.Equal(c, 0, result.ExitCode)
+	assert.Equal(c, "hello world", result.Stdout())
+	assert.Equal(c, "\n", result.Stderr())
 }
 
 func (s *BasicSuite) TestIgnoresStdinWithInFlag(c *C) {

--- a/internal/tests/integration/inputdir_test.go
+++ b/internal/tests/integration/inputdir_test.go
@@ -50,7 +50,9 @@ func (s *InputDirSuite) TestInputDir(c *C) {
 		"--output-dir", s.tmpDir.Join("out"),
 		"-d", "config="+s.tmpDir.Join("config.yml"),
 	)
-	result.Assert(c, icmd.Success)
+	assert.Equal(c, 0, result.ExitCode)
+	assert.Equal(c, "", result.Stderr())
+	assert.Equal(c, "", result.Stdout())
 
 	files, err := ioutil.ReadDir(s.tmpDir.Join("out"))
 	assert.NilError(c, err)

--- a/template.go
+++ b/template.go
@@ -235,19 +235,11 @@ func fileToTemplates(inFile, outFile string, mode os.FileMode, modeOverride bool
 	return tmpl, nil
 }
 
-func stdout(cfg *config.Config) io.WriteCloser {
-	wc, ok := cfg.Stdout.(io.WriteCloser)
-	if ok {
-		return wc
-	}
-	return &iohelpers.NopCloser{Writer: cfg.Stdout}
-}
-
-func openOutFile(cfg *config.Config, filename string, mode os.FileMode, modeOverride bool) (out io.WriteCloser, err error) {
+func openOutFile(cfg *config.Config, filename string, mode os.FileMode, modeOverride bool) (out io.Writer, err error) {
 	if cfg.SuppressEmpty {
-		out = iohelpers.NewEmptySkipper(func() (io.WriteCloser, error) {
+		out = iohelpers.NewEmptySkipper(func() (io.Writer, error) {
 			if filename == "-" {
-				return stdout(cfg), nil
+				return cfg.Stdout, nil
 			}
 			return createOutFile(filename, mode, modeOverride)
 		})
@@ -255,7 +247,7 @@ func openOutFile(cfg *config.Config, filename string, mode os.FileMode, modeOver
 	}
 
 	if filename == "-" {
-		return stdout(cfg), nil
+		return cfg.Stdout, nil
 	}
 	return createOutFile(filename, mode, modeOverride)
 }


### PR DESCRIPTION
Fixes #1057 

I've also simplified some of the internal API to stop wrapping io.Writers as io.WriteClosers when it's pretty much unnecessary. 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>