### PR TITLE
Fix --input-dir=. bug

### DIFF
--- a/gomplate.go
+++ b/gomplate.go
@@ -156,7 +156,7 @@ func (g *gomplate) runTemplates(ctx context.Context, cfg *config.Config) error {
 	Metrics.GatherDuration = time.Since(start)
 	if err != nil {
 		Metrics.Errors++
-		return err
+		return fmt.Errorf("failed to gather templates for rendering: %w", err)
 	}
 	Metrics.TemplatesGathered = len(tmpl)
 	start = time.Now()
@@ -167,7 +167,7 @@ func (g *gomplate) runTemplates(ctx context.Context, cfg *config.Config) error {
 		Metrics.RenderDuration[t.name] = time.Since(tstart)
 		if err != nil {
 			Metrics.Errors++
-			return err
+			return fmt.Errorf("failed to render template %s: %w", t.name, err)
 		}
 		Metrics.TemplatesProcessed++
 	}

--- a/internal/tests/integration/inputdir_test.go
+++ b/internal/tests/integration/inputdir_test.go
@@ -246,3 +246,27 @@ func (s *InputDirSuite) TestReportsFilenameWithBadInputFile(c *C) {
 		Err:      "bad.tmpl:1: unexpected {{end}}",
 	})
 }
+
+func (s *InputDirSuite) TestInputDirCwd(c *C) {
+	result := icmd.RunCmd(icmd.Command(GomplateBin,
+		"--input-dir", ".",
+		"--include", "*.txt",
+		"--output-map", `{{ .in | strings.ReplaceAll ".txt" ".out" }}`,
+		"-d", "config="+s.tmpDir.Join("config.yml"),
+	), func(c *icmd.Cmd) {
+		c.Dir = s.tmpDir.Path()
+	})
+	result.Assert(c, icmd.Success)
+
+	content, err := ioutil.ReadFile(s.tmpDir.Join("in", "eins.out"))
+	assert.NilError(c, err)
+	assert.Equal(c, "eins", string(content))
+
+	content, err = ioutil.ReadFile(s.tmpDir.Join("in", "inner", "deux.out"))
+	assert.NilError(c, err)
+	assert.Equal(c, "deux", string(content))
+
+	content, err = ioutil.ReadFile(s.tmpDir.Join("in", "vier.out"))
+	assert.NilError(c, err)
+	assert.Equal(c, `deux * deux`, string(content))
+}


### PR DESCRIPTION
When using `--input-dir .`, gomplate fails with an error `lstat <some file>: file does not exist`. I'm still not entirely sure why this isn't working, but I believe it's a bug in `xignore` (I'll log a bug upstream at some point soon). The workaround is fairly straightforward though - just feed the absolute path instead for that specific case.

This came up in https://github.com/hairyhenderson/gomplate/issues/1081#issuecomment-787548173.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>