### PR TITLE
strings.Title - fix ability to handle unicode punctuation

### DIFF
--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Masterminds/goutils"
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/pkg/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"strings"
 
@@ -39,7 +41,7 @@ func AddStringFuncs(f map[string]interface{}) {
 func CreateStringFuncs(ctx context.Context) map[string]interface{} {
 	f := map[string]interface{}{}
 
-	ns := &StringFuncs{ctx}
+	ns := &StringFuncs{ctx, language.Und}
 	f["strings"] = func() interface{} { return ns }
 
 	f["replaceAll"] = ns.ReplaceAll
@@ -66,6 +68,10 @@ func CreateStringFuncs(ctx context.Context) map[string]interface{} {
 // StringFuncs -
 type StringFuncs struct {
 	ctx context.Context
+
+	// tag - the selected BCP 47 language tag. Currently gomplate only supports
+	// Und (undetermined)
+	tag language.Tag
 }
 
 // Abbrev -
@@ -168,18 +174,18 @@ func (StringFuncs) TrimSuffix(cutset string, s interface{}) string {
 }
 
 // Title -
-func (StringFuncs) Title(s interface{}) string {
-	return strings.Title(conv.ToString(s))
+func (f *StringFuncs) Title(s interface{}) string {
+	return cases.Title(f.tag).String(conv.ToString(s))
 }
 
 // ToUpper -
-func (StringFuncs) ToUpper(s interface{}) string {
-	return strings.ToUpper(conv.ToString(s))
+func (f *StringFuncs) ToUpper(s interface{}) string {
+	return cases.Upper(f.tag).String(conv.ToString(s))
 }
 
 // ToLower -
-func (StringFuncs) ToLower(s interface{}) string {
-	return strings.ToLower(conv.ToString(s))
+func (f *StringFuncs) ToLower(s interface{}) string {
+	return cases.Lower(f.tag).String(conv.ToString(s))
 }
 
 // TrimSpace -

--- a/funcs/strings_test.go
+++ b/funcs/strings_test.go
@@ -59,6 +59,26 @@ func TestTrimPrefix(t *testing.T) {
 		sf.TrimPrefix("Foo", "FooBar"))
 }
 
+func TestTitle(t *testing.T) {
+	sf := &StringFuncs{}
+	testdata := []struct {
+		in  interface{}
+		out string
+	}{
+		{``, ``},
+		{`foo`, `Foo`},
+		{`foo bar`, `Foo Bar`},
+		{`ǉoo ǆar`, `ǈoo ǅar`},
+		{`foo bar᳇baz`, `Foo Bar᳇Baz`}, // ᳇ should be treated as punctuation
+		{`foo,bar&baz`, `Foo,Bar&Baz`},
+	}
+
+	for _, d := range testdata {
+		up := sf.Title(d.in)
+		assert.Equal(t, d.out, up)
+	}
+}
+
 func TestTrunc(t *testing.T) {
 	sf := &StringFuncs{}
 	assert.Equal(t, "", sf.Trunc(5, ""))

--- a/internal/tests/integration/strings_test.go
+++ b/internal/tests/integration/strings_test.go
@@ -38,6 +38,16 @@ func TestStrings_Slug(t *testing.T) {
 }
 
 func TestStrings_CaseFuncs(t *testing.T) {
+	inOutTest(t, `{{ strings.ToLower "HELLO" }}
+{{ strings.ToUpper "hello" }}
+{{ strings.Title "is there anybody out there?" }}
+{{ strings.Title "foo,bar᳇ǆaz"}}
+`,
+		`hello
+HELLO
+Is There Anybody Out There?
+Foo,Bar᳇ǅaz
+`)
 	inOutTest(t, `{{ strings.CamelCase "Hellö, Wôrld! Free @ last..." }}
 {{ strings.SnakeCase "Hellö, Wôrld! Free @ last..." }}
 {{ strings.KebabCase "Hellö, Wôrld! Free @ last..." }}`, `HellöWôrldFreeLast


### PR DESCRIPTION
There's a bug in Go's [`strings.Title`](https://pkg.go.dev/strings#Title) function which prevents it from recognizing words separated by certain unicode punctuation marks. In Go 1.18, `strings.Title` will be deprecated. This replaces that usage with `golang.org/x/text/cases`, as suggested by the Go 1.18 documentation.

I've also updated the `ToUpper` and `ToLower` functions accordingly, and added the ability to later define a specific BCP 47 language tag (not yet sure _how_, but the plumbing is laid).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>