### PR TITLE
Typo in alias > simple quotes required

### DIFF
--- a/docs/content/installing.md
+++ b/docs/content/installing.md
@@ -59,7 +59,7 @@ It can be pretty awkward to always type `docker run hairyhenderson/gomplate`,
 so this can be made simpler with a shell alias:
 
 ```console
-$ alias gomplate=docker run hairyhenderson/gomplate
+$ alias gomplate='docker run hairyhenderson/gomplate'
 $ gomplate --version
 gomplate version 3.8.0
 ```


### PR DESCRIPTION
# Context

The current alias command : 

```
alias gomplate=docker run hairyhenderson/gomplate
```

leads to the following error message : 

```
-bash: alias: run: not found
-bash: alias: hairyhenderson/gomplate: not found
```

# Fix

This one does the job : 

```
alias gomplate='docker run hairyhenderson/gomplate'
````