### PR TITLE
Update integration test to work properly with Consul v.11+

### DIFF
--- a/internal/tests/integration/integration_test.go
+++ b/internal/tests/integration/integration_test.go
@@ -106,7 +106,7 @@ func waitForURL(t *testing.T, url string) error {
 			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("URL %s never responded with 200", url)
 }
 
 type vaultClient struct {


### PR DESCRIPTION
Not sure why I didn't see these test errors in CI, but I'm seeing them locally.

```
* Unexpected response code: 410 (Endpoint /v1/acl/create for the legacy ACL system was removed in Consul 1.11.)
```

Signed-off-by: Dave Henderson <dhenderson@gmail.com>