### PR TITLE
New crypto.SHA*Bytes functions

### DIFF
--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -341,6 +341,32 @@ funcs:
       - |
         $ gomplate -i '{{ crypto.SHA512 "bar" }}'
         cc06808cbbee0510331aa97974132e8dc296aeb795be229d064bae784b0a87a5cf4281d82e8c99271b75db2148f08a026c1a60ed9cabdb8cac6d24242dac4063
+  - rawName: '`crypto.SHA1Bytes`, `crypto.SHA224Bytes`, `crypto.SHA256Bytes`, `crypto.SHA384Bytes`, `crypto.SHA512Bytes`, `crypto.SHA512_224Bytes`, `crypto.SHA512_256Bytes`'
+    description: |
+      Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
+
+      These functions output the raw binary result, suitable for piping to other functions.
+
+      _Warning: SHA-1 is cryptographically broken and should not be used for secure applications._
+    pipeline: false
+    rawUsage: |
+      ```
+      crypto.SHA1Bytes input
+      crypto.SHA224Bytes input
+      crypto.SHA256Bytes input
+      crypto.SHA384Bytes input
+      crypto.SHA512Bytes input
+      crypto.SHA512_224Bytes input
+      crypto.SHA512_256Bytes input
+      ```
+    arguments:
+      - name: input
+        required: true
+        description: the data to hash - can be binary data or text
+    examples:
+      - |
+        $ gomplate -i '{{ crypto.SHA256Bytes "foo" | base64.Encode }}'
+        LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=
   - name: crypto.WPAPSK
     description: |
       This is really an alias to [`crypto.PBKDF2`](#crypto.PBKDF2) with the

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -488,6 +488,38 @@ $ gomplate -i '{{ crypto.SHA512 "bar" }}'
 cc06808cbbee0510331aa97974132e8dc296aeb795be229d064bae784b0a87a5cf4281d82e8c99271b75db2148f08a026c1a60ed9cabdb8cac6d24242dac4063
 ```
 
+## `crypto.SHA1Bytes`, `crypto.SHA224Bytes`, `crypto.SHA256Bytes`, `crypto.SHA384Bytes`, `crypto.SHA512Bytes`, `crypto.SHA512_224Bytes`, `crypto.SHA512_256Bytes`
+
+Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
+
+These functions output the raw binary result, suitable for piping to other functions.
+
+_Warning: SHA-1 is cryptographically broken and should not be used for secure applications._
+
+### Usage
+```
+crypto.SHA1Bytes input
+crypto.SHA224Bytes input
+crypto.SHA256Bytes input
+crypto.SHA384Bytes input
+crypto.SHA512Bytes input
+crypto.SHA512_224Bytes input
+crypto.SHA512_256Bytes input
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `input` | _(required)_ the data to hash - can be binary data or text |
+
+### Examples
+
+```console
+$ gomplate -i '{{ crypto.SHA256Bytes "foo" | base64.Encode }}'
+LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=
+```
+
 ## `crypto.WPAPSK`
 
 This is really an alias to [`crypto.PBKDF2`](#crypto.PBKDF2) with the

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -73,55 +73,107 @@ func (f CryptoFuncs) WPAPSK(ssid, password interface{}) (string, error) {
 }
 
 // SHA1 - Note: SHA-1 is cryptographically broken and should not be used for secure applications.
-func (CryptoFuncs) SHA1(input interface{}) string {
-	in := toBytes(input)
+func (f CryptoFuncs) SHA1(input interface{}) string {
 	// nolint: gosec
-	out := sha1.Sum(in)
+	out, _ := f.SHA1Bytes(input)
 	return fmt.Sprintf("%02x", out)
 }
 
 // SHA224 -
-func (CryptoFuncs) SHA224(input interface{}) string {
-	in := toBytes(input)
-	out := sha256.Sum224(in)
+func (f CryptoFuncs) SHA224(input interface{}) string {
+	out, _ := f.SHA224Bytes(input)
 	return fmt.Sprintf("%02x", out)
 }
 
 // SHA256 -
-func (CryptoFuncs) SHA256(input interface{}) string {
-	in := toBytes(input)
-	out := sha256.Sum256(in)
+func (f CryptoFuncs) SHA256(input interface{}) string {
+	out, _ := f.SHA256Bytes(input)
 	return fmt.Sprintf("%02x", out)
 }
 
 // SHA384 -
-func (CryptoFuncs) SHA384(input interface{}) string {
-	in := toBytes(input)
-	out := sha512.Sum384(in)
+func (f CryptoFuncs) SHA384(input interface{}) string {
+	out, _ := f.SHA384Bytes(input)
 	return fmt.Sprintf("%02x", out)
 }
 
 // SHA512 -
-func (CryptoFuncs) SHA512(input interface{}) string {
-	in := toBytes(input)
-	out := sha512.Sum512(in)
+func (f CryptoFuncs) SHA512(input interface{}) string {
+	out, _ := f.SHA512Bytes(input)
 	return fmt.Sprintf("%02x", out)
 }
 
 // SHA512_224 -
 //nolint: revive,stylecheck
-func (CryptoFuncs) SHA512_224(input interface{}) string {
-	in := toBytes(input)
-	out := sha512.Sum512_224(in)
+func (f CryptoFuncs) SHA512_224(input interface{}) string {
+	out, _ := f.SHA512_224Bytes(input)
 	return fmt.Sprintf("%02x", out)
 }
 
 // SHA512_256 -
 //nolint: revive,stylecheck
-func (CryptoFuncs) SHA512_256(input interface{}) string {
-	in := toBytes(input)
-	out := sha512.Sum512_256(in)
+func (f CryptoFuncs) SHA512_256(input interface{}) string {
+	out, _ := f.SHA512_256Bytes(input)
 	return fmt.Sprintf("%02x", out)
+}
+
+// SHA1 - Note: SHA-1 is cryptographically broken and should not be used for secure applications.
+func (CryptoFuncs) SHA1Bytes(input interface{}) ([]byte, error) {
+	//nolint:gosec
+	b := sha1.Sum(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
+}
+
+// SHA224 -
+func (CryptoFuncs) SHA224Bytes(input interface{}) ([]byte, error) {
+	b := sha256.Sum224(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
+}
+
+// SHA256 -
+func (CryptoFuncs) SHA256Bytes(input interface{}) ([]byte, error) {
+	b := sha256.Sum256(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
+}
+
+// SHA384 -
+func (CryptoFuncs) SHA384Bytes(input interface{}) ([]byte, error) {
+	b := sha512.Sum384(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
+}
+
+// SHA512 -
+func (CryptoFuncs) SHA512Bytes(input interface{}) ([]byte, error) {
+	b := sha512.Sum512(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
+}
+
+// SHA512_224 -
+//nolint: revive,stylecheck
+func (CryptoFuncs) SHA512_224Bytes(input interface{}) ([]byte, error) {
+	b := sha512.Sum512_224(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
+}
+
+// SHA512_256 -
+//nolint: revive,stylecheck
+func (CryptoFuncs) SHA512_256Bytes(input interface{}) ([]byte, error) {
+	b := sha512.Sum512_256(toBytes(input))
+	out := make([]byte, len(b))
+	copy(out, b[:])
+	return out, nil
 }
 
 // Bcrypt -


### PR DESCRIPTION
Sometimes it's useful to be able to get a SHA sum in a form other than hexadecimal, so this adds new functions for that.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>