### PR TITLE
Add ECDSA generation functions to crypto funcs

### DIFF
--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -1,0 +1,72 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// ECDSAGenerateKey -
+func ECDSAGenerateKey(curve string) ([]byte, error) {
+	var c elliptic.Curve
+
+	if curve == "P-224" {
+		c = elliptic.P224()
+	} else if curve == "P-256" {
+		c = elliptic.P256()
+	} else if curve == "P-384" {
+		c = elliptic.P384()
+	} else if curve == "P-521" {
+		c = elliptic.P521()
+	} else {
+		return nil, fmt.Errorf("unknow curve: %s", curve)
+	}
+
+	priv, err := ecdsa.GenerateKey(c, rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA private key: %w", err)
+	}
+	der, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ECDSA private key: %w", err)
+	}
+	block := &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: der,
+	}
+	buf := &bytes.Buffer{}
+	err = pem.Encode(buf, block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode generated ECDSA private key: pem encoding failed: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ECDSADerivePublicKey -
+func ECDSADerivePublicKey(privatekey []byte) ([]byte, error) {
+	block, _ := pem.Decode(privatekey)
+	if block == nil {
+		return nil, fmt.Errorf("failed to read key: no key found")
+	}
+
+	priv, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key: %w", err)
+	}
+
+	b, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal PKIX public key: %w", err)
+	}
+
+	block = &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: b,
+	}
+
+	return pem.EncodeToMemory(block), nil
+}

--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -14,15 +14,16 @@ import (
 func ECDSAGenerateKey(curve string) ([]byte, error) {
 	var c elliptic.Curve
 
-	if curve == "P-224" {
+	switch curve {
+	case "P-224":
 		c = elliptic.P224()
-	} else if curve == "P-256" {
+	case "P-256":
 		c = elliptic.P256()
-	} else if curve == "P-384" {
+	case "P-384":
 		c = elliptic.P384()
-	} else if curve == "P-521" {
+	case "P-521":
 		c = elliptic.P521()
-	} else {
+	default:
 		return nil, fmt.Errorf("unknow curve: %s", curve)
 	}
 

--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -10,40 +10,39 @@ import (
 	"fmt"
 )
 
-// ECDSAGenerateKey -
-func ECDSAGenerateKey(curve string) ([]byte, error) {
-	var c elliptic.Curve
-
-	switch curve {
-	case "P-224":
-		c = elliptic.P224()
-	case "P-256":
-		c = elliptic.P256()
-	case "P-384":
-		c = elliptic.P384()
-	case "P-521":
-		c = elliptic.P521()
-	default:
-		return nil, fmt.Errorf("unknow curve: %s", curve)
+var (
+	// Curves is a map of curve names to curves
+	Curves = map[string]elliptic.Curve{
+		"P224": elliptic.P224(),
+		"P256": elliptic.P256(),
+		"P384": elliptic.P384(),
+		"P521": elliptic.P521(),
 	}
+)
 
-	priv, err := ecdsa.GenerateKey(c, rand.Reader)
+// ECDSAGenerateKey -
+func ECDSAGenerateKey(curve elliptic.Curve) ([]byte, error) {
+	priv, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ECDSA private key: %w", err)
 	}
+
 	der, err := x509.MarshalECPrivateKey(priv)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal ECDSA private key: %w", err)
 	}
+
 	block := &pem.Block{
 		Type:  "EC PRIVATE KEY",
 		Bytes: der,
 	}
 	buf := &bytes.Buffer{}
+
 	err = pem.Encode(buf, block)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode generated ECDSA private key: pem encoding failed: %w", err)
 	}
+
 	return buf.Bytes(), nil
 }
 

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -1,0 +1,82 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func genECDSAPrivKey() (*ecdsa.PrivateKey, string) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	der, _ := x509.MarshalECPrivateKey(priv)
+	privBlock := &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: der,
+	}
+	return priv, string(pem.EncodeToMemory(privBlock))
+}
+
+func deriveECPubkey(priv *ecdsa.PrivateKey) string {
+	b, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	pubBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: b,
+	}
+	testPubKey := string(pem.EncodeToMemory(pubBlock))
+	return testPubKey
+}
+
+func TestECDSAGenerateKey(t *testing.T) {
+	key, err := ECDSAGenerateKey("P-224")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(key),
+		"-----BEGIN EC PRIVATE KEY-----"))
+	assert.True(t, strings.HasSuffix(string(key),
+		"-----END EC PRIVATE KEY-----\n"))
+
+	key, err = ECDSAGenerateKey("P-256")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(key),
+		"-----BEGIN EC PRIVATE KEY-----"))
+	assert.True(t, strings.HasSuffix(string(key),
+		"-----END EC PRIVATE KEY-----\n"))
+
+	key, err = ECDSAGenerateKey("P-384")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(key),
+		"-----BEGIN EC PRIVATE KEY-----"))
+	assert.True(t, strings.HasSuffix(string(key),
+		"-----END EC PRIVATE KEY-----\n"))
+
+	key, err = ECDSAGenerateKey("P-521")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(key),
+		"-----BEGIN EC PRIVATE KEY-----"))
+	assert.True(t, strings.HasSuffix(string(key),
+		"-----END EC PRIVATE KEY-----\n"))
+
+	key, err = ECDSAGenerateKey("P-999")
+	assert.Error(t, err)
+}
+
+func TestECDSADerivePublicKey(t *testing.T) {
+	_, err := ECDSADerivePublicKey(nil)
+	assert.Error(t, err)
+
+	_, err = ECDSADerivePublicKey([]byte(`-----BEGIN FOO-----
+	-----END FOO-----`))
+	assert.Error(t, err)
+
+	priv, privKey := genECDSAPrivKey()
+	expected := deriveECPubkey(priv)
+
+	actual, err := ECDSADerivePublicKey([]byte(privKey))
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(actual))
+}

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -33,36 +33,33 @@ func deriveECPubkey(priv *ecdsa.PrivateKey) string {
 }
 
 func TestECDSAGenerateKey(t *testing.T) {
-	key, err := ECDSAGenerateKey("P-224")
+	key, err := ECDSAGenerateKey(elliptic.P224())
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(key),
 		"-----BEGIN EC PRIVATE KEY-----"))
 	assert.True(t, strings.HasSuffix(string(key),
 		"-----END EC PRIVATE KEY-----\n"))
 
-	key, err = ECDSAGenerateKey("P-256")
+	key, err = ECDSAGenerateKey(elliptic.P256())
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(key),
 		"-----BEGIN EC PRIVATE KEY-----"))
 	assert.True(t, strings.HasSuffix(string(key),
 		"-----END EC PRIVATE KEY-----\n"))
 
-	key, err = ECDSAGenerateKey("P-384")
+	key, err = ECDSAGenerateKey(elliptic.P384())
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(key),
 		"-----BEGIN EC PRIVATE KEY-----"))
 	assert.True(t, strings.HasSuffix(string(key),
 		"-----END EC PRIVATE KEY-----\n"))
 
-	key, err = ECDSAGenerateKey("P-521")
+	key, err = ECDSAGenerateKey(elliptic.P521())
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(string(key),
 		"-----BEGIN EC PRIVATE KEY-----"))
 	assert.True(t, strings.HasSuffix(string(key),
 		"-----END EC PRIVATE KEY-----\n"))
-
-	_, err = ECDSAGenerateKey("P-999")
-	assert.Error(t, err)
 }
 
 func TestECDSADerivePublicKey(t *testing.T) {

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -61,7 +61,7 @@ func TestECDSAGenerateKey(t *testing.T) {
 	assert.True(t, strings.HasSuffix(string(key),
 		"-----END EC PRIVATE KEY-----\n"))
 
-	key, err = ECDSAGenerateKey("P-999")
+	_, err = ECDSAGenerateKey("P-999")
 	assert.Error(t, err)
 }
 

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -103,6 +103,52 @@ funcs:
       - |
         $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Encode }}'
         MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
+  - name: crypto.ECDSAGenerateKey
+    experimental: true
+    description: |
+      Generate a new Elliptic Curve Private Key and output in
+      PEM-encoded PKCS#1 ASN.1 DER form.
+
+      Go's standard NIST P-224, P-256, P-384, and P-521 elliptic curves are all
+      supported.
+
+      Default curve is P-256 and can be overridden with the optional `curve`
+      parameter.
+    pipeline: true
+    arguments:
+      - name: curve
+        required: false
+        description: |
+          One of Go's standard NIST curves, P-224, P-256, P-384, or P-521 -
+          defaults to P-256.
+    examples:
+      - |
+        $ gomplate -i '{{ crypto.ECDSAGenerateKey }}'
+        -----BEGIN EC PRIVATE KEY-----
+        ...
+      - |
+        $ gomplate -i '{{ $key := crypto.ECDSAGenerateKey "P-521" -}}
+          {{ $pub := crypto.ECDSADerivePublicKey $key -}}'
+        hello
+  - name: crypto.ECDSADerivePublicKey
+    experimental: true
+    description: |
+      Derive a public key from an elliptic curve private key and output in PKIX
+      ASN.1 DER form.
+    pipeline: true
+    arguments:
+      - name: key
+        required: true
+        description: the private key to derive a public key from
+    examples:
+      - |
+        $ gomplate -i '{{ crypto.ECDSAGenerateKey | crypto.ECDSADerivePublicKey }}'
+        -----BEGIN PUBLIC KEY-----
+        ...
+      - |
+        $ gomplate -c privKey=./privKey.pem \
+          -i '{{ $pub := crypto.ECDSADerivePublicKey .privKey -}}'
+        hello
   - name: crypto.PBKDF2
     description: |
       Run the Password-Based Key Derivation Function &num;2 as defined in
@@ -290,7 +336,7 @@ funcs:
           {{ $enc := "hello" | crypto.RSAEncrypt $pub -}}
           {{ crypto.RSADecrypt .privKey $enc }}'
         hello
-  - rawName: '`crypto.SHA1`, `crypto.SHA224`, `crypto.SHA256`, `crypto.SHA384`, `crypto.SHA512`, `crypto.SHA512_224`, `crypto.SHA512_256`'
+  - rawName: "`crypto.SHA1`, `crypto.SHA224`, `crypto.SHA256`, `crypto.SHA384`, `crypto.SHA512`, `crypto.SHA512_224`, `crypto.SHA512_256`"
     description: |
       Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
 
@@ -319,7 +365,7 @@ funcs:
       - |
         $ gomplate -i '{{ crypto.SHA512 "bar" }}'
         cc06808cbbee0510331aa97974132e8dc296aeb795be229d064bae784b0a87a5cf4281d82e8c99271b75db2148f08a026c1a60ed9cabdb8cac6d24242dac4063
-  - rawName: '`crypto.SHA1Bytes`, `crypto.SHA224Bytes`, `crypto.SHA256Bytes`, `crypto.SHA384Bytes`, `crypto.SHA512Bytes`, `crypto.SHA512_224Bytes`, `crypto.SHA512_256Bytes`'
+  - rawName: "`crypto.SHA1Bytes`, `crypto.SHA224Bytes`, `crypto.SHA256Bytes`, `crypto.SHA384Bytes`, `crypto.SHA512Bytes`, `crypto.SHA512_224Bytes`, `crypto.SHA512_256Bytes`"
     description: |
       Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
 

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -126,10 +126,6 @@ funcs:
         $ gomplate -i '{{ crypto.ECDSAGenerateKey }}'
         -----BEGIN EC PRIVATE KEY-----
         ...
-      - |
-        $ gomplate -i '{{ $key := crypto.ECDSAGenerateKey "P-521" -}}
-          {{ $pub := crypto.ECDSADerivePublicKey $key -}}'
-        hello
   - name: crypto.ECDSADerivePublicKey
     experimental: true
     description: |
@@ -146,9 +142,13 @@ funcs:
         -----BEGIN PUBLIC KEY-----
         ...
       - |
-        $ gomplate -c privKey=./privKey.pem \
-          -i '{{ $pub := crypto.ECDSADerivePublicKey .privKey -}}'
-        hello
+        $ gomplate -d key=priv.pem -i '{{ crypto.ECDSADerivePublicKey (include "key") }}'
+        -----BEGIN PUBLIC KEY-----
+        MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBZvTS1wcCJSsGYQUVoSVctynkuhke
+        kikB38iNwx/80jzdm+Z8OmRGlwH6OE9NX1MyxjvYMimhcj6zkaOKh1/HhMABrfuY
+        +hIz6+EUt/Db51awO7iCuRly5L4TZ+CnMAsIbtUOqsqwSQDtv0AclAuogmCst75o
+        aztsmrD79OXXnhUlURI=
+        -----END PUBLIC KEY-----
   - name: crypto.PBKDF2
     description: |
       Run the Password-Based Key Derivation Function &num;2 as defined in

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -151,6 +151,85 @@ $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Enc
 MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
 ```
 
+## `crypto.ECDSAGenerateKey` _(experimental)_
+**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+
+[experimental]: ../config/#experimental
+
+Generate a new Elliptic Curve Private Key and output in
+PEM-encoded PKCS#1 ASN.1 DER form.
+
+Go's standard NIST P-224, P-256, P-384, and P-521 elliptic curves are all
+supported.
+
+Default curve is P-256 and can be overridden with the optional `curve`
+parameter.
+
+### Usage
+
+```go
+crypto.ECDSAGenerateKey [curve]
+```
+```go
+curve | crypto.ECDSAGenerateKey
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `curve` | _(optional)_ One of Go's standard NIST curves, P-224, P-256, P-384, or P-521 -
+defaults to P-256.
+ |
+
+### Examples
+
+```console
+$ gomplate -i '{{ crypto.ECDSAGenerateKey }}'
+-----BEGIN EC PRIVATE KEY-----
+...
+```
+
+## `crypto.ECDSADerivePublicKey` _(experimental)_
+**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+
+[experimental]: ../config/#experimental
+
+Derive a public key from an elliptic curve private key and output in PKIX
+ASN.1 DER form.
+
+### Usage
+
+```go
+crypto.ECDSADerivePublicKey key
+```
+```go
+key | crypto.ECDSADerivePublicKey
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `key` | _(required)_ the private key to derive a public key from |
+
+### Examples
+
+```console
+$ gomplate -i '{{ crypto.ECDSAGenerateKey | crypto.ECDSADerivePublicKey }}'
+-----BEGIN PUBLIC KEY-----
+...
+```
+```console
+$ gomplate -d key=priv.pem -i '{{ crypto.ECDSADerivePublicKey (include "key") }}'
+-----BEGIN PUBLIC KEY-----
+MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBZvTS1wcCJSsGYQUVoSVctynkuhke
+kikB38iNwx/80jzdm+Z8OmRGlwH6OE9NX1MyxjvYMimhcj6zkaOKh1/HhMABrfuY
++hIz6+EUt/Db51awO7iCuRly5L4TZ+CnMAsIbtUOqsqwSQDtv0AclAuogmCst75o
+aztsmrD79OXXnhUlURI=
+-----END PUBLIC KEY-----
+```
+
 ## `crypto.PBKDF2`
 
 Run the Password-Based Key Derivation Function &num;2 as defined in

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -3,10 +3,12 @@ package funcs
 import (
 	"context"
 	gcrypto "crypto"
+	"crypto/elliptic"
 	"crypto/sha1" //nolint: gosec
 	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
+	"strings"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -250,26 +252,38 @@ func (f *CryptoFuncs) RSADerivePublicKey(privateKey string) (string, error) {
 	return string(out), err
 }
 
-// ECDSAGenerateKey - -
+// ECDSAGenerateKey -
 // Experimental!
 func (f *CryptoFuncs) ECDSAGenerateKey(args ...interface{}) (string, error) {
 	if err := checkExperimental(f.ctx); err != nil {
 		return "", err
 	}
-	curve := "P-256"
+
+	curve := elliptic.P256()
 	if len(args) == 1 {
-		curve = conv.ToString(args[0])
+		c := conv.ToString(args[0])
+		c = strings.ToUpper(c)
+		c = strings.ReplaceAll(c, "-", "")
+		var ok bool
+		curve, ok = crypto.Curves[c]
+		if !ok {
+			return "", fmt.Errorf("unknown curve: %s", c)
+		}
 	} else if len(args) > 1 {
 		return "", fmt.Errorf("wrong number of args: want 0 or 1, got %d", len(args))
 	}
+
 	out, err := crypto.ECDSAGenerateKey(curve)
 	return string(out), err
 }
 
+// ECDSADerivePublicKey -
+// Experimental!
 func (f *CryptoFuncs) ECDSADerivePublicKey(privateKey string) (string, error) {
 	if err := checkExperimental(f.ctx); err != nil {
 		return "", err
 	}
+
 	out, err := crypto.ECDSADerivePublicKey([]byte(privateKey))
 	return string(out), err
 }

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -250,6 +250,30 @@ func (f *CryptoFuncs) RSADerivePublicKey(privateKey string) (string, error) {
 	return string(out), err
 }
 
+// ECDSAGenerateKey - -
+// Experimental!
+func (f *CryptoFuncs) ECDSAGenerateKey(args ...interface{}) (string, error) {
+	if err := checkExperimental(f.ctx); err != nil {
+		return "", err
+	}
+	curve := "P-256"
+	if len(args) == 1 {
+		curve = conv.ToString(args[0])
+	} else if len(args) > 1 {
+		return "", fmt.Errorf("wrong number of args: want 0 or 1, got %d", len(args))
+	}
+	out, err := crypto.ECDSAGenerateKey(curve)
+	return string(out), err
+}
+
+func (f *CryptoFuncs) ECDSADerivePublicKey(privateKey string) (string, error) {
+	if err := checkExperimental(f.ctx); err != nil {
+		return "", err
+	}
+	out, err := crypto.ECDSADerivePublicKey([]byte(privateKey))
+	return string(out), err
+}
+
 // EncryptAES -
 func (f *CryptoFuncs) EncryptAES(key string, args ...interface{}) ([]byte, error) {
 	k, msg, err := parseAESArgs(key, args...)

--- a/funcs/crypto_test.go
+++ b/funcs/crypto_test.go
@@ -115,6 +115,37 @@ func TestRSAGenerateKey(t *testing.T) {
 		"-----END RSA PRIVATE KEY-----\n"))
 }
 
+func TestECDSAGenerateKey(t *testing.T) {
+	c := testCryptoNS()
+	_, err := c.ECDSAGenerateKey("")
+	assert.Error(t, err)
+
+	_, err = c.ECDSAGenerateKey(0, "P-999", true)
+	assert.Error(t, err)
+
+	key, err := c.ECDSAGenerateKey("P-256")
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(key,
+		"-----BEGIN EC PRIVATE KEY-----"))
+	assert.True(t, strings.HasSuffix(key,
+		"-----END EC PRIVATE KEY-----\n"))
+}
+
+func TestECDSADerivePublicKey(t *testing.T) {
+	c := testCryptoNS()
+
+	_, err := c.ECDSADerivePublicKey("")
+	assert.Error(t, err)
+
+	key, _ := c.ECDSAGenerateKey("P-256")
+	pub, err := c.ECDSADerivePublicKey(key)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(pub,
+		"-----BEGIN PUBLIC KEY-----"))
+	assert.True(t, strings.HasSuffix(pub,
+		"-----END PUBLIC KEY-----\n"))
+}
+
 func TestRSACrypt(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow test")


### PR DESCRIPTION
ECDSAGenerateKey takes one of Go's supported named NIST curves and an
argument and returns a newly generated EC private key PEM encoded.

ECDSADerivePublicKey takes a PEM encoded EC private key and derives the
corresponding public key, which is returned PEM encoded.