### PR TITLE
Reset cached mime-type when reading sub-datasources

### DIFF
--- a/data/datasource_file.go
+++ b/data/datasource_file.go
@@ -31,6 +31,9 @@ func readFile(ctx context.Context, source *Source, args ...string) ([]byte, erro
 		if parsed.Path != "" {
 			p = filepath.Join(p, parsed.Path)
 		}
+
+		// reset the media type - it may have been set by a parent dir read
+		source.mediaType = ""
 	}
 
 	// make sure we can access the file

--- a/internal/tests/integration/datasources_file_test.go
+++ b/internal/tests/integration/datasources_file_test.go
@@ -57,7 +57,7 @@ QUX='single quotes ignore $variables'
 	return tmpDir
 }
 
-func TestDatasourcess_File(t *testing.T) {
+func TestDatasources_File(t *testing.T) {
 	tmpDir := setupDatasourcesFileTest(t)
 
 	o, e, err := cmd(t,
@@ -149,4 +149,16 @@ func TestDatasourcess_File(t *testing.T) {
   "FOO.BAR": "values can be double-quoted, and shell\nescapes are supported",
   "QUX": "single quotes ignore $variables"
 }`)
+}
+
+func TestDatasources_File_Directory(t *testing.T) {
+	tmpDir := setupDatasourcesFileTest(t)
+
+	o, e, err := cmd(t,
+		"-d", "data=sortorder/",
+		"-i", `{{ range (ds "data") }}{{ if strings.HasSuffix ".yaml" . -}}
+			{{ . }} root key: {{ range $k, $v := ds "data" . }}{{ $k }}{{ end }}
+		{{- end }}{{ end }}`).
+		withDir(tmpDir.Path()).run()
+	assertSuccess(t, o, e, err, "core.yaml root key: cloud")
 }


### PR DESCRIPTION
Fixes #1333

This isn't super-elegant, and it highlights a big flaw in the way datasources work right now in gomplate... _But_ this should all go away once the port to go-fsimpl is done.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>