### PR TITLE
fix lint warning - it's OK that parseNetipPrefix isn't used yet

### DIFF
--- a/funcs/net.go
+++ b/funcs/net.go
@@ -103,6 +103,8 @@ func (f NetFuncs) parseStdnetIPNet(prefix interface{}) (*stdnet.IPNet, error) {
 	}
 }
 
+// TODO: look at using this instead of parseStdnetIPNet
+//nolint:unused
 func (f NetFuncs) parseNetipPrefix(prefix interface{}) (netip.Prefix, error) {
 	switch p := prefix.(type) {
 	case *stdnet.IPNet:


### PR DESCRIPTION
Signed-off-by: Dave Henderson <dhenderson@gmail.com>