### PR TITLE
Ensure output file paths exist

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -243,6 +243,9 @@ See [`--output-dir`](../usage/#--input-dir-and---output-dir).
 The directory to write rendered output files. Must be used with 
 [`inputDir`](#inputdir).
 
+If the directory is missing, it will be created with the same permissions as the
+`inputDir`.
+
 ```yaml
 inputDir: templates/
 outputDir: out/
@@ -257,6 +260,9 @@ See [`--out`/`-o`](../usage/#--file-f---in-i-and---out-o).
 An array of output file paths. The special value `-` means `Stdout`. Multiple
 values can be set, but there must be a corresponding number of `inputFiles`
 entries present.
+
+If any of the parent directories are missing, they will be created with the same
+permissions as the input directories.
 
 ```yaml
 inputFiles:

--- a/internal/iohelpers/filemode.go
+++ b/internal/iohelpers/filemode.go
@@ -17,8 +17,10 @@ func NormalizeFileMode(mode os.FileMode) os.FileMode {
 }
 
 func windowsFileMode(mode os.FileMode) os.FileMode {
-	// non-owner and execute bits are stripped
-	mode &^= 0o177
+	// non-owner and execute bits are stripped on files
+	if !mode.IsDir() {
+		mode &^= 0o177
+	}
 
 	if mode&0o200 != 0 {
 		// writeable implies read/write on Windows

--- a/internal/iohelpers/filemode_test.go
+++ b/internal/iohelpers/filemode_test.go
@@ -2,6 +2,7 @@ package iohelpers
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"testing"
 
@@ -34,4 +35,7 @@ func TestWindowsFileMode(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("%o", d.expected), fmt.Sprintf("%o", actual))
 		assert.Equal(t, d.expected, actual)
 	}
+
+	// directories are always 0777
+	assert.Equal(t, 0o777|fs.ModeDir, windowsFileMode(0o755|fs.ModeDir))
 }

--- a/template_test.go
+++ b/template_test.go
@@ -22,7 +22,7 @@ func TestOpenOutFile(t *testing.T) {
 	_ = fs.Mkdir("/tmp", 0777)
 
 	cfg := &config.Config{}
-	f, err := openOutFile(cfg, "/tmp/foo", 0644, false)
+	f, err := openOutFile(cfg, "/tmp/foo", 0755, 0644, false)
 	assert.NoError(t, err)
 
 	wc, ok := f.(io.WriteCloser)
@@ -36,7 +36,7 @@ func TestOpenOutFile(t *testing.T) {
 
 	cfg.Stdout = &bytes.Buffer{}
 
-	f, err = openOutFile(cfg, "-", 0644, false)
+	f, err = openOutFile(cfg, "-", 0755, 0644, false)
 	assert.NoError(t, err)
 	assert.Equal(t, cfg.Stdout, f)
 }
@@ -261,7 +261,7 @@ func TestCreateOutFile(t *testing.T) {
 	fs = afero.NewMemMapFs()
 	_ = fs.Mkdir("in", 0755)
 
-	_, err := createOutFile("in", 0644, false)
+	_, err := createOutFile("in", 0755, 0644, false)
 	assert.Error(t, err)
 	assert.IsType(t, &os.PathError{}, err)
 }


### PR DESCRIPTION
Instead of failing when the output directory is missing, this creates it. IMO a less surprising behaviour.

Fixes #1277 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>