### PR TITLE
crypto.RSAGenerateKey - Enforce key length of at least 2048 bits

### DIFF
--- a/crypto/rsa.go
+++ b/crypto/rsa.go
@@ -62,6 +62,11 @@ func RSADecrypt(key string, in []byte) ([]byte, error) {
 
 // RSAGenerateKey -
 func RSAGenerateKey(bits int) ([]byte, error) {
+	// Protect against CWE-326: Inadequate Encryption Strength
+	// https://cwe.mitre.org/data/definitions/326.html
+	if bits < 2048 {
+		return nil, fmt.Errorf("RSA key size must be at least 2048 bits")
+	}
 	priv, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate RSA private key: %w", err)

--- a/crypto/rsa_test.go
+++ b/crypto/rsa_test.go
@@ -84,7 +84,10 @@ func TestRSAGenerateKey(t *testing.T) {
 	_, err := RSAGenerateKey(0)
 	assert.Error(t, err)
 
-	key, err := RSAGenerateKey(12)
+	_, err = RSAGenerateKey(12)
+	assert.Error(t, err)
+
+	key, err := RSAGenerateKey(2048)
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(key),
 		"-----BEGIN RSA PRIVATE KEY-----"))

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -169,13 +169,16 @@ funcs:
       Default key length is 4096 bits, which should be safe enough for most
       uses, but can be overridden with the optional `bits` parameter.
 
+      In order to protect against [CWE-326](https://cwe.mitre.org/data/definitions/326.html),
+      keys shorter than `2048` bits may not be generated.
+
       The output is a string, suitable for use with the other `crypto.RSA*`
       functions.
     pipeline: true
     arguments:
       - name: bits
         required: false
-        description: bit size of the generated key. Defaults to `4096`
+        description: Length in bits of the generated key. Must be at least `2048`. Defaults to `4096`
     examples:
       - |
         $ gomplate -i '{{ crypto.RSAGenerateKey }}'

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -237,6 +237,9 @@ form.
 Default key length is 4096 bits, which should be safe enough for most
 uses, but can be overridden with the optional `bits` parameter.
 
+In order to protect against [CWE-326](https://cwe.mitre.org/data/definitions/326.html),
+keys shorter than `2048` bits may not be generated.
+
 The output is a string, suitable for use with the other `crypto.RSA*`
 functions.
 
@@ -253,7 +256,7 @@ bits | crypto.RSAGenerateKey
 
 | name | description |
 |------|-------------|
-| `bits` | _(optional)_ bit size of the generated key. Defaults to `4096` |
+| `bits` | _(optional)_ Length in bits of the generated key. Must be at least `2048`. Defaults to `4096` |
 
 ### Examples
 

--- a/funcs/crypto_test.go
+++ b/funcs/crypto_test.go
@@ -107,7 +107,7 @@ func TestRSAGenerateKey(t *testing.T) {
 	_, err = c.RSAGenerateKey(0, "foo", true)
 	assert.Error(t, err)
 
-	key, err := c.RSAGenerateKey(12)
+	key, err := c.RSAGenerateKey(2048)
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(key,
 		"-----BEGIN RSA PRIVATE KEY-----"))


### PR DESCRIPTION
Enhances the security of the `crypto.RSAGenerateKey` function to require at least 2048 bits. See https://cwe.mitre.org/data/definitions/326.html for details

Signed-off-by: Dave Henderson <dhenderson@gmail.com>