### PR TITLE
Add example of how to use Time.IsDST

### DIFF
--- a/docs-src/content/functions/time.yml
+++ b/docs-src/content/functions/time.yml
@@ -92,6 +92,16 @@ funcs:
         ```
 
         _(notice how the TZ adjusted for daylight savings!)_
+      - |
+        Usage with [`IsDST`](https://golang.org/pkg/time/#Time.IsDST):
+        ```console
+        $ gomplate -i '{{ $t := time.Now }}At the tone, the time will be {{ ($t.Round (time.Minute 1)).Add (time.Minute 1) }}.
+          It is{{ if not $t.IsDST }} not{{ end }} daylight savings time.
+          ... ... BEEP'
+        At the tone, the time will be 2022-02-10 09:01:00 -0500 EST.
+        It is not daylight savings time.
+        ... ... BEEP
+        ```
   - name: time.Parse
     description: |
       Parses a timestamp defined by the given layout. This wraps [`time.Parse`](https://golang.org/pkg/time/#Parse).

--- a/docs/content/functions/time.md
+++ b/docs/content/functions/time.md
@@ -103,6 +103,15 @@ Tue Nov 14 09:57:02 EST 2017
 ```
 
 _(notice how the TZ adjusted for daylight savings!)_
+Usage with [`IsDST`](https://golang.org/pkg/time/#Time.IsDST):
+```console
+$ gomplate -i '{{ $t := time.Now }}At the tone, the time will be {{ ($t.Round (time.Minute 1)).Add (time.Minute 1) }}.
+  It is{{ if not $t.IsDST }} not{{ end }} daylight savings time.
+  ... ... BEEP'
+At the tone, the time will be 2022-02-10 09:01:00 -0500 EST.
+It is not daylight savings time.
+... ... BEEP
+```
 
 ## `time.Parse`
 


### PR DESCRIPTION
I was going to add a separate `time.IsDST` function, but it's just as easy to call `time.Now.IsDST`. Adding an example to show how to use this.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>