### PR TITLE
Stop printing newline on stderr when outputting to stdout

### DIFF
--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -106,12 +105,6 @@ func NewGomplateCmd() *cobra.Command {
 			cmd.SilenceErrors = true
 			cmd.SilenceUsage = true
 
-			// print a newline to stderr for convenience if the output is going
-			// to stdout, since otherwise the shell prompt may look wrong
-			if consoleOutput(cfg) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "\n")
-			}
-
 			log.Debug().Int("templatesRendered", gomplate.Metrics.TemplatesProcessed).
 				Int("errors", gomplate.Metrics.Errors).
 				Dur("duration", gomplate.Metrics.TotalRenderDuration).
@@ -125,14 +118,6 @@ func NewGomplateCmd() *cobra.Command {
 		Args: optionalExecArgs,
 	}
 	return rootCmd
-}
-
-// TODO: consider only doing this if stdout doesn't have a trailing newline
-// already.
-func consoleOutput(cfg *config.Config) bool {
-	consoleOnly := len(cfg.OutputFiles) == 0 || (len(cfg.OutputFiles) == 1 && cfg.OutputFiles[0] == "-")
-	usingDirs := cfg.InputDir != "" && cfg.OutputDir != ""
-	return consoleOnly && !usingDirs && !cfg.ExecPipe && cfg.Stdout == os.Stdout
 }
 
 // InitFlags - initialize the various flags and help strings on the command.

--- a/internal/tests/integration/basic_test.go
+++ b/internal/tests/integration/basic_test.go
@@ -45,7 +45,7 @@ func (s *BasicSuite) TestTakesStdinByDefault(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
-	assert.Equal(c, "hello world\n", result.Combined())
+	assert.Equal(c, "hello world", result.Combined())
 }
 
 func (s *BasicSuite) TestTakesStdinWithFileFlag(c *C) {
@@ -53,15 +53,14 @@ func (s *BasicSuite) TestTakesStdinWithFileFlag(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hello world"})
-	assert.Equal(c, "hello world\n", result.Combined())
+	assert.Equal(c, "hello world", result.Combined())
 }
 func (s *BasicSuite) TestWritesToStdoutWithOutFlag(c *C) {
 	result := icmd.RunCmd(icmd.Command(GomplateBin, "--out", "-"), func(cmd *icmd.Cmd) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	assert.Equal(c, 0, result.ExitCode)
-	assert.Equal(c, "hello world", result.Stdout())
-	assert.Equal(c, "\n", result.Stderr())
+	assert.Equal(c, "hello world", result.Combined())
 }
 
 func (s *BasicSuite) TestIgnoresStdinWithInFlag(c *C) {
@@ -69,7 +68,7 @@ func (s *BasicSuite) TestIgnoresStdinWithInFlag(c *C) {
 		cmd.Stdin = bytes.NewBufferString("hello world")
 	})
 	result.Assert(c, icmd.Expected{ExitCode: 0, Out: "hi"})
-	assert.Equal(c, "hi\n", result.Combined())
+	assert.Equal(c, "hi", result.Combined())
 }
 
 func (s *BasicSuite) TestErrorsWithInputOutputImbalance(c *C) {


### PR DESCRIPTION
Fixes #1075 and #1074 by removing the feature entirely.

Note that this will change the perceived output when gomplate is used interactively with a template that does not end in a newline. For example:

in bash:
```console
$ gomplate -i "hello world"
hello world$ 
```

in zsh:
```console
$ gomplate -i "hello world"
hello world%
$ 
```

Note that this does not affect the stdout stream, which was never modified. Only the stderr stream was modified (and is now no longer modified).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>