### PR TITLE
New experimental gomplate.Renderer API

### DIFF
--- a/data/datasource.go
+++ b/data/datasource.go
@@ -140,6 +140,7 @@ func FromConfig(ctx context.Context, cfg *config.Config) *Data {
 }
 
 // Source - a data source
+// Deprecated: will be replaced in future
 type Source struct {
 	Alias             string
 	URL               *url.URL

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -269,8 +269,9 @@ Hello World
 
 All arguments provided to the function will be passed as positional arguments to
 the plugin, and the plugin's standard output stream (`Stdout`) will be printed
-to the rendered output. Currently there is no way to set the plugin's standard
-input stream (`Stdin`).
+to the rendered output. To instead pipe the final argument of the function to
+the plugin's standard input stream, use the [config file](../config/#plugins)
+and set the `pipe` field.
 
 If the plugin exits with a non-zero exit code, gomplate will also fail. All signals
 caught by gomplate will be propagated to the plugin. Any output on the standard

--- a/gomplate.go
+++ b/gomplate.go
@@ -6,8 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -16,47 +14,11 @@ import (
 	"github.com/hairyhenderson/gomplate/v3/data"
 	"github.com/hairyhenderson/gomplate/v3/internal/config"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
 )
-
-// gomplate -
-type gomplate struct {
-	tmplctx         interface{}
-	funcMap         template.FuncMap
-	nestedTemplates config.Templates
-
-	leftDelim, rightDelim string
-}
-
-// runTemplate -
-func (g *gomplate) runTemplate(ctx context.Context, t *tplate) error {
-	tmpl, err := t.toGoTemplate(ctx, g)
-	if err != nil {
-		return err
-	}
-
-	wr, ok := t.target.(io.Closer)
-	if ok && wr != os.Stdout {
-		defer wr.Close()
-	}
-
-	return tmpl.Execute(t.target, g.tmplctx)
-}
-
-// newGomplate -
-func newGomplate(funcMap template.FuncMap, leftDelim, rightDelim string, nested config.Templates, tctx interface{}) *gomplate {
-	return &gomplate{
-		leftDelim:       leftDelim,
-		rightDelim:      rightDelim,
-		funcMap:         funcMap,
-		nestedTemplates: nested,
-		tmplctx:         tctx,
-	}
-}
 
 // RunTemplates - run all gomplate templates specified by the given configuration
 //
-// Deprecated: use Run instead
+// Deprecated: use the Renderer interface instead
 func RunTemplates(o *Config) error {
 	cfg, err := o.toNewConfig()
 	if err != nil {
@@ -67,8 +29,6 @@ func RunTemplates(o *Config) error {
 
 // Run all gomplate templates specified by the given configuration
 func Run(ctx context.Context, cfg *config.Config) error {
-	log := zerolog.Ctx(ctx)
-
 	Metrics = newMetrics()
 	defer runCleanupHooks()
 
@@ -80,59 +40,43 @@ func Run(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to validate config: %w\n%+v", err, cfg)
 	}
 
-	d := data.FromConfig(ctx, cfg)
-	log.Debug().Str("data", fmt.Sprintf("%+v", d)).Msg("created data from config")
-
-	addCleanupHook(d.Cleanup)
-
-	aliases := []string{}
-	for k := range cfg.Context {
-		aliases = append(aliases, k)
-	}
-	c, err := createTmplContext(ctx, aliases, d)
-	if err != nil {
-		return err
-	}
-
-	funcMap := CreateFuncs(ctx, d)
+	funcMap := template.FuncMap{}
 	err = bindPlugins(ctx, cfg, funcMap)
 	if err != nil {
 		return err
 	}
-	g := newGomplate(funcMap, cfg.LDelim, cfg.RDelim, cfg.Templates, c)
 
-	return g.runTemplates(ctx, cfg)
-}
+	// if a custom Stdin is set in the config, inject it into the context now
+	ctx = data.ContextWithStdin(ctx, cfg.Stdin)
 
-func (g *gomplate) runTemplates(ctx context.Context, cfg *config.Config) error {
+	opts := optionsFromConfig(cfg)
+	opts.Funcs = funcMap
+	tr := NewRenderer(opts)
+
 	start := time.Now()
-	tmpl, err := gatherTemplates(ctx, cfg, chooseNamer(cfg, g))
+
+	namer := chooseNamer(cfg, tr)
+	tmpl, err := gatherTemplates(ctx, cfg, namer)
 	Metrics.GatherDuration = time.Since(start)
 	if err != nil {
 		Metrics.Errors++
 		return fmt.Errorf("failed to gather templates for rendering: %w", err)
 	}
 	Metrics.TemplatesGathered = len(tmpl)
-	start = time.Now()
-	defer func() { Metrics.TotalRenderDuration = time.Since(start) }()
-	for _, t := range tmpl {
-		tstart := time.Now()
-		err := g.runTemplate(ctx, t)
-		Metrics.RenderDuration[t.name] = time.Since(tstart)
-		if err != nil {
-			Metrics.Errors++
-			return fmt.Errorf("failed to render template %s: %w", t.name, err)
-		}
-		Metrics.TemplatesProcessed++
+
+	err = tr.RenderTemplates(ctx, tmpl)
+	if err != nil {
+		return err
 	}
+
 	return nil
 }
 
-func chooseNamer(cfg *config.Config, g *gomplate) func(context.Context, string) (string, error) {
+func chooseNamer(cfg *config.Config, tr *Renderer) func(context.Context, string) (string, error) {
 	if cfg.OutputMap == "" {
 		return simpleNamer(cfg.OutputDir)
 	}
-	return mappingNamer(cfg.OutputMap, g)
+	return mappingNamer(cfg.OutputMap, tr)
 }
 
 func simpleNamer(outDir string) func(ctx context.Context, inPath string) (string, error) {
@@ -142,21 +86,19 @@ func simpleNamer(outDir string) func(ctx context.Context, inPath string) (string
 	}
 }
 
-func mappingNamer(outMap string, g *gomplate) func(context.Context, string) (string, error) {
+func mappingNamer(outMap string, tr *Renderer) func(context.Context, string) (string, error) {
 	return func(ctx context.Context, inPath string) (string, error) {
-		out := &bytes.Buffer{}
-		t := &tplate{
-			name:     "<OutputMap>",
-			contents: outMap,
-			target:   out,
-		}
-		tpl, err := t.toGoTemplate(ctx, g)
+		tr.data.Ctx = ctx
+		tcontext, err := createTmplContext(ctx, tr.tctxAliases, tr.data)
 		if err != nil {
 			return "", err
 		}
+
+		// add '.in' to the template context and preserve the original context
+		// in '.ctx'
 		tctx := &tmplctx{}
 		// nolint: gocritic
-		switch c := g.tmplctx.(type) {
+		switch c := tcontext.(type) {
 		case *tmplctx:
 			for k, v := range *c {
 				if k != "in" && k != "ctx" {
@@ -164,10 +106,12 @@ func mappingNamer(outMap string, g *gomplate) func(context.Context, string) (str
 				}
 			}
 		}
-		(*tctx)["ctx"] = g.tmplctx
+		(*tctx)["ctx"] = tcontext
 		(*tctx)["in"] = inPath
 
-		err = tpl.Execute(t.target, tctx)
+		out := &bytes.Buffer{}
+		err = tr.renderTemplatesWithData(ctx,
+			[]Template{{Name: "<OutputMap>", Text: outMap, Writer: out}}, tctx)
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to render outputMap with ctx %+v and inPath %s", tctx, inPath)
 		}

--- a/render.go
+++ b/render.go
@@ -1,0 +1,271 @@
+package gomplate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"text/template"
+	"time"
+
+	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v3/funcs" //nolint:staticcheck
+	"github.com/hairyhenderson/gomplate/v3/internal/config"
+)
+
+// Options for template rendering.
+//
+// Experimental: subject to breaking changes before the next major release
+type Options struct {
+	// Datasources - map of datasources to be read on demand when the
+	// 'datasource'/'ds'/'include' functions are used.
+	Datasources map[string]Datasource
+	// Context - map of datasources to be read immediately and added to the
+	// template's context
+	Context map[string]Datasource
+	// Templates - map of templates that can be referenced as nested templates
+	Templates map[string]Datasource
+
+	// Extra HTTP headers not attached to pre-defined datsources. Potentially
+	// used by datasources defined in the template.
+	ExtraHeaders map[string]http.Header
+
+	// Funcs - map of functions to be added to the default template functions.
+	// Duplicate functions will be overwritten by entries in this map.
+	Funcs template.FuncMap
+
+	// LeftDelim - set the left action delimiter for the template and all nested
+	// templates to the specified string. Defaults to "{{"
+	LDelim string
+	// RightDelim - set the right action delimiter for the template and all nested
+	// templates to the specified string. Defaults to "{{"
+	RDelim string
+
+	// Experimental - enable experimental features
+	Experimental bool
+}
+
+// optionsFromConfig - create a set of options from the internal config struct.
+// Does not set the Funcs field.
+func optionsFromConfig(cfg *config.Config) Options {
+	ds := make(map[string]Datasource, len(cfg.DataSources))
+	for k, v := range cfg.DataSources {
+		ds[k] = Datasource{
+			URL:    v.URL,
+			Header: v.Header,
+		}
+	}
+	cs := make(map[string]Datasource, len(cfg.Context))
+	for k, v := range cfg.Context {
+		cs[k] = Datasource{
+			URL:    v.URL,
+			Header: v.Header,
+		}
+	}
+	ts := make(map[string]Datasource, len(cfg.Templates))
+	for k, v := range cfg.Templates {
+		ts[k] = Datasource{
+			URL:    v.URL,
+			Header: v.Header,
+		}
+	}
+
+	opts := Options{
+		Datasources:  ds,
+		Context:      cs,
+		Templates:    ts,
+		ExtraHeaders: cfg.ExtraHeaders,
+		LDelim:       cfg.LDelim,
+		RDelim:       cfg.RDelim,
+		Experimental: cfg.Experimental,
+	}
+
+	return opts
+}
+
+// Datasource - a datasource URL with optional headers
+//
+// Experimental: subject to breaking changes before the next major release
+type Datasource struct {
+	URL    *url.URL
+	Header http.Header
+}
+
+// Renderer provides gomplate's core template rendering functionality.
+// It should be initialized with NewRenderer.
+//
+// Experimental: subject to breaking changes before the next major release
+type Renderer struct {
+	data        *data.Data
+	nested      config.Templates
+	funcs       template.FuncMap
+	lDelim      string
+	rDelim      string
+	tctxAliases []string
+}
+
+// NewRenderer creates a new template renderer with the specified options.
+// The returned renderer can be reused, but it is not (yet) safe for concurrent
+// use.
+//
+// Experimental: subject to breaking changes before the next major release
+func NewRenderer(opts Options) *Renderer {
+	if Metrics == nil {
+		Metrics = newMetrics()
+	}
+
+	tctxAliases := []string{}
+	sources := map[string]*data.Source{}
+
+	for alias, ds := range opts.Context {
+		tctxAliases = append(tctxAliases, alias)
+		sources[alias] = &data.Source{
+			Alias:  alias,
+			URL:    ds.URL,
+			Header: ds.Header,
+		}
+	}
+	for alias, ds := range opts.Datasources {
+		sources[alias] = &data.Source{
+			Alias:  alias,
+			URL:    ds.URL,
+			Header: ds.Header,
+		}
+	}
+
+	// convert the internal config.Templates to a map[string]Datasource
+	// TODO: simplify when config.Templates is removed
+	nested := config.Templates{}
+	for alias, ds := range opts.Templates {
+		nested[alias] = config.DataSource{
+			URL:    ds.URL,
+			Header: ds.Header,
+		}
+	}
+
+	d := &data.Data{
+		ExtraHeaders: opts.ExtraHeaders,
+		Sources:      sources,
+	}
+
+	// make sure data cleanups are run on exit
+	addCleanupHook(d.Cleanup)
+
+	if opts.Funcs == nil {
+		opts.Funcs = template.FuncMap{}
+	}
+
+	return &Renderer{
+		nested:      nested,
+		data:        d,
+		funcs:       opts.Funcs,
+		tctxAliases: tctxAliases,
+		lDelim:      opts.LDelim,
+		rDelim:      opts.RDelim,
+	}
+}
+
+// Template contains the basic data needed to render a template with a Renderer
+//
+// Experimental: subject to breaking changes before the next major release
+type Template struct {
+	// Writer is the writer to output the rendered template to. If this writer
+	// is a non-os.Stdout io.Closer, it will be closed after the template is
+	// rendered.
+	Writer io.Writer
+	// Name is the name of the template - used for error messages
+	Name string
+	// Text is the template text
+	Text string
+}
+
+// RenderTemplates renders a list of templates, parsing each template's Text
+// and executing it, outputting to its Writer. If a template's Writer is a
+// non-os.Stdout io.Closer, it will be closed after the template is rendered.
+//
+// Experimental: subject to breaking changes before the next major release
+func (t *Renderer) RenderTemplates(ctx context.Context, templates []Template) error {
+	// we need to inject the current context into the Data value, because
+	// the Datasource method may need it
+	// TODO: remove this in v4
+	t.data.Ctx = ctx
+
+	// configure the template context with the refreshed Data value
+	// only done here because the data context may have changed
+	tmplctx, err := createTmplContext(ctx, t.tctxAliases, t.data)
+	if err != nil {
+		return err
+	}
+
+	return t.renderTemplatesWithData(ctx, templates, tmplctx)
+}
+
+func (t *Renderer) renderTemplatesWithData(ctx context.Context, templates []Template, tmplctx interface{}) error {
+	// update funcs with the current context
+	// only done here to ensure the context is properly set in func namespaces
+	f := template.FuncMap{}
+	addToMap(f, funcs.CreateDataFuncs(ctx, t.data))
+	addToMap(f, funcs.CreateAWSFuncs(ctx))
+	addToMap(f, funcs.CreateGCPFuncs(ctx))
+	addToMap(f, funcs.CreateBase64Funcs(ctx))
+	addToMap(f, funcs.CreateNetFuncs(ctx))
+	addToMap(f, funcs.CreateReFuncs(ctx))
+	addToMap(f, funcs.CreateStringFuncs(ctx))
+	addToMap(f, funcs.CreateEnvFuncs(ctx))
+	addToMap(f, funcs.CreateConvFuncs(ctx))
+	addToMap(f, funcs.CreateTimeFuncs(ctx))
+	addToMap(f, funcs.CreateMathFuncs(ctx))
+	addToMap(f, funcs.CreateCryptoFuncs(ctx))
+	addToMap(f, funcs.CreateFileFuncs(ctx))
+	addToMap(f, funcs.CreateFilePathFuncs(ctx))
+	addToMap(f, funcs.CreatePathFuncs(ctx))
+	addToMap(f, funcs.CreateSockaddrFuncs(ctx))
+	addToMap(f, funcs.CreateTestFuncs(ctx))
+	addToMap(f, funcs.CreateCollFuncs(ctx))
+	addToMap(f, funcs.CreateUUIDFuncs(ctx))
+	addToMap(f, funcs.CreateRandomFuncs(ctx))
+
+	// add user-defined funcs last so they override the built-in funcs
+	addToMap(f, t.funcs)
+
+	// track some metrics for debug output
+	start := time.Now()
+	defer func() { Metrics.TotalRenderDuration = time.Since(start) }()
+	for _, template := range templates {
+		if template.Writer != nil {
+			wr, ok := template.Writer.(io.Closer)
+			if ok && wr != os.Stdout {
+				defer wr.Close()
+			}
+		}
+
+		tstart := time.Now()
+		tmpl, err := parseTemplate(ctx, template.Name, template.Text,
+			f, tmplctx, t.nested, t.lDelim, t.rDelim)
+		if err != nil {
+			return err
+		}
+
+		err = tmpl.Execute(template.Writer, tmplctx)
+		Metrics.RenderDuration[template.Name] = time.Since(tstart)
+		if err != nil {
+			Metrics.Errors++
+			return fmt.Errorf("failed to render template %s: %w", template.Name, err)
+		}
+		Metrics.TemplatesProcessed++
+	}
+	return nil
+}
+
+// Render is a convenience method for rendering a single template. For more
+// than one template, use RenderTemplates. If wr is a non-os.Stdout
+// io.Closer, it will be closed after the template is rendered.
+//
+// Experimental: subject to breaking changes before the next major release
+func (t *Renderer) Render(ctx context.Context, name, text string, wr io.Writer) error {
+	return t.RenderTemplates(ctx, []Template{
+		{Name: name, Text: text, Writer: wr},
+	})
+}

--- a/render_test.go
+++ b/render_test.go
@@ -1,0 +1,155 @@
+package gomplate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/hairyhenderson/go-fsimpl"
+	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	fsys := fstest.MapFS{}
+	ctx := ContextWithFSProvider(context.Background(),
+		fsimpl.WrappedFSProvider(fsys, "mem"))
+
+	// no options - built-in function
+	tr := NewRenderer(Options{})
+	out := &bytes.Buffer{}
+	err := tr.Render(ctx, "test", "{{ `hello world` | toUpper }}", out)
+	assert.NoError(t, err)
+	assert.Equal(t, "HELLO WORLD", out.String())
+
+	// with datasource and context
+	hu, _ := url.Parse("stdin:")
+	wu, _ := url.Parse("env:WORLD")
+
+	os.Setenv("WORLD", "world")
+	defer os.Unsetenv("WORLD")
+
+	tr = NewRenderer(Options{
+		Context: map[string]Datasource{
+			"hi": {URL: hu},
+		},
+		Datasources: map[string]Datasource{
+			"world": {URL: wu},
+		},
+	})
+	ctx = data.ContextWithStdin(ctx, strings.NewReader("hello"))
+	out = &bytes.Buffer{}
+	err = tr.Render(ctx, "test", `{{ .hi | toUpper }} {{ (ds "world") | toUpper }}`, out)
+	assert.NoError(t, err)
+	assert.Equal(t, "HELLO WORLD", out.String())
+
+	// with a nested template
+	nu, _ := url.Parse("nested.tmpl")
+	fsys["nested.tmpl"] = &fstest.MapFile{Data: []byte(
+		`<< . | toUpper >>`)}
+
+	tr = NewRenderer(Options{
+		Templates: map[string]Datasource{
+			"nested": {URL: nu},
+		},
+		LDelim: "<<",
+		RDelim: ">>",
+	})
+	out = &bytes.Buffer{}
+	err = tr.Render(ctx, "test", `<< template "nested" "hello" >>`, out)
+	assert.NoError(t, err)
+	assert.Equal(t, "HELLO", out.String())
+
+	// errors contain the template name
+	tr = NewRenderer(Options{})
+	err = tr.Render(ctx, "foo", `{{ bogus }}`, &bytes.Buffer{})
+	assert.ErrorContains(t, err, "template: foo:")
+}
+
+//// examples
+
+func ExampleRenderer() {
+	ctx := context.Background()
+
+	// create a new template renderer
+	tr := NewRenderer(Options{})
+
+	// render a template to stdout
+	err := tr.Render(ctx, "mytemplate",
+		`{{ "hello, world!" | toUpper }}`,
+		os.Stdout)
+	if err != nil {
+		fmt.Println("gomplate error:", err)
+	}
+
+	// Output:
+	// HELLO, WORLD!
+}
+
+func ExampleRenderer_manyTemplates() {
+	ctx := context.Background()
+
+	// create a new template renderer
+	tr := NewRenderer(Options{})
+
+	templates := []Template{
+		{
+			Name:   "one.tmpl",
+			Text:   `contents of {{ tmpl.Path }}`,
+			Writer: &bytes.Buffer{},
+		},
+		{
+			Name:   "two.tmpl",
+			Text:   `{{ "hello world" | toUpper }}`,
+			Writer: &bytes.Buffer{},
+		},
+		{
+			Name:   "three.tmpl",
+			Text:   `1 + 1 = {{ math.Add 1 1 }}`,
+			Writer: &bytes.Buffer{},
+		},
+	}
+
+	// render the templates
+	err := tr.RenderTemplates(ctx, templates)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, t := range templates {
+		fmt.Printf("%s: %s\n", t.Name, t.Writer.(*bytes.Buffer).String())
+	}
+
+	// Output:
+	// one.tmpl: contents of one.tmpl
+	// two.tmpl: HELLO WORLD
+	// three.tmpl: 1 + 1 = 2
+}
+
+func ExampleRenderer_datasources() {
+	ctx := context.Background()
+
+	// a datasource that retrieves JSON from a maritime registry dataset
+	u, _ := url.Parse("https://www.econdb.com/maritime/vessel/9437/")
+	tr := NewRenderer(Options{
+		Context: map[string]Datasource{
+			"vessel": {URL: u},
+		},
+	})
+
+	err := tr.Render(ctx, "jsontest",
+		`{{"\U0001F6A2"}} The {{ .vessel.data.Name }}'s call sign is {{ .vessel.data.Callsign }}, `+
+			`and it has a draught of {{ .vessel.data.Draught }}.`,
+		os.Stdout)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// 🚢 The MONTREAL EXPRESS's call sign is ZCET4, and it has a draught of 10.5.
+}

--- a/template_unix_test.go
+++ b/template_unix_test.go
@@ -32,22 +32,19 @@ func TestWalkDir(t *testing.T) {
 	templates, err := walkDir(ctx, cfg, "/indir", simpleNamer("/outdir"), []string{"*/two"}, 0, false)
 
 	assert.NoError(t, err)
-	expected := []*tplate{
+	expected := []Template{
 		{
-			name:     "/indir/one/bar",
-			contents: "bar",
-			mode:     0664,
+			Name: "/indir/one/bar",
+			Text: "bar",
 		},
 		{
-			name:     "/indir/one/foo",
-			contents: "foo",
-			mode:     0644,
+			Name: "/indir/one/foo",
+			Text: "foo",
 		},
 	}
 	assert.Len(t, templates, 2)
 	for i, tmpl := range templates {
-		assert.Equal(t, expected[i].name, tmpl.name)
-		assert.Equal(t, expected[i].contents, tmpl.contents)
-		assert.Equal(t, expected[i].mode, tmpl.mode)
+		assert.Equal(t, expected[i].Name, tmpl.Name)
+		assert.Equal(t, expected[i].Text, tmpl.Text)
 	}
 }

--- a/template_windows_test.go
+++ b/template_windows_test.go
@@ -32,22 +32,19 @@ func TestWalkDir(t *testing.T) {
 	templates, err := walkDir(ctx, cfg, `C:\indir`, simpleNamer(`C:\outdir`), []string{`*\two`}, 0, false)
 
 	assert.NoError(t, err)
-	expected := []*tplate{
+	expected := []Template{
 		{
-			name:     `C:\indir\one\bar`,
-			contents: "bar",
-			mode:     0644,
+			Name: `C:\indir\one\bar`,
+			Text: "bar",
 		},
 		{
-			name:     `C:\indir\one\foo`,
-			contents: "foo",
-			mode:     0644,
+			Name: `C:\indir\one\foo`,
+			Text: "foo",
 		},
 	}
 	assert.Len(t, templates, 2)
 	for i, tmpl := range templates {
-		assert.Equal(t, expected[i].name, tmpl.name)
-		assert.Equal(t, expected[i].contents, tmpl.contents)
-		assert.Equal(t, expected[i].mode, tmpl.mode)
+		assert.Equal(t, expected[i].Name, tmpl.Name)
+		assert.Equal(t, expected[i].Text, tmpl.Text)
 	}
 }


### PR DESCRIPTION
Addresses #548 and #1097 by adding a new `gomplate.Renderer` type that exposes rendering functionality in gomplate for programmatic use. There's a couple example tests that outline some common ways to use this.

Instead of exporting the internal `config.Config` type I've opted to create new `gomplate.Options` and `gomplate.Template` types, which represent common options (datasources, etc) and templates (input text + output writer).

I've also refactored the current internals to use this new functionality.

Since the interface is brand new I'm marking it as experimental API - subject to change before v4. I'm hoping to get some feedback after v3.11 is released, after which point it'll stable API.

Fixes #551 
Fixes #1097 
Fixes #548 

Signed-off-by: Dave Henderson <dhenderson@gmail.com>