### PR TITLE
[3.11.x backport] Fixing flakey LookupIP test

### DIFF
--- a/net/net_test.go
+++ b/net/net_test.go
@@ -14,13 +14,11 @@ func must(r interface{}, err error) interface{} {
 }
 func TestLookupIP(t *testing.T) {
 	assert.Equal(t, "127.0.0.1", must(LookupIP("localhost")))
-	assert.Equal(t, "35.196.83.195", must(LookupIP("hairyhenderson.ca")))
 	assert.Equal(t, "93.184.216.34", must(LookupIP("example.com")))
 }
 
 func TestLookupIPs(t *testing.T) {
 	assert.Equal(t, []string{"127.0.0.1"}, must(LookupIPs("localhost")))
-	assert.Equal(t, []string{"35.196.83.195"}, must(LookupIPs("hairyhenderson.ca")))
 	assert.Equal(t, []string{"93.184.216.34"}, must(LookupIPs("example.com")))
 }
 

--- a/render_test.go
+++ b/render_test.go
@@ -149,7 +149,4 @@ func ExampleRenderer_datasources() {
 	if err != nil {
 		panic(err)
 	}
-
-	// Output:
-	// 🚢 The MONTREAL EXPRESS's call sign is ZCET4, and it has a draught of 10.5.
 }


### PR DESCRIPTION
Backport of #1443 to 3.11.x

Signed-off-by: Dave Henderson <dhenderson@gmail.com>