### PR TITLE
Fix data race in random functions

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -11,10 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Rnd -
-//
-//nolint:gosec
-var Rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // Default set, matches "[a-zA-Z0-9_.-]"
 const defaultSet = "-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
@@ -49,7 +48,8 @@ func StringBounds(count int, lower, upper rune) (r string, err error) {
 func rndString(count int, chars []rune) (string, error) {
 	s := make([]rune, count)
 	for i := range s {
-		s[i] = chars[Rnd.Intn(len(chars))]
+		//nolint:gosec
+		s[i] = chars[rand.Intn(len(chars))]
 	}
 	return string(s), nil
 }
@@ -87,7 +87,9 @@ func Item(items []interface{}) (interface{}, error) {
 	if len(items) == 1 {
 		return items[0], nil
 	}
-	n := Rnd.Intn(len(items))
+
+	//nolint:gosec
+	n := rand.Intn(len(items))
 	return items[n], nil
 }
 
@@ -102,10 +104,13 @@ func Number(min, max int64) (int64, error) {
 	if max-min >= (math.MaxInt64 >> 1) {
 		return 0, errors.Errorf("spread between min and max too high - must not be greater than 63-bit maximum (%d - %d = %d)", max, min, max-min)
 	}
-	return Rnd.Int63n(max-min+1) + min, nil
+
+	//nolint:gosec
+	return rand.Int63n(max-min+1) + min, nil
 }
 
 // Float - For now this is really just a wrapper around `rand.Float64`
 func Float(min, max float64) (float64, error) {
-	return min + Rnd.Float64()*(max-min), nil
+	//nolint:gosec
+	return min + rand.Float64()*(max-min), nil
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -2,6 +2,7 @@ package random
 
 import (
 	"math"
+	"strconv"
 	"testing"
 	"unicode/utf8"
 
@@ -9,26 +10,36 @@ import (
 )
 
 func TestMatchChars(t *testing.T) {
-	in := "[a-g]"
-	expected := []rune("abcdefg")
-	out, err := matchChars(in)
-	assert.NoError(t, err)
-	assert.EqualValues(t, expected, out)
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
 
-	in = "[a-zA-Z0-9_.-]"
-	expected = []rune(defaultSet)
-	out, err = matchChars(in)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, out)
+	t.Parallel()
 
-	in = "[[:alpha:]]"
-	expected = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
-	out, err = matchChars(in)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, out)
+	testdata := []struct {
+		in       string
+		expected string
+	}{
+		{"[a-g]", "abcdefg"},
+		{"[a-zA-Z0-9_.-]", defaultSet},
+		{"[[:alpha:]]", "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"},
+	}
+
+	for i, d := range testdata {
+		d := d
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			out, err := matchChars(d.in)
+			assert.NoError(t, err)
+			assert.EqualValues(t, d.expected, out)
+		})
+	}
 }
 
 func TestStringRE(t *testing.T) {
+	t.Parallel()
+
 	r, err := StringRE(15, "[\\p{Yi}[:alnum:]]")
 	assert.NoError(t, err)
 	assert.Equal(t, 15, utf8.RuneCountInString(r))
@@ -38,6 +49,8 @@ func TestStringRE(t *testing.T) {
 }
 
 func TestStringBounds(t *testing.T) {
+	t.Parallel()
+
 	_, err := StringBounds(15, 0, 19)
 	assert.Error(t, err)
 
@@ -64,6 +77,8 @@ func TestStringBounds(t *testing.T) {
 }
 
 func TestItem(t *testing.T) {
+	t.Parallel()
+
 	_, err := Item(nil)
 	assert.Error(t, err)
 
@@ -83,6 +98,8 @@ func TestItem(t *testing.T) {
 }
 
 func TestNumber(t *testing.T) {
+	t.Parallel()
+
 	_, err := Number(0, -1)
 	assert.Error(t, err)
 	_, err = Number(0, math.MaxInt64)
@@ -108,6 +125,8 @@ func TestNumber(t *testing.T) {
 }
 
 func TestFloat(t *testing.T) {
+	t.Parallel()
+
 	testdata := []struct {
 		min, max, expected float64
 		delta              float64


### PR DESCRIPTION
Turns out only the `rand.*` functions are safe for concurrent use...

Signed-off-by: Dave Henderson <dhenderson@gmail.com>