### PR TITLE
Add Terraform CIDR based functions

### DIFF
--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -8,6 +8,7 @@ preamble: |
   [RFC 4632]: http://tools.ietf.org/html/rfc4632
   [RFC 4291]: http://tools.ietf.org/html/rfc4291
   [`inet.af/netaddr`]: https://pkg.go.dev/inet.af/netaddr
+  [`net`]: https://pkg.go.dev/net
 funcs:
   - name: net.LookupIP
     description: |
@@ -192,3 +193,116 @@ funcs:
         $ gomplate -i '{{ $range := net.ParseIPRange "1.2.3.0-1.2.3.233" -}}
           {{ $range.Prefixes }}'
         [1.2.3.0/25 1.2.3.128/26 1.2.3.192/27]
+  - name: net.StdParseIP
+    description: |
+      Parse the given string as an IP address (a `net.IP` from the
+      [`net`][] package).
+
+      Any of `net.IP`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net) for details.
+    pipeline: true
+    arguments:
+      - name: ip
+        required: true
+        description: The IP string to parse. It must be either an IPv4 or IPv6 address.
+    examples:
+      - |
+        $ gomplate -i '{{ net.StdParseIP "192.168.0.1" }}'
+        192.168.0.1
+        $ gomplate -i '{{ $ip := net.StdParseIP (net.LookupIP "example.com") -}}
+          {{ $ip }}'
+        93.184.216.34
+  - name: net.StdParseCIDR
+    description: |
+      Parse the given string as an IP address prefix (CIDR) representing an IP
+      network (a `net.ParseCIDR` from the
+      [`net`][] package).
+
+      The string can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
+      the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
+
+      Any of `net.IP`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net) for details.
+    pipeline: true
+    arguments:
+      - name: prefix
+        required: true
+        description: The IP address prefix to parse. It must represent either an IPv4 or IPv6 prefix, containing a `/`.
+    examples:
+      - |
+        $ gomplate -i '{{ net.StdParseCIDR "192.168.0.123/24" }}'
+        192.168.0.0/24
+  - name: net.CidrHost
+    description: |
+      Calculates a full host IP address for a given host number within a given IP network address prefix.
+
+      The IP network can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
+      the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
+
+      Any of `net.IP`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net) for details.
+    pipeline: true
+    arguments:
+      - name: hostnum
+        required: true
+        description: Is a whole number that can be represented as a binary integer with no more than the number of digits remaining in the address after the given prefix.
+      - name: prefix
+        required: true
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+    examples:
+      - |
+        $ gomplate -i '{{ "10.12.127.0/20" | net.CidrHost 268 }}'
+        10.12.113.12
+  - name: net.CidrNetmask
+    description: |
+      The result is a subnet address formatted in the conventional dotted-decimal IPv4 address syntax, as expected by some software.
+
+      Any of `net.IP`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net) for details.
+    pipeline: true
+    arguments:
+      - name: prefix
+        required: true
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+    examples:
+      - |
+        $ gomplate -i '{{ net.CidrNetmask "10.12.127.0/20" }}'
+        255.255.240.0
+  - name: net.CidrSubnets
+    description: |
+      Calculates a subnet address within given IP network address prefix.
+
+      Any of `net.IPNet`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net) for details.
+    pipeline: true
+    arguments:
+      - name: newbits
+        required: true
+        description: Is the number of additional bits with which to extend the prefix. For example, if given a prefix ending in `/16` and a `newbits` value of `4`, the resulting subnet address will have length `/20`.
+      - name: prefix
+        required: true
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+    examples:
+      - |
+        $ gomplate -i '{{ index ("10.0.0.0/16" | net.CidrSubnets 2) 1 }}'
+        10.0.64.0/18
+        $ gomplate -i '{{ net.CidrSubnets 2 "10.0.0.0/16" -}}'
+        [10.0.0.0/18 10.0.64.0/18 10.0.128.0/18 10.0.192.0/18]
+  - name: net.CidrSubnetSizes
+    description: |
+      Calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.
+
+      Any of `net.IPNet`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net) for details.
+    pipeline: true
+    arguments:
+      - name: newbits...
+        required: true
+        description: Numbers of additional network prefix bits for returned address range.
+      - name: prefix
+        required: true
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+    examples:
+      - |
+        $ gomplate -i '{{ net.CidrSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'
+        [10.1.0.0/20 10.1.16.0/20 10.1.32.0/24 10.1.48.0/20]

--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -216,7 +216,7 @@ funcs:
         10.12.113.12
   - name: net.CidrNetmask
     description: |
-      The result is a subnet address formatted in the conventional dotted-decimal IPv4 address syntax, as expected by some software.
+      The result is a subnet address formatted in the conventional dotted-decimal IPv4 address syntax or hexadecimal IPv6 address syntax, as expected by some software.
 
       Any of `net.IP`'s methods may be called on the resulting value. See
       [the docs](https://pkg.go.dev/net) for details.
@@ -229,6 +229,8 @@ funcs:
       - |
         $ gomplate -i '{{ net.CidrNetmask "10.12.127.0/20" }}'
         255.255.240.0
+        $ gomplate -i '{{ net.CidrNetmask "fd00:fd12:3456:7890:00a2::/72" }}'
+        ffff:ffff:ffff:ffff:ff00::
   - name: net.CidrSubnets
     description: |
       Calculates a subnet address within given IP network address prefix.

--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -193,15 +193,16 @@ funcs:
         $ gomplate -i '{{ $range := net.ParseIPRange "1.2.3.0-1.2.3.233" -}}
           {{ $range.Prefixes }}'
         [1.2.3.0/25 1.2.3.128/26 1.2.3.192/27]
-  - name: net.CidrHost
+  - name: net.CIDRHost
+    experimental: true
     description: |
       Calculates a full host IP address for a given host number within a given IP network address prefix.
 
       The IP network can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
       the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
 
-      Any of `net.IP`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/net) for details.
+      Any of `netip.Addr`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net/netip#Addr) for details.
     pipeline: true
     arguments:
       - name: hostnum
@@ -212,14 +213,15 @@ funcs:
         description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
-        $ gomplate -i '{{ "10.12.127.0/20" | net.CidrHost 268 }}'
+        $ gomplate -i '{{ "10.12.127.0/20" | net.CIDRHost 268 }}'
         10.12.113.12
-  - name: net.CidrNetmask
+  - name: net.CIDRNetmask
+    experimental: true
     description: |
       The result is a subnet address formatted in the conventional dotted-decimal IPv4 address syntax or hexadecimal IPv6 address syntax, as expected by some software.
 
-      Any of `net.IP`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/net) for details.
+      Any of `netip.Addr`'s methods may be called on the resulting value. See
+      [the docs](https://pkg.go.dev/net/netip#Addr) for details.
     pipeline: true
     arguments:
       - name: prefix
@@ -227,16 +229,17 @@ funcs:
         description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
-        $ gomplate -i '{{ net.CidrNetmask "10.12.127.0/20" }}'
+        $ gomplate -i '{{ net.CIDRNetmask "10.12.127.0/20" }}'
         255.255.240.0
-        $ gomplate -i '{{ net.CidrNetmask "fd00:fd12:3456:7890:00a2::/72" }}'
+        $ gomplate -i '{{ net.CIDRNetmask "fd00:fd12:3456:7890:00a2::/72" }}'
         ffff:ffff:ffff:ffff:ff00::
-  - name: net.CidrSubnets
+  - name: net.CIDRSubnets
+    experimental: true
     description: |
       Calculates a subnet address within given IP network address prefix.
 
-      Any of `net.IPNet`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/net) for details.
+      Any of `netip.Prefix`'s methods may be called on the resulting values. See
+      [the docs](https://pkg.go.dev/net/netip#Prefix) for details.
     pipeline: true
     arguments:
       - name: newbits
@@ -247,16 +250,17 @@ funcs:
         description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
-        $ gomplate -i '{{ index ("10.0.0.0/16" | net.CidrSubnets 2) 1 }}'
+        $ gomplate -i '{{ index ("10.0.0.0/16" | net.CIDRSubnets 2) 1 }}'
         10.0.64.0/18
-        $ gomplate -i '{{ net.CidrSubnets 2 "10.0.0.0/16" -}}'
+        $ gomplate -i '{{ net.CIDRSubnets 2 "10.0.0.0/16" -}}'
         [10.0.0.0/18 10.0.64.0/18 10.0.128.0/18 10.0.192.0/18]
-  - name: net.CidrSubnetSizes
+  - name: net.CIDRSubnetSizes
+    experimental: true
     description: |
       Calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.
 
-      Any of `net.IPNet`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/net) for details.
+      Any of `netip.Prefix`'s methods may be called on the resulting values. See
+      [the docs](https://pkg.go.dev/net/netip#Prefix) for details.
     pipeline: true
     arguments:
       - name: newbits...
@@ -267,5 +271,5 @@ funcs:
         description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
-        $ gomplate -i '{{ net.CidrSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'
+        $ gomplate -i '{{ net.CIDRSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'
         [10.1.0.0/20 10.1.16.0/20 10.1.32.0/24 10.1.48.0/20]

--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -193,45 +193,6 @@ funcs:
         $ gomplate -i '{{ $range := net.ParseIPRange "1.2.3.0-1.2.3.233" -}}
           {{ $range.Prefixes }}'
         [1.2.3.0/25 1.2.3.128/26 1.2.3.192/27]
-  - name: net.StdParseIP
-    description: |
-      Parse the given string as an IP address (a `net.IP` from the
-      [`net`][] package).
-
-      Any of `net.IP`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/net) for details.
-    pipeline: true
-    arguments:
-      - name: ip
-        required: true
-        description: The IP string to parse. It must be either an IPv4 or IPv6 address.
-    examples:
-      - |
-        $ gomplate -i '{{ net.StdParseIP "192.168.0.1" }}'
-        192.168.0.1
-        $ gomplate -i '{{ $ip := net.StdParseIP (net.LookupIP "example.com") -}}
-          {{ $ip }}'
-        93.184.216.34
-  - name: net.StdParseCIDR
-    description: |
-      Parse the given string as an IP address prefix (CIDR) representing an IP
-      network (a `net.ParseCIDR` from the
-      [`net`][] package).
-
-      The string can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
-      the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
-
-      Any of `net.IP`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/net) for details.
-    pipeline: true
-    arguments:
-      - name: prefix
-        required: true
-        description: The IP address prefix to parse. It must represent either an IPv4 or IPv6 prefix, containing a `/`.
-    examples:
-      - |
-        $ gomplate -i '{{ net.StdParseCIDR "192.168.0.123/24" }}'
-        192.168.0.0/24
   - name: net.CidrHost
     description: |
       Calculates a full host IP address for a given host number within a given IP network address prefix.
@@ -248,7 +209,7 @@ funcs:
         description: Is a whole number that can be represented as a binary integer with no more than the number of digits remaining in the address after the given prefix.
       - name: prefix
         required: true
-        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
         $ gomplate -i '{{ "10.12.127.0/20" | net.CidrHost 268 }}'
@@ -263,7 +224,7 @@ funcs:
     arguments:
       - name: prefix
         required: true
-        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
         $ gomplate -i '{{ net.CidrNetmask "10.12.127.0/20" }}'
@@ -281,7 +242,7 @@ funcs:
         description: Is the number of additional bits with which to extend the prefix. For example, if given a prefix ending in `/16` and a `newbits` value of `4`, the resulting subnet address will have length `/20`.
       - name: prefix
         required: true
-        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
         $ gomplate -i '{{ index ("10.0.0.0/16" | net.CidrSubnets 2) 1 }}'
@@ -301,7 +262,7 @@ funcs:
         description: Numbers of additional network prefix bits for returned address range.
       - name: prefix
         required: true
-        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.StdParseCIDR` can by used.
+        description: Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used.
     examples:
       - |
         $ gomplate -i '{{ net.CidrSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -13,6 +13,7 @@ calculations.
 [RFC 4632]: http://tools.ietf.org/html/rfc4632
 [RFC 4291]: http://tools.ietf.org/html/rfc4291
 [`inet.af/netaddr`]: https://pkg.go.dev/inet.af/netaddr
+[`net`]: https://pkg.go.dev/net
 
 ## `net.LookupIP`
 
@@ -319,4 +320,142 @@ $ gomplate -i '{{ (net.ParseIPRange "192.168.0.0-192.168.0.255").To }}'
 $ gomplate -i '{{ $range := net.ParseIPRange "1.2.3.0-1.2.3.233" -}}
   {{ $range.Prefixes }}'
 [1.2.3.0/25 1.2.3.128/26 1.2.3.192/27]
+```
+
+## `net.CIDRHost` _(experimental)_
+**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+
+[experimental]: ../config/#experimental
+
+Calculates a full host IP address for a given host number within a given IP network address prefix.
+
+The IP network can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
+the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
+
+Any of `netip.Addr`'s methods may be called on the resulting value. See
+[the docs](https://pkg.go.dev/net/netip#Addr) for details.
+
+### Usage
+
+```go
+net.CIDRHost hostnum prefix
+```
+```go
+prefix | net.CIDRHost hostnum
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `hostnum` | _(required)_ Is a whole number that can be represented as a binary integer with no more than the number of digits remaining in the address after the given prefix. |
+| `prefix` | _(required)_ Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used. |
+
+### Examples
+
+```console
+$ gomplate -i '{{ "10.12.127.0/20" | net.CIDRHost 268 }}'
+10.12.113.12
+```
+
+## `net.CIDRNetmask` _(experimental)_
+**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+
+[experimental]: ../config/#experimental
+
+The result is a subnet address formatted in the conventional dotted-decimal IPv4 address syntax or hexadecimal IPv6 address syntax, as expected by some software.
+
+Any of `netip.Addr`'s methods may be called on the resulting value. See
+[the docs](https://pkg.go.dev/net/netip#Addr) for details.
+
+### Usage
+
+```go
+net.CIDRNetmask prefix
+```
+```go
+prefix | net.CIDRNetmask
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `prefix` | _(required)_ Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used. |
+
+### Examples
+
+```console
+$ gomplate -i '{{ net.CIDRNetmask "10.12.127.0/20" }}'
+255.255.240.0
+$ gomplate -i '{{ net.CIDRNetmask "fd00:fd12:3456:7890:00a2::/72" }}'
+ffff:ffff:ffff:ffff:ff00::
+```
+
+## `net.CIDRSubnets` _(experimental)_
+**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+
+[experimental]: ../config/#experimental
+
+Calculates a subnet address within given IP network address prefix.
+
+Any of `netip.Prefix`'s methods may be called on the resulting values. See
+[the docs](https://pkg.go.dev/net/netip#Prefix) for details.
+
+### Usage
+
+```go
+net.CIDRSubnets newbits prefix
+```
+```go
+prefix | net.CIDRSubnets newbits
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `newbits` | _(required)_ Is the number of additional bits with which to extend the prefix. For example, if given a prefix ending in `/16` and a `newbits` value of `4`, the resulting subnet address will have length `/20`. |
+| `prefix` | _(required)_ Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used. |
+
+### Examples
+
+```console
+$ gomplate -i '{{ index ("10.0.0.0/16" | net.CIDRSubnets 2) 1 }}'
+10.0.64.0/18
+$ gomplate -i '{{ net.CIDRSubnets 2 "10.0.0.0/16" -}}'
+[10.0.0.0/18 10.0.64.0/18 10.0.128.0/18 10.0.192.0/18]
+```
+
+## `net.CIDRSubnetSizes` _(experimental)_
+**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+
+[experimental]: ../config/#experimental
+
+Calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.
+
+Any of `netip.Prefix`'s methods may be called on the resulting values. See
+[the docs](https://pkg.go.dev/net/netip#Prefix) for details.
+
+### Usage
+
+```go
+net.CIDRSubnetSizes newbits... prefix
+```
+```go
+prefix | net.CIDRSubnetSizes newbits...
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `newbits...` | _(required)_ Numbers of additional network prefix bits for returned address range. |
+| `prefix` | _(required)_ Must be given in CIDR notation. It must represent either an IPv4 or IPv6 prefix, containing a `/`. String or [`net.IPNet`](https://pkg.go.dev/net#IPNet) object returned from `net.ParseIPPrefix` can by used. |
+
+### Examples
+
+```console
+$ gomplate -i '{{ net.CIDRSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'
+[10.1.0.0/20 10.1.16.0/20 10.1.32.0/24 10.1.48.0/20]
 ```

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -85,12 +85,12 @@ func (f NetFuncs) ParseIPRange(iprange interface{}) (netaddr.IPRange, error) {
 }
 
 // StdParseIP -
-func (f NetFuncs) StdParseIP(prefix interface{}) (stdnet.IP, error) {
-	ip := stdnet.ParseIP(conv.ToString(prefix))
-	if ip == nil {
+func (f NetFuncs) StdParseIP(ip interface{}) (stdnet.IP, error) {
+	i := stdnet.ParseIP(conv.ToString(ip))
+	if i == nil {
 		return nil, errors.Errorf("invalid IP address")
 	}
-	return ip, nil
+	return i, nil
 }
 
 func (f NetFuncs) stdParseCIDR(prefix interface{}) (*stdnet.IPNet, error) {

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -114,6 +114,18 @@ func (f NetFuncs) ipPrefixFromIpNet(n *stdnet.IPNet) netaddr.IPPrefix {
 	return prefix
 }
 
+// func (f NetFuncs) addrFromNetIp(n stdnet.IP) netip.Addr {
+// 	ip, _ := netip.AddrFromSlice(n)
+// 	return ip
+// }
+
+// func (f NetFuncs) prefixFromIpNet(n *stdnet.IPNet) netip.Prefix {
+// 	ip, _ := netip.AddrFromSlice(n.IP)
+// 	bits, _ := n.Mask.Size()
+// 	prefix := netip.PrefixFrom(ip, bits)
+// 	return prefix
+// }
+
 // CidrHost -
 func (f NetFuncs) CidrHost(hostnum interface{}, prefix interface{}) (netaddr.IP, error) {
 	network, err := f.parseStdnetIPNet(prefix)
@@ -130,10 +142,6 @@ func (f NetFuncs) CidrNetmask(prefix interface{}) (netaddr.IP, error) {
 	network, err := f.parseStdnetIPNet(prefix)
 	if err != nil {
 		return netaddr.IP{}, err
-	}
-
-	if len(network.IP) != stdnet.IPv4len {
-		return netaddr.IP{}, errors.Errorf("only IPv4 networks are supported")
 	}
 
 	netmask := stdnet.IP(network.Mask)

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -2,10 +2,13 @@ package funcs
 
 import (
 	"context"
+	"math/big"
 	stdnet "net"
 
+	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/hairyhenderson/gomplate/v3/net"
+	"github.com/pkg/errors"
 	"inet.af/netaddr"
 )
 
@@ -79,4 +82,137 @@ func (f NetFuncs) ParseIPPrefix(ipprefix interface{}) (netaddr.IPPrefix, error) 
 // ParseIPRange -
 func (f NetFuncs) ParseIPRange(iprange interface{}) (netaddr.IPRange, error) {
 	return netaddr.ParseIPRange(conv.ToString(iprange))
+}
+
+// StdParseIP -
+func (f NetFuncs) StdParseIP(prefix interface{}) (stdnet.IP, error) {
+	ip := stdnet.ParseIP(conv.ToString(prefix))
+	if ip == nil {
+		return nil, errors.Errorf("invalid IP address")
+	}
+	return ip, nil
+}
+
+func (f NetFuncs) stdParseCIDR(prefix interface{}) (*stdnet.IPNet, error) {
+	if n, ok := prefix.(*stdnet.IPNet); ok {
+		return n, nil
+	}
+
+	_, network, err := stdnet.ParseCIDR(conv.ToString(prefix))
+	return network, err
+}
+
+// StdParseCIDR -
+func (f NetFuncs) StdParseCIDR(prefix interface{}) (*stdnet.IPNet, error) {
+	return f.stdParseCIDR(prefix)
+}
+
+// CidrHost -
+func (f NetFuncs) CidrHost(hostnum interface{}, prefix interface{}) (*stdnet.IP, error) {
+	network, err := f.stdParseCIDR(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	ip, err := cidr.HostBig(network, big.NewInt(conv.ToInt64(hostnum)))
+	return &ip, err
+}
+
+// CidrNetmask -
+func (f NetFuncs) CidrNetmask(prefix interface{}) (*stdnet.IP, error) {
+	network, err := f.stdParseCIDR(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(network.IP) != stdnet.IPv4len {
+		return nil, errors.Errorf("only IPv4 networks are supported")
+	}
+
+	netmask := stdnet.IP(network.Mask)
+	return &netmask, nil
+}
+
+// CidrSubnets -
+func (f NetFuncs) CidrSubnets(newbits interface{}, prefix interface{}) ([]*stdnet.IPNet, error) {
+	network, err := f.stdParseCIDR(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	nBits := conv.ToInt(newbits)
+	if nBits < 1 {
+		return nil, errors.Errorf("must extend prefix by at least one bit")
+	}
+
+	maxNetNum := int64(1 << uint64(nBits))
+	retValues := make([]*stdnet.IPNet, maxNetNum)
+	for i := int64(0); i < maxNetNum; i++ {
+		subnet, err := cidr.SubnetBig(network, nBits, big.NewInt(i))
+		if err != nil {
+			return nil, err
+		}
+		retValues[i] = subnet
+	}
+
+	return retValues, nil
+}
+
+// CidrSubnetSizes -
+func (f NetFuncs) CidrSubnetSizes(args ...interface{}) ([]*stdnet.IPNet, error) {
+	if len(args) < 2 {
+		return nil, errors.Errorf("wrong number of args: want 2 or more, got %d", len(args))
+	}
+
+	network, err := f.stdParseCIDR(args[len(args)-1])
+	if err != nil {
+		return nil, err
+	}
+	newbits := conv.ToInts(args[:len(args)-1]...)
+
+	startPrefixLen, _ := network.Mask.Size()
+	firstLength := newbits[0]
+
+	firstLength += startPrefixLen
+	retValues := make([]*stdnet.IPNet, len(newbits))
+
+	current, _ := cidr.PreviousSubnet(network, firstLength)
+
+	for i, length := range newbits {
+		if length < 1 {
+			return nil, errors.Errorf("must extend prefix by at least one bit")
+		}
+		// For portability with 32-bit systems where the subnet number
+		// will be a 32-bit int, we only allow extension of 32 bits in
+		// one call even if we're running on a 64-bit machine.
+		// (Of course, this is significant only for IPv6.)
+		if length > 32 {
+			return nil, errors.Errorf("may not extend prefix by more than 32 bits")
+		}
+
+		length += startPrefixLen
+		if length > (len(network.IP) * 8) {
+			protocol := "IP"
+			switch len(network.IP) {
+			case stdnet.IPv4len:
+				protocol = "IPv4"
+			case stdnet.IPv6len:
+				protocol = "IPv6"
+			}
+			return nil, errors.Errorf("would extend prefix to %d bits, which is too long for an %s address", length, protocol)
+		}
+
+		next, rollover := cidr.NextSubnet(current, length)
+		if rollover || !network.Contains(next.IP) {
+			// If we run out of suffix bits in the base CIDR prefix then
+			// NextSubnet will start incrementing the prefix bits, which
+			// we don't allow because it would then allocate addresses
+			// outside of the caller's given prefix.
+			return nil, errors.Errorf("not enough remaining address space for a subnet with a prefix of %d bits after %s", length, current.String())
+		}
+		current = next
+		retValues[i] = current
+	}
+
+	return retValues, nil
 }

--- a/funcs/net_test.go
+++ b/funcs/net_test.go
@@ -2,6 +2,7 @@ package funcs
 
 import (
 	"context"
+	stdnet "net"
 	"strconv"
 	"testing"
 
@@ -68,4 +69,105 @@ func TestParseIPRange(t *testing.T) {
 	iprange, err := n.ParseIPRange("192.168.0.2-192.168.23.255")
 	assert.NoError(t, err)
 	assert.Equal(t, "192.168.0.2-192.168.23.255", iprange.String())
+}
+
+func TestStdParseIP(t *testing.T) {
+	n := NetFuncs{}
+	ip, err := n.StdParseIP("not an IP")
+	assert.Nil(t, ip)
+	assert.Error(t, err)
+
+	ip, err = n.StdParseIP("10.12.113.12")
+	assert.NoError(t, err)
+	assert.Equal(t, stdnet.IPv4(0x0A, 0x0C, 0x71, 0x0C), ip)
+
+	ip, err = n.StdParseIP("2001:470:20::2")
+	assert.NoError(t, err)
+	assert.Equal(t, stdnet.IP{
+		0x20, 0x01, 0x04, 0x70,
+		0, 0x20, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0x02,
+	}, ip)
+}
+func TestStdParseCIDR(t *testing.T) {
+	n := NetFuncs{}
+	_, err := n.StdParseCIDR("not an IP")
+	assert.Error(t, err)
+
+	_, err = n.StdParseCIDR("1.1.1.1")
+	assert.Error(t, err)
+
+	cidr, err := n.StdParseCIDR("192.168.0.2/28")
+	assert.NoError(t, err)
+	assert.Equal(t, "192.168.0.0/28", cidr.String())
+}
+
+func TestCidrHost(t *testing.T) {
+	n := NetFuncs{}
+	_, network, _ := stdnet.ParseCIDR("10.12.127.0/20")
+
+	ip, err := n.CidrHost(16, network)
+	assert.NoError(t, err)
+	assert.Equal(t, "10.12.112.16", ip.String())
+
+	ip, err = n.CidrHost(268, network)
+	assert.NoError(t, err)
+	assert.Equal(t, "10.12.113.12", ip.String())
+
+	_, network, _ = stdnet.ParseCIDR("fd00:fd12:3456:7890:00a2::/72")
+	ip, err = n.CidrHost(34, network)
+	assert.NoError(t, err)
+	assert.Equal(t, "fd00:fd12:3456:7890::22", ip.String())
+}
+
+func TestCidrNetmask(t *testing.T) {
+	n := NetFuncs{}
+	_, network, _ := stdnet.ParseCIDR("10.0.0.0/12")
+
+	ip, err := n.CidrNetmask(network)
+	assert.NoError(t, err)
+	assert.Equal(t, "255.240.0.0", ip.String())
+}
+
+func TestCidrSubnets(t *testing.T) {
+	n := NetFuncs{}
+	_, network, _ := stdnet.ParseCIDR("10.0.0.0/16")
+
+	subnets, err := n.CidrSubnets(-1, network)
+	assert.Nil(t, subnets)
+	assert.Error(t, err)
+
+	subnets, err = n.CidrSubnets(2, network)
+	assert.NoError(t, err)
+	assert.Len(t, subnets, 4)
+	assert.Equal(t, "10.0.0.0/18", subnets[0].String())
+	assert.Equal(t, "10.0.64.0/18", subnets[1].String())
+	assert.Equal(t, "10.0.128.0/18", subnets[2].String())
+	assert.Equal(t, "10.0.192.0/18", subnets[3].String())
+}
+
+func TestCidrSubnetSizes(t *testing.T) {
+	n := NetFuncs{}
+	_, network, _ := stdnet.ParseCIDR("10.1.0.0/16")
+
+	subnets, err := n.CidrSubnetSizes(network)
+	assert.Nil(t, subnets)
+	assert.Error(t, err)
+
+	subnets, err = n.CidrSubnetSizes(32, network)
+	assert.Nil(t, subnets)
+	assert.Error(t, err)
+
+	subnets, err = n.CidrSubnetSizes(-1, network)
+	assert.Nil(t, subnets)
+	assert.Error(t, err)
+
+	subnets, err = n.CidrSubnetSizes(4, 4, 8, 4, network)
+	assert.NoError(t, err)
+	assert.Len(t, subnets, 4)
+	assert.Equal(t, "10.1.0.0/20", subnets[0].String())
+	assert.Equal(t, "10.1.16.0/20", subnets[1].String())
+	assert.Equal(t, "10.1.32.0/24", subnets[2].String())
+	assert.Equal(t, "10.1.48.0/20", subnets[3].String())
 }

--- a/funcs/net_test.go
+++ b/funcs/net_test.go
@@ -126,11 +126,14 @@ func TestCidrHost(t *testing.T) {
 
 func TestCidrNetmask(t *testing.T) {
 	n := NetFuncs{}
-	_, network, _ := stdnet.ParseCIDR("10.0.0.0/12")
 
-	ip, err := n.CidrNetmask(network)
+	ip, err := n.CidrNetmask("10.0.0.0/12")
 	assert.NoError(t, err)
 	assert.Equal(t, "255.240.0.0", ip.String())
+
+	ip, err = n.CidrNetmask("fd00:fd12:3456:7890:00a2::/72")
+	assert.NoError(t, err)
+	assert.Equal(t, "ffff:ffff:ffff:ffff:ff00::", ip.String())
 }
 
 func TestCidrSubnets(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/Masterminds/goutils v1.1.1
 	github.com/Shopify/ejson v1.3.3
+	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.44.4
 	github.com/docker/libkv v0.2.2-0.20180912205406-458977154600
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
+github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=

--- a/internal/tests/integration/integration_test.go
+++ b/internal/tests/integration/integration_test.go
@@ -33,6 +33,15 @@ func inOutTest(t *testing.T, i, o string) {
 	assert.Equal(t, o, stdout)
 }
 
+func inOutTestExperimental(t *testing.T, i, o string) {
+	t.Helper()
+
+	stdout, stderr, err := cmd(t, "--experimental", "-i", i).run()
+	assert.NoError(t, err)
+	assert.Equal(t, "", stderr)
+	assert.Equal(t, o, stdout)
+}
+
 func inOutContains(t *testing.T, i, o string) {
 	t.Helper()
 

--- a/internal/tests/integration/net_test.go
+++ b/internal/tests/integration/net_test.go
@@ -8,22 +8,22 @@ func TestNet_LookupIP(t *testing.T) {
 	inOutTest(t, `{{ net.LookupIP "localhost" }}`, "127.0.0.1")
 }
 
-func TestNet_CidrHost(t *testing.T) {
-	inOutTest(t, `{{ net.ParseIPPrefix "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
-	inOutTest(t, `{{ "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
-	inOutTest(t, `{{ net.CidrHost 268 "10.12.127.0/20" }}`, "10.12.113.12")
-	inOutTest(t, `{{ net.CidrHost 34 "fd00:fd12:3456:7890:00a2::/72" }}`, "fd00:fd12:3456:7890::22")
+func TestNet_CIDRHost(t *testing.T) {
+	inOutTestExperimental(t, `{{ net.ParseIPPrefix "10.12.127.0/20" | net.CIDRHost 16 }}`, "10.12.112.16")
+	inOutTestExperimental(t, `{{ "10.12.127.0/20" | net.CIDRHost 16 }}`, "10.12.112.16")
+	inOutTestExperimental(t, `{{ net.CIDRHost 268 "10.12.127.0/20" }}`, "10.12.113.12")
+	inOutTestExperimental(t, `{{ net.CIDRHost 34 "fd00:fd12:3456:7890:00a2::/72" }}`, "fd00:fd12:3456:7890::22")
 }
 
-func TestNet_CidrNetmask(t *testing.T) {
-	inOutTest(t, `{{ "10.12.127.0/20" | net.CidrNetmask }}`, "255.255.240.0")
-	inOutTest(t, `{{ net.CidrNetmask "10.0.0.0/12" }}`, "255.240.0.0")
-	inOutTest(t, `{{ net.CidrNetmask "fd00:fd12:3456:7890:00a2::/72" }}`, "ffff:ffff:ffff:ffff:ff00::")
+func TestNet_CIDRNetmask(t *testing.T) {
+	inOutTestExperimental(t, `{{ "10.12.127.0/20" | net.CIDRNetmask }}`, "255.255.240.0")
+	inOutTestExperimental(t, `{{ net.CIDRNetmask "10.0.0.0/12" }}`, "255.240.0.0")
+	inOutTestExperimental(t, `{{ net.CIDRNetmask "fd00:fd12:3456:7890:00a2::/72" }}`, "ffff:ffff:ffff:ffff:ff00::")
 }
 
-func TestNet_CidrSubnets(t *testing.T) {
-	inOutTest(t, `{{ index ("10.0.0.0/16" | net.CidrSubnets 2) 1 }}`, "10.0.64.0/18")
-	inOutTest(t, `{{ range net.CidrSubnets 2 "10.0.0.0/16" }}
+func TestNet_CIDRSubnets(t *testing.T) {
+	inOutTestExperimental(t, `{{ index ("10.0.0.0/16" | net.CIDRSubnets 2) 1 }}`, "10.0.64.0/18")
+	inOutTestExperimental(t, `{{ range net.CIDRSubnets 2 "10.0.0.0/16" }}
 {{ . }}{{ end }}`, `
 10.0.0.0/18
 10.0.64.0/18
@@ -31,10 +31,10 @@ func TestNet_CidrSubnets(t *testing.T) {
 10.0.192.0/18`)
 }
 
-func TestNet_CidrSubnetSizes(t *testing.T) {
-	inOutTest(t, `{{ index ("10.0.0.0/16" | net.CidrSubnetSizes 1) 0 }}`, "10.0.0.0/17")
-	inOutTest(t, `{{ index ("10.1.0.0/16" | net.CidrSubnetSizes 4 4 8 4) 1 }}`, "10.1.16.0/20")
-	inOutTest(t, `{{ range net.CidrSubnetSizes 16 16 16 32 "fd00:fd12:3456:7890::/56" }}
+func TestNet_CIDRSubnetSizes(t *testing.T) {
+	inOutTestExperimental(t, `{{ index ("10.0.0.0/16" | net.CIDRSubnetSizes 1) 0 }}`, "10.0.0.0/17")
+	inOutTestExperimental(t, `{{ index ("10.1.0.0/16" | net.CIDRSubnetSizes 4 4 8 4) 1 }}`, "10.1.16.0/20")
+	inOutTestExperimental(t, `{{ range net.CIDRSubnetSizes 16 16 16 32 "fd00:fd12:3456:7890::/56" }}
 {{ . }}{{ end }}`, `
 fd00:fd12:3456:7800::/72
 fd00:fd12:3456:7800:100::/72

--- a/internal/tests/integration/net_test.go
+++ b/internal/tests/integration/net_test.go
@@ -7,3 +7,40 @@ import (
 func TestNet_LookupIP(t *testing.T) {
 	inOutTest(t, `{{ net.LookupIP "localhost" }}`, "127.0.0.1")
 }
+
+func TestNet_ParseCIDR(t *testing.T) {
+	inOutTest(t, `{{ net.StdParseCIDR "10.12.127.0/20" }}`, "10.12.112.0/20")
+}
+
+func TestNet_CidrHost(t *testing.T) {
+	inOutTest(t, `{{ net.StdParseCIDR "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
+	inOutTest(t, `{{ "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
+	inOutTest(t, `{{ net.CidrHost 268 "10.12.127.0/20" }}`, "10.12.113.12")
+	inOutTest(t, `{{ net.CidrHost 34 "fd00:fd12:3456:7890:00a2::/72" }}`, "fd00:fd12:3456:7890::22")
+}
+
+func TestNet_CidrNetmask(t *testing.T) {
+	inOutTest(t, `{{ "10.12.127.0/20" | net.CidrNetmask }}`, "255.255.240.0")
+	inOutTest(t, `{{ net.CidrNetmask "10.0.0.0/12" }}`, "255.240.0.0")
+}
+
+func TestNet_CidrSubnets(t *testing.T) {
+	inOutTest(t, `{{ index ("10.0.0.0/16" | net.CidrSubnets 2) 1 }}`, "10.0.64.0/18")
+	inOutTest(t, `{{ range net.CidrSubnets 2 "10.0.0.0/16" }}
+{{ . }}{{ end }}`, `
+10.0.0.0/18
+10.0.64.0/18
+10.0.128.0/18
+10.0.192.0/18`)
+}
+
+func TestNet_CidrSubnetSizes(t *testing.T) {
+	inOutTest(t, `{{ index ("10.0.0.0/16" | net.CidrSubnetSizes 1) 0 }}`, "10.0.0.0/17")
+	inOutTest(t, `{{ index ("10.1.0.0/16" | net.CidrSubnetSizes 4 4 8 4) 1 }}`, "10.1.16.0/20")
+	inOutTest(t, `{{ range net.CidrSubnetSizes 16 16 16 32 "fd00:fd12:3456:7890::/56" }}
+{{ . }}{{ end }}`, `
+fd00:fd12:3456:7800::/72
+fd00:fd12:3456:7800:100::/72
+fd00:fd12:3456:7800:200::/72
+fd00:fd12:3456:7800:300::/88`)
+}

--- a/internal/tests/integration/net_test.go
+++ b/internal/tests/integration/net_test.go
@@ -8,12 +8,8 @@ func TestNet_LookupIP(t *testing.T) {
 	inOutTest(t, `{{ net.LookupIP "localhost" }}`, "127.0.0.1")
 }
 
-func TestNet_ParseCIDR(t *testing.T) {
-	inOutTest(t, `{{ net.StdParseCIDR "10.12.127.0/20" }}`, "10.12.112.0/20")
-}
-
 func TestNet_CidrHost(t *testing.T) {
-	inOutTest(t, `{{ net.StdParseCIDR "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
+	inOutTest(t, `{{ net.ParseIPPrefix "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
 	inOutTest(t, `{{ "10.12.127.0/20" | net.CidrHost 16 }}`, "10.12.112.16")
 	inOutTest(t, `{{ net.CidrHost 268 "10.12.127.0/20" }}`, "10.12.113.12")
 	inOutTest(t, `{{ net.CidrHost 34 "fd00:fd12:3456:7890:00a2::/72" }}`, "fd00:fd12:3456:7890::22")

--- a/internal/tests/integration/net_test.go
+++ b/internal/tests/integration/net_test.go
@@ -18,6 +18,7 @@ func TestNet_CidrHost(t *testing.T) {
 func TestNet_CidrNetmask(t *testing.T) {
 	inOutTest(t, `{{ "10.12.127.0/20" | net.CidrNetmask }}`, "255.255.240.0")
 	inOutTest(t, `{{ net.CidrNetmask "10.0.0.0/12" }}`, "255.240.0.0")
+	inOutTest(t, `{{ net.CidrNetmask "fd00:fd12:3456:7890:00a2::/72" }}`, "ffff:ffff:ffff:ffff:ff00::")
 }
 
 func TestNet_CidrSubnets(t *testing.T) {


### PR DESCRIPTION
I've added a few more functions to the `net` namespace:

- `net.CidrHost` to calculate host IP address from CIDR and host number, based on Terraform [`cidrhost`](https://www.terraform.io/language/functions/cidrhost) function
- `net.CidrNetmask` to return CIDR netmask in dotted-decimal IPv4 address syntax, based on Terraform [`cidrnetmask`](https://www.terraform.io/language/functions/cidrnetmask) function
- `net.CidrSubnets` to return a list of subnets from give CIDR and new netmask bits, based on Terraform [`cidrsubnet `](https://www.terraform.io/language/functions/cidrsubnet) function
- `net.CidrSubnetSizes` to calculate a sequence of consecutive IP address ranges within a particular CIDR prefix, based on Terraform [`cidrsubnets`](https://www.terraform.io/language/functions/cidrsubnets) function