### PR TITLE
Add NotBefore/NotAfter to test cert so integration tests pass

### DIFF
--- a/internal/tests/integration/datasources_vault_ec2_test.go
+++ b/internal/tests/integration/datasources_vault_ec2_test.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package integration
 
@@ -44,9 +45,11 @@ func TestDatasources_VaultEc2(t *testing.T) {
 
 	v.vc.Logical().Write("secret/foo", map[string]interface{}{"value": "bar"})
 	defer v.vc.Logical().Delete("secret/foo")
+
 	err := v.vc.Sys().EnableAuth("aws", "aws", "")
 	require.NoError(t, err)
 	defer v.vc.Sys().DisableAuth("aws")
+
 	_, err = v.vc.Logical().Write("auth/aws/config/client", map[string]interface{}{
 		"secret_key": "secret", "access_key": "access",
 		"endpoint":     srv.URL + "/ec2",

--- a/internal/tests/integration/test_ec2_utils.go
+++ b/internal/tests/integration/test_ec2_utils.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/big"
 	"net/http"
+	"time"
 
 	"github.com/fullsailor/pkcs7"
 )
@@ -56,6 +57,8 @@ func certificateGenerate() (priv *rsa.PrivateKey, derBytes []byte, err error) {
 		Subject: pkix.Name{
 			Organization: []string{"Test"},
 		},
+		NotBefore: time.Now().Add(-24 * time.Hour),
+		NotAfter:  time.Now().Add(365 * 24 * time.Hour),
 	}
 
 	derBytes, err = x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)


### PR DESCRIPTION
Some of the changes in Go 1.17 were to the [`crypto/x509`](https://golang.org/doc/go1.17#crypto/x509) package, and I suspect the date is now verified more carefully.

This should fix failures like [this one](https://github.com/hairyhenderson/gomplate/runs/3508960837?check_suite_focus=true)

Signed-off-by: Dave Henderson <dhenderson@gmail.com>