### PR TITLE
New tmpl.Path/tmpl.PathDir functions

### DIFF
--- a/docs-src/content/functions/tmpl.yml
+++ b/docs-src/content/functions/tmpl.yml
@@ -55,3 +55,42 @@ funcs:
         '
         hello world
         goodbye world
+  - name: tmpl.Path
+    description: |
+      Output the path of the current template, if it came from a file. For
+      inline templates, this will be an empty string.
+
+      Note that if this function is called from a nested template, the path
+      of the main template will be returned instead.
+    pipeline: false
+    rawExamples:
+      - |
+        _`subdir/input.tpl`:_
+        ```
+        this template is in {{ tmpl.Path }}
+        ```
+
+        ```console
+        $ gomplate -f subdir/input.tpl
+        this template is in subdir/input.tpl
+        ```
+        ```
+  - name: tmpl.PathDir
+    description: |
+      Output the current template's directory. For inline templates, this will
+      be an empty string.
+
+      Note that if this function is called from a nested template, the path
+      of the main template will be used instead.
+    pipeline: false
+    rawExamples:
+      - |
+        _`subdir/input.tpl`:_
+        ```
+        this template is in {{ tmpl.Dir }}
+        ```
+
+        ```console
+        $ gomplate -f subdir/input.tpl
+        this template is in subdir
+        ```

--- a/docs/content/functions/tmpl.md
+++ b/docs/content/functions/tmpl.md
@@ -80,3 +80,58 @@ $ gomplate -i '
 hello world
 goodbye world
 ```
+
+## `tmpl.Path`
+
+Output the path of the current template, if it came from a file. For
+inline templates, this will be an empty string.
+
+Note that if this function is called from a nested template, the path
+of the main template will be returned instead.
+
+### Usage
+
+```go
+tmpl.Path
+```
+
+
+### Examples
+
+_`subdir/input.tpl`:_
+```
+this template is in {{ tmpl.Path }}
+```
+
+```console
+$ gomplate -f subdir/input.tpl
+this template is in subdir/input.tpl
+```
+```
+
+## `tmpl.PathDir`
+
+Output the current template's directory. For inline templates, this will
+be an empty string.
+
+Note that if this function is called from a nested template, the path
+of the main template will be used instead.
+
+### Usage
+
+```go
+tmpl.PathDir
+```
+
+
+### Examples
+
+_`subdir/input.tpl`:_
+```
+this template is in {{ tmpl.Dir }}
+```
+
+```console
+$ gomplate -f subdir/input.tpl
+this template is in subdir
+```

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -3,6 +3,7 @@ package tmpl
 
 import (
 	"bytes"
+	"path/filepath"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -12,11 +13,28 @@ import (
 type Template struct {
 	root       *template.Template
 	defaultCtx interface{}
+	path       string
 }
 
 // New -
-func New(root *template.Template, ctx interface{}) *Template {
-	return &Template{root, ctx}
+func New(root *template.Template, tctx interface{}, path string) *Template {
+	return &Template{root, tctx, path}
+}
+
+// Path - returns the path to the current template if it came from a file.
+// An empty string is returned for inline templates.
+func (t *Template) Path() (string, error) {
+	return t.path, nil
+}
+
+// PathDir - returns the directory of the template, if it came from a file. An empty
+// string is returned for inline templates. If the template was loaded from the
+// current working directory, "." is returned.
+func (t *Template) PathDir() (string, error) {
+	if t.path == "" {
+		return "", nil
+	}
+	return filepath.Dir(t.path), nil
 }
 
 // Inline - a template function to do inline template processing

--- a/tmpl/tmpl_test.go
+++ b/tmpl/tmpl_test.go
@@ -29,7 +29,7 @@ func TestInline(t *testing.T) {
 
 func TestParseArgs(t *testing.T) {
 	defaultCtx := map[string]string{"hello": "world"}
-	tmpl := New(nil, defaultCtx)
+	tmpl := New(nil, defaultCtx, "")
 	name, in, ctx, err := tmpl.parseArgs("foo")
 	assert.NoError(t, err)
 	assert.Equal(t, "<inline>", name)
@@ -87,4 +87,35 @@ func TestExec(t *testing.T) {
 
 	_, err = tmpl.Exec("bogus")
 	assert.Error(t, err)
+}
+
+func TestPath(t *testing.T) {
+	tmpl := New(nil, nil, "")
+
+	p, err := tmpl.Path()
+	assert.NoError(t, err)
+	assert.Equal(t, "", p)
+
+	tmpl = New(nil, nil, "foo")
+	p, err = tmpl.Path()
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", p)
+}
+
+func TestPathDir(t *testing.T) {
+	tmpl := New(nil, nil, "")
+
+	p, err := tmpl.PathDir()
+	assert.NoError(t, err)
+	assert.Equal(t, "", p)
+
+	tmpl = New(nil, nil, "foo")
+	p, err = tmpl.PathDir()
+	assert.NoError(t, err)
+	assert.Equal(t, ".", p)
+
+	tmpl = New(nil, nil, "foo/bar")
+	p, err = tmpl.PathDir()
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", p)
 }


### PR DESCRIPTION
Fixes #1363 

Two new functions to output the path and directory of the current template.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>