### PR TITLE
Stop emitting ANSI colour codes on Windows in unsupported terminals

### DIFF
--- a/internal/cmd/logger.go
+++ b/internal/cmd/logger.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	stdlog "log"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/hairyhenderson/gomplate/v3/env"
@@ -50,7 +51,7 @@ func createLogger(format string, out io.Writer) zerolog.Logger {
 	switch format {
 	case "console":
 		useColour := false
-		if f, ok := out.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		if f, ok := out.(*os.File); ok && term.IsTerminal(int(f.Fd())) && runtime.GOOS != "windows" {
 			useColour = true
 		}
 		l = l.Output(zerolog.ConsoleWriter{


### PR DESCRIPTION
Part-fix for #1095

Signed-off-by: Dave Henderson <dhenderson@gmail.com>