### PR TITLE
Support git repos with default branches other than "master"

### DIFF
--- a/data/datasource_git_test.go
+++ b/data/datasource_git_test.go
@@ -229,10 +229,18 @@ func setupGitRepo(t *testing.T) billy.Filesystem {
 	r, err := git.Init(s, repo)
 	assert.NilError(t, err)
 
+	// default to main
+	h := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.ReferenceName("refs/heads/main"))
+	err = s.SetReference(h)
+	assert.NilError(t, err)
+
 	// config needs to be created after setting up a "normal" fs repo
 	// this is possibly a bug in git-go?
 	c, err := r.Config()
 	assert.NilError(t, err)
+
+	c.Init.DefaultBranch = "main"
+
 	s.SetConfig(c)
 	assert.NilError(t, err)
 
@@ -331,12 +339,12 @@ func TestOpenFileRepo(t *testing.T) {
 	b, _ := ioutil.ReadAll(f)
 	assert.Equal(t, "hello world", string(b))
 
-	_, repo, err := g.clone(ctx, mustParseURL("git+file:///repo#master"), 0)
+	_, repo, err := g.clone(ctx, mustParseURL("git+file:///repo#main"), 0)
 	assert.NilError(t, err)
 
-	ref, err := repo.Reference(plumbing.NewBranchReferenceName("master"), true)
+	ref, err := repo.Reference(plumbing.NewBranchReferenceName("main"), true)
 	assert.NilError(t, err)
-	assert.Equal(t, "refs/heads/master", ref.Name().String())
+	assert.Equal(t, "refs/heads/main", ref.Name().String())
 
 	_, repo, err = g.clone(ctx, mustParseURL("git+file:///repo#refs/tags/v1"), 0)
 	assert.NilError(t, err)

--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -475,7 +475,7 @@ The _scheme_, _authority_ (with _userinfo_), _path_, and _fragment_ are used, an
 - the _authority_ component points to the remote git server hostname (and optional port, if applicable). The _userinfo_ subcomponent can be used for authenticated datasources like `git+https` and `git+ssh`.
 - the _path_ component is a composite of the path to the repository, and the path to the file or directory being referenced within. The `//` sequence (double forward-slash) is used to separate the repository from the path. If no `//` is present in the URL, the datasource will point to the root directory of the repository.
 - the _fragment_ component can be used to specify which branch or tag to reference. By default, the repository's default branch will be chosen.
-  - branches can be referenced by short name or by the long form. Valid fragments are `#master`, `#develop`, `#refs/heads/mybranch`, etc...
+  - branches can be referenced by short name or by the long form. Valid fragments are `#main`, `#master`, `#develop`, `#refs/heads/mybranch`, etc...
   - tags must use the long form prefixed by `refs/tags/`, i.e. `#refs/tags/v1` for the `v1` tag
 
 ### Authentication
@@ -701,7 +701,7 @@ This table describes the currently-supported authentication mechanisms and how t
 
 _**Note:**_ The secret values listed in the above table can either be set in environment variables or provided in files. This can increase security when using [Docker Swarm Secrets](https://docs.docker.com/engine/swarm/secrets/), for example. To use files, specify the filename by appending `_FILE` to the environment variable, (i.e. `VAULT_USER_ID_FILE`). If the non-file variable is set, this will override any `_FILE` variable and the secret file will be ignored.
 
-### Vault Permissions 
+### Vault Permissions
 
 The correct capabilities must be allowed for the [authenticated](#vault-authentication) credentials. See the [Vault documentation](https://www.vaultproject.io/docs/concepts/policies.html#capabilities) for full details.
 

--- a/internal/tests/integration/datasources_git_test.go
+++ b/internal/tests/integration/datasources_git_test.go
@@ -117,6 +117,13 @@ func TestDatasources_GitHTTPDatasource(t *testing.T) {
 		"-i", `{{ .short.glossary.title}}`,
 	).run()
 	assertSuccess(t, o, e, err, "example glossary")
+
+	// and one with a default branch of 'main'
+	o, e, err = cmd(t,
+		"-c", "data=git+https://github.com/hairyhenderson/git-fixtures.git//small_test.json",
+		"-i", `{{ .data.foo}}`,
+	).run()
+	assertSuccess(t, o, e, err, "bar")
 }
 
 func TestDatasources_GitSSHDatasource(t *testing.T) {


### PR DESCRIPTION
Fixes #1049

This is a workaround for https://github.com/go-git/go-git/issues/249, as suggested in https://github.com/go-git/go-git/issues/249#issuecomment-772354474.

Ideally `go-git` would do this for me, but for now this is the best option.

I've altered the tests so that one of the test repos has a default branch of `main`, to verify the behaviour.

If for some reason the remote's branch can't be determined, the error will be logged but the datasource will continue to defer to `go-git`'s default.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>