### PR TITLE
conv.ToInt: return -1 instead of overflowing on 32-bit systems

### DIFF
--- a/conv/conv.go
+++ b/conv/conv.go
@@ -3,6 +3,7 @@ package conv
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -211,7 +212,15 @@ func ToInt64(v interface{}) int64 {
 
 // ToInt -
 func ToInt(in interface{}) int {
-	return int(ToInt64(in))
+	// Protect against CWE-190 and CWE-681
+	// https://cwe.mitre.org/data/definitions/190.html
+	// https://cwe.mitre.org/data/definitions/681.html
+	if i := ToInt64(in); i <= math.MaxInt || i >= math.MinInt {
+		return int(i)
+	}
+
+	// we're probably on a 32-bit system, so we can't represent this number
+	return -1
 }
 
 // ToInt64s -

--- a/docs-src/content/functions/conv.yml
+++ b/docs-src/content/functions/conv.yml
@@ -304,6 +304,11 @@ funcs:
       platforms, but is useful when input to another function must be provided
       as an `int`.
 
+      On 32-bit systems, given a number that is too large to fit in an `int`,
+      the result is `-1`. This is done to protect against
+      [CWE-190](https://cwe.mitre.org/data/definitions/190.html) and
+      [CWE-681](https://cwe.mitre.org/data/definitions/681.html).
+
       See also [`conv.ToInt64`](#conv-toint64).
     arguments:
       - name: in

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -472,6 +472,11 @@ on platform). This is similar to [`conv.ToInt64`](#conv-toint64) on 64-bit
 platforms, but is useful when input to another function must be provided
 as an `int`.
 
+On 32-bit systems, given a number that is too large to fit in an `int`,
+the result is `-1`. This is done to protect against
+[CWE-190](https://cwe.mitre.org/data/definitions/190.html) and
+[CWE-681](https://cwe.mitre.org/data/definitions/681.html).
+
 See also [`conv.ToInt64`](#conv-toint64).
 
 ### Usage


### PR DESCRIPTION
Protecting against [CWE-190](https://cwe.mitre.org/data/definitions/190.html) and [CWE-681](https://cwe.mitre.org/data/definitions/681.html).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>