### PR TITLE
Add support for aws imdsv2

### DIFF
--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestTag_MissingKey(t *testing.T) {
-	server, ec2meta := MockServer(200, `"i-1234"`)
-	defer server.Close()
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
 			{
@@ -39,8 +39,8 @@ func TestTag_MissingKey(t *testing.T) {
 }
 
 func TestTag_ValidKey(t *testing.T) {
-	server, ec2meta := MockServer(200, `"i-1234"`)
-	defer server.Close()
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
 			{
@@ -66,8 +66,7 @@ func TestTag_ValidKey(t *testing.T) {
 }
 
 func TestTags(t *testing.T) {
-	server, ec2meta := MockServer(200, `"i-1234"`)
-	defer server.Close()
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
 			{
@@ -92,9 +91,9 @@ func TestTags(t *testing.T) {
 }
 
 func TestTag_NonEC2(t *testing.T) {
-	server, ec2meta := MockServer(404, "")
+	ec2meta := MockEC2Meta(nil, "")
 	ec2meta.nonAWS = true
-	defer server.Close()
+
 	client := DummyInstanceDescriber{}
 	e := &Ec2Info{
 		describer: func() (InstanceDescriber, error) {
@@ -109,8 +108,7 @@ func TestTag_NonEC2(t *testing.T) {
 }
 
 func TestNewEc2Info(t *testing.T) {
-	server, ec2meta := MockServer(200, `"i-1234"`)
-	defer server.Close()
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
 			{
@@ -161,8 +159,8 @@ func TestGetRegion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "unknown", region)
 
-	server, ec2meta := MockServer(200, `{"region":"us-east-1"}`)
-	defer server.Close()
+	ec2meta := MockEC2Meta(nil, "us-east-1")
+
 	region, err = getRegion(ec2meta)
 	assert.NoError(t, err)
 	assert.Equal(t, "us-east-1", region)

--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTag_MissingKey(t *testing.T) {
-	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, nil, "")
 
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
@@ -39,7 +39,7 @@ func TestTag_MissingKey(t *testing.T) {
 }
 
 func TestTag_ValidKey(t *testing.T) {
-	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, nil, "")
 
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
@@ -66,7 +66,7 @@ func TestTag_ValidKey(t *testing.T) {
 }
 
 func TestTags(t *testing.T) {
-	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, nil, "")
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
 			{
@@ -91,7 +91,7 @@ func TestTags(t *testing.T) {
 }
 
 func TestTag_NonEC2(t *testing.T) {
-	ec2meta := MockEC2Meta(nil, "")
+	ec2meta := MockEC2Meta(nil, nil, "")
 	ec2meta.nonAWS = true
 
 	client := DummyInstanceDescriber{}
@@ -108,7 +108,7 @@ func TestTag_NonEC2(t *testing.T) {
 }
 
 func TestNewEc2Info(t *testing.T) {
-	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, nil, "")
 	client := DummyInstanceDescriber{
 		tags: []*ec2.Tag{
 			{
@@ -159,7 +159,7 @@ func TestGetRegion(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "unknown", region)
 
-	ec2meta := MockEC2Meta(nil, "us-east-1")
+	ec2meta := MockEC2Meta(nil, nil, "us-east-1")
 
 	region, err = getRegion(ec2meta)
 	assert.NoError(t, err)

--- a/aws/ec2meta.go
+++ b/aws/ec2meta.go
@@ -20,9 +20,8 @@ var ec2metadataClient EC2Metadata
 // Ec2Meta -
 type Ec2Meta struct {
 	cache               map[string]string
-	nonAWS              bool
-	ec2meta             *ec2metadata.EC2Metadata
 	ec2MetadataProvider func() (EC2Metadata, error)
+	nonAWS              bool
 }
 
 type EC2Metadata interface {
@@ -41,7 +40,12 @@ func NewEc2Meta(options ClientOptions) *Ec2Meta {
 				if endpoint := env.Getenv("AWS_META_ENDPOINT"); endpoint != "" {
 					config = config.WithEndpoint(endpoint)
 				}
-				ec2metadataClient = ec2metadata.New(session.New(config))
+
+				s, err := session.NewSession(config)
+				if err != nil {
+					return nil, err
+				}
+				ec2metadataClient = ec2metadata.New(s)
 			}
 			return ec2metadataClient, nil
 		},

--- a/aws/ec2meta_test.go
+++ b/aws/ec2meta_test.go
@@ -71,5 +71,5 @@ func TestRetrieveMetadata_NonEC2(t *testing.T) {
 	ec2meta := NewEc2Meta(ClientOptions{})
 	ec2meta.nonAWS = true
 
-	assert.Equal(t, "foo", must(ec2meta.retrieveData(metaData, "", "foo")))
+	assert.Equal(t, "foo", must(ec2meta.retrieveMetadata("", "foo")))
 }

--- a/aws/ec2meta_test.go
+++ b/aws/ec2meta_test.go
@@ -15,47 +15,47 @@ func must(r interface{}, err error) interface{} {
 }
 
 func TestMeta_MissingKey(t *testing.T) {
-	ec2meta := MockEC2Meta(nil, "")
+	ec2meta := MockEC2Meta(nil, nil, "")
 
 	assert.Empty(t, must(ec2meta.Meta("foo")))
 	assert.Equal(t, "default", must(ec2meta.Meta("foo", "default")))
 }
 
 func TestMeta_ValidKey(t *testing.T) {
-	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, nil, "")
 
 	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id")))
 	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id", "unused default")))
 }
 
 func TestDynamic_MissingKey(t *testing.T) {
-	ec2meta := MockEC2Meta(nil, "")
+	ec2meta := MockEC2Meta(nil, nil, "")
 
 	assert.Empty(t, must(ec2meta.Dynamic("foo")))
 	assert.Equal(t, "default", must(ec2meta.Dynamic("foo", "default")))
 }
 
 func TestDynamic_ValidKey(t *testing.T) {
-	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
+	ec2meta := MockEC2Meta(nil, map[string]string{"instance-id": "i-1234"}, "")
 
 	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id")))
 	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id", "unused default")))
 }
 
 func TestRegion_NoRegion(t *testing.T) {
-	ec2meta := MockEC2Meta(nil, "")
+	ec2meta := MockEC2Meta(nil, nil, "")
 
 	assert.Equal(t, "unknown", must(ec2meta.Region()))
 }
 
 func TestRegion_NoRegionWithDefault(t *testing.T) {
-	ec2meta := MockEC2Meta(nil, "")
+	ec2meta := MockEC2Meta(nil, nil, "")
 
 	assert.Equal(t, "foo", must(ec2meta.Region("foo")))
 }
 
 func TestRegion_KnownRegion(t *testing.T) {
-	ec2meta := MockEC2Meta(nil, "us-east-1")
+	ec2meta := MockEC2Meta(nil, nil, "us-east-1")
 
 	assert.Equal(t, "us-east-1", must(ec2meta.Region()))
 }
@@ -71,5 +71,5 @@ func TestRetrieveMetadata_NonEC2(t *testing.T) {
 	ec2meta := NewEc2Meta(ClientOptions{})
 	ec2meta.nonAWS = true
 
-	assert.Equal(t, "foo", must(ec2meta.retrieveMetadata("", "foo")))
+	assert.Equal(t, "foo", must(ec2meta.retrieveData(metaData, "", "foo")))
 }

--- a/aws/ec2meta_test.go
+++ b/aws/ec2meta_test.go
@@ -15,54 +15,47 @@ func must(r interface{}, err error) interface{} {
 }
 
 func TestMeta_MissingKey(t *testing.T) {
-	server, ec2meta := MockServer(404, "")
-	defer server.Close()
+	ec2meta := MockEC2Meta(nil, "")
 
 	assert.Empty(t, must(ec2meta.Meta("foo")))
 	assert.Equal(t, "default", must(ec2meta.Meta("foo", "default")))
 }
 
 func TestMeta_ValidKey(t *testing.T) {
-	server, ec2meta := MockServer(200, "i-1234")
-	defer server.Close()
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
 
 	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id")))
 	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id", "unused default")))
 }
 
 func TestDynamic_MissingKey(t *testing.T) {
-	server, ec2meta := MockServer(404, "")
-	defer server.Close()
+	ec2meta := MockEC2Meta(nil, "")
 
 	assert.Empty(t, must(ec2meta.Dynamic("foo")))
 	assert.Equal(t, "default", must(ec2meta.Dynamic("foo", "default")))
 }
 
 func TestDynamic_ValidKey(t *testing.T) {
-	server, ec2meta := MockServer(200, "i-1234")
-	defer server.Close()
+	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, "")
 
 	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id")))
 	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id", "unused default")))
 }
 
 func TestRegion_NoRegion(t *testing.T) {
-	server, ec2meta := MockServer(200, "{}")
-	defer server.Close()
+	ec2meta := MockEC2Meta(nil, "")
 
 	assert.Equal(t, "unknown", must(ec2meta.Region()))
 }
 
 func TestRegion_NoRegionWithDefault(t *testing.T) {
-	server, ec2meta := MockServer(200, "{}")
-	defer server.Close()
+	ec2meta := MockEC2Meta(nil, "")
 
 	assert.Equal(t, "foo", must(ec2meta.Region("foo")))
 }
 
 func TestRegion_KnownRegion(t *testing.T) {
-	server, ec2meta := MockServer(200, `{"region":"us-east-1"}`)
-	defer server.Close()
+	ec2meta := MockEC2Meta(nil, "us-east-1")
 
 	assert.Equal(t, "us-east-1", must(ec2meta.Region()))
 }

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -58,8 +58,8 @@ func (d DummyInstanceDescriber) DescribeInstances(*ec2.DescribeInstancesInput) (
 }
 
 type DummEC2MetadataProvider struct {
-	region string
 	data   map[string]string
+	region string
 }
 
 func (d DummEC2MetadataProvider) GetMetadata(p string) (string, error) {

--- a/aws/testutils.go
+++ b/aws/testutils.go
@@ -9,7 +9,8 @@ import (
 // MockEC2Meta -
 func MockEC2Meta(data map[string]string, dynamicData map[string]string, region string) *Ec2Meta {
 	return &Ec2Meta{
-		cache: map[string]string{},
+		metadataCache:    map[string]string{},
+		dynamicdataCache: map[string]string{},
 		ec2MetadataProvider: func() (EC2Metadata, error) {
 			return &DummEC2MetadataProvider{
 				data:        data,

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -53,7 +53,7 @@ func TestBoolTemplates(t *testing.T) {
 
 func TestEc2MetaTemplates(t *testing.T) {
 	createGomplate := func(data map[string]string, region string) *gomplate {
-		ec2meta := aws.MockEC2Meta(data, region)
+		ec2meta := aws.MockEC2Meta(data, nil, region)
 		return &gomplate{funcMap: template.FuncMap{"ec2meta": ec2meta.Meta}}
 	}
 
@@ -67,7 +67,7 @@ func TestEc2MetaTemplates(t *testing.T) {
 }
 
 func TestEc2MetaTemplates_WithJSON(t *testing.T) {
-	ec2meta := aws.MockEC2Meta(map[string]string{"obj": `"foo": "bar"`}, "")
+	ec2meta := aws.MockEC2Meta(map[string]string{"obj": `"foo": "bar"`}, nil, "")
 
 	g := &gomplate{
 		funcMap: template.FuncMap{

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -67,7 +67,7 @@ func TestEc2MetaTemplates(t *testing.T) {
 }
 
 func TestEc2MetaTemplates_WithJSON(t *testing.T) {
-	ec2meta := aws.MockEC2Meta(map[string]string{"obj": `"foo": "bar"`}, nil, "")
+	ec2meta := aws.MockEC2Meta(map[string]string{"obj": `"foo": "bar"`}, map[string]string{"obj": `"foo": "baz"`}, "")
 
 	g := &gomplate{
 		funcMap: template.FuncMap{
@@ -78,7 +78,7 @@ func TestEc2MetaTemplates_WithJSON(t *testing.T) {
 	}
 
 	assert.Equal(t, "bar", testTemplate(t, g, `{{ (ec2meta "obj" | json).foo }}`))
-	assert.Equal(t, "bar", testTemplate(t, g, `{{ (ec2dynamic "obj" | json).foo }}`))
+	assert.Equal(t, "baz", testTemplate(t, g, `{{ (ec2dynamic "obj" | json).foo }}`))
 }
 
 func TestJSONArrayTemplates(t *testing.T) {


### PR DESCRIPTION
Changes:

* Start using the AWS SDK for retrieving instance data (to future proof against changes that might come in EC2 auth)
* Supports both IMDSv1 and IMDSv2 transparently

Fixes #848 