### PR TITLE
Add make target for zip files containing the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ clean:
 
 build-x: $(patsubst %,$(PREFIX)/bin/$(PKG_NAME)_%,$(platforms))
 
+$(PREFIX)/bin/%.zip: $(PREFIX)/bin/%
+	@zip -j $@ $^
+
+$(PREFIX)/bin/$(PKG_NAME)_windows-%.zip: $(PREFIX)/bin/$(PKG_NAME)_windows-%.exe
+	@zip -j $@ $^
+
 compress-all: $(patsubst %,$(PREFIX)/bin/$(PKG_NAME)_%,$(compressed-platforms))
 
 UPX_VERSION := $(shell upx --version | head -n1 | cut -f2 -d\ )


### PR DESCRIPTION
Fixes #1122 

Adds the ability to build a zip file containing just the gomplate binary at the root.

I'll add this to my (still internal) automated release process and in the next gomplate release a `gomplate_windows-amd64.zip` archive will be made available.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>