### PR TITLE
Fixing deprecation annotation syntax

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     # - dogsled
     # - dupl
@@ -64,13 +63,11 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     # - unparam
     - unused
-    - varcheck
     # - whitespace
     # - wsl
 

--- a/config.go
+++ b/config.go
@@ -12,7 +12,8 @@ import (
 // Config - values necessary for rendering templates with gomplate.
 // Mainly for use by the CLI
 //
-// Deprecated: this type will be phased out, internal/config.Config is used
+// Deprecated: this type will be phased out,
+// [github.com/hairyhenderson/gomplate/v3/internal/config.Config] is used
 // everywhere else, and will be exposed as API in a future version
 type Config struct {
 	Input       string

--- a/context.go
+++ b/context.go
@@ -22,7 +22,9 @@ func (c *tmplctx) Env() map[string]string {
 }
 
 // createTmplContext reads the datasources for the given aliases
-func createTmplContext(ctx context.Context, aliases []string, d *data.Data) (interface{}, error) {
+func createTmplContext(ctx context.Context, aliases []string,
+	//nolint:staticcheck
+	d *data.Data) (interface{}, error) {
 	var err error
 	tctx := &tmplctx{}
 	for _, a := range aliases {

--- a/context_test.go
+++ b/context_test.go
@@ -34,6 +34,7 @@ func TestCreateContext(t *testing.T) {
 	barURL := "env:///bar?type=application/yaml"
 	uf, _ := url.Parse(fooURL)
 	ub, _ := url.Parse(barURL)
+	//nolint:staticcheck
 	d := &data.Data{
 		Sources: map[string]*data.Source{
 			"foo": {URL: uf},

--- a/conv/conv.go
+++ b/conv/conv.go
@@ -17,6 +17,7 @@ import (
 // All other values are considered false.
 //
 // See ToBool also for a more flexible version.
+//
 // Deprecated: use ToBool instead
 func Bool(in string) bool {
 	if b, err := strconv.ParseBool(in); err == nil {
@@ -67,6 +68,8 @@ func ToBools(in ...interface{}) []bool {
 }
 
 // Slice creates a slice from a bunch of arguments
+//
+// Deprecated: use [github.com/hairyhenderson/gomplate/v3/coll.Slice] instead
 func Slice(args ...interface{}) []interface{} {
 	return args
 }

--- a/data/datasource.go
+++ b/data/datasource.go
@@ -76,6 +76,7 @@ func (d *Data) lookupReader(scheme string) (func(context.Context, *Source, ...st
 }
 
 // Data -
+//
 // Deprecated: will be replaced in future
 type Data struct {
 	Ctx context.Context
@@ -98,6 +99,7 @@ func (d *Data) Cleanup() {
 }
 
 // NewData - constructor for Data
+//
 // Deprecated: will be replaced in future
 func NewData(datasourceArgs, headerArgs []string) (*Data, error) {
 	cfg := &config.Config{}
@@ -138,6 +140,7 @@ func FromConfig(ctx context.Context, cfg *config.Config) *Data {
 }
 
 // Source - a data source
+//
 // Deprecated: will be replaced in future
 type Source struct {
 	Alias             string

--- a/funcs.go
+++ b/funcs.go
@@ -10,13 +10,16 @@ import (
 )
 
 // Funcs -
-// Deprecated: use CreateFuncs instead
+//
+// Deprecated: use [CreateFuncs] instead
 func Funcs(d *data.Data) template.FuncMap {
 	return CreateFuncs(context.Background(), d)
 }
 
 // CreateFuncs - function mappings are created here
-func CreateFuncs(ctx context.Context, d *data.Data) template.FuncMap {
+func CreateFuncs(ctx context.Context,
+	//nolint:staticcheck
+	d *data.Data) template.FuncMap {
 	f := template.FuncMap{}
 	addToMap(f, funcs.CreateDataFuncs(ctx, d))
 	addToMap(f, funcs.CreateAWSFuncs(ctx))

--- a/funcs/aws.go
+++ b/funcs/aws.go
@@ -9,6 +9,7 @@ import (
 )
 
 // AWSNS - the aws namespace
+//
 // Deprecated: don't use
 //
 //nolint:golint
@@ -17,7 +18,8 @@ func AWSNS() *Funcs {
 }
 
 // AWSFuncs -
-// Deprecated: use CreateAWSFuncs instead
+//
+// Deprecated: use [CreateAWSFuncs] instead
 func AWSFuncs(f map[string]interface{}) {
 	f2 := CreateAWSFuncs(context.Background())
 	for k, v := range f2 {

--- a/funcs/base64.go
+++ b/funcs/base64.go
@@ -8,13 +8,15 @@ import (
 )
 
 // Base64NS - the base64 namespace
+//
 // Deprecated: don't use
 func Base64NS() *Base64Funcs {
 	return &Base64Funcs{}
 }
 
 // AddBase64Funcs -
-// Deprecated: use CreateBase64Funcs instead
+//
+// Deprecated: use [CreateBase64Funcs] instead
 func AddBase64Funcs(f map[string]interface{}) {
 	for k, v := range CreateBase64Funcs(context.Background()) {
 		f[k] = v

--- a/funcs/coll.go
+++ b/funcs/coll.go
@@ -13,12 +13,14 @@ import (
 )
 
 // CollNS -
+//
 // Deprecated: don't use
 func CollNS() *CollFuncs {
 	return &CollFuncs{}
 }
 
 // AddCollFuncs -
+//
 // Deprecated: use CreateCollFuncs instead
 func AddCollFuncs(f map[string]interface{}) {
 	for k, v := range CreateCollFuncs(context.Background()) {

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -11,13 +11,15 @@ import (
 )
 
 // ConvNS -
+//
 // Deprecated: don't use
 func ConvNS() *ConvFuncs {
 	return &ConvFuncs{}
 }
 
 // AddConvFuncs -
-// Deprecated: use CreateConvFuncs instead
+//
+// Deprecated: use [CreateConvFuncs] instead
 func AddConvFuncs(f map[string]interface{}) {
 	for k, v := range CreateConvFuncs(context.Background()) {
 		f[k] = v
@@ -44,7 +46,8 @@ type ConvFuncs struct {
 }
 
 // Bool -
-// Deprecated: use ToBool instead
+//
+// Deprecated: use [ToBool] instead
 func (f *ConvFuncs) Bool(s interface{}) bool {
 	deprecated.WarnDeprecated(f.ctx, "conv.Bool is deprecated - use conv.ToBool instead")
 	return conv.Bool(conv.ToString(s))
@@ -61,7 +64,8 @@ func (ConvFuncs) ToBools(in ...interface{}) []bool {
 }
 
 // Slice -
-// Deprecated: use [coll.Slice] instead
+//
+// Deprecated: use [CollFuncs.Slice] instead
 func (f *ConvFuncs) Slice(args ...interface{}) []interface{} {
 	deprecated.WarnDeprecated(f.ctx, "conv.Slice is deprecated - use coll.Slice instead")
 	return coll.Slice(args...)
@@ -73,7 +77,8 @@ func (ConvFuncs) Join(in interface{}, sep string) (string, error) {
 }
 
 // Has -
-// Deprecated: use coll.Has instead
+//
+// Deprecated: use [CollFuncs.Has] instead
 func (f *ConvFuncs) Has(in interface{}, key string) bool {
 	deprecated.WarnDeprecated(f.ctx, "conv.Has is deprecated - use coll.Has instead")
 	return coll.Has(in, key)
@@ -153,7 +158,8 @@ func (ConvFuncs) Default(def, in interface{}) interface{} {
 }
 
 // Dict -
-// Deprecated: use coll.Dict instead
+//
+// Deprecated: use [CollFuncs.Dict] instead
 func (f *ConvFuncs) Dict(in ...interface{}) (map[string]interface{}, error) {
 	deprecated.WarnDeprecated(f.ctx, "conv.Dict is deprecated - use coll.Dict instead")
 	return coll.Dict(in...)

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -19,13 +19,15 @@ import (
 )
 
 // CryptoNS - the crypto namespace
+//
 // Deprecated: don't use
 func CryptoNS() *CryptoFuncs {
 	return &CryptoFuncs{}
 }
 
 // AddCryptoFuncs -
-// Deprecated: use CreateCryptoFuncs instead
+//
+// Deprecated: use [CreateCryptoFuncs] instead
 func AddCryptoFuncs(f map[string]interface{}) {
 	for k, v := range CreateCryptoFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/data.go
+++ b/funcs/data.go
@@ -8,13 +8,15 @@ import (
 )
 
 // DataNS -
+//
 // Deprecated: don't use
 func DataNS() *DataFuncs {
 	return &DataFuncs{}
 }
 
 // AddDataFuncs -
-// Deprecated: use CreateDataFuncs instead
+//
+// Deprecated: use [CreateDataFuncs] instead
 func AddDataFuncs(f map[string]interface{}, d *data.Data) {
 	for k, v := range CreateDataFuncs(context.Background(), d) {
 		f[k] = v
@@ -22,7 +24,9 @@ func AddDataFuncs(f map[string]interface{}, d *data.Data) {
 }
 
 // CreateDataFuncs -
-func CreateDataFuncs(ctx context.Context, d *data.Data) map[string]interface{} {
+func CreateDataFuncs(ctx context.Context,
+	//nolint:staticcheck
+	d *data.Data) map[string]interface{} {
 	f := map[string]interface{}{}
 	f["datasource"] = d.Datasource
 	f["ds"] = d.Datasource

--- a/funcs/env.go
+++ b/funcs/env.go
@@ -8,13 +8,15 @@ import (
 )
 
 // EnvNS - the Env namespace
+//
 // Deprecated: don't use
 func EnvNS() *EnvFuncs {
 	return &EnvFuncs{}
 }
 
 // AddEnvFuncs -
-// Deprecated: use CreateEnvFuncs instead
+//
+// Deprecated: use [CreateEnvFuncs] instead
 func AddEnvFuncs(f map[string]interface{}) {
 	for k, v := range CreateEnvFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/file.go
+++ b/funcs/file.go
@@ -10,13 +10,15 @@ import (
 )
 
 // FileNS - the File namespace
+//
 // Deprecated: don't use
 func FileNS() *FileFuncs {
 	return &FileFuncs{}
 }
 
 // AddFileFuncs -
-// Deprecated: use CreateFileFuncs instead
+//
+// Deprecated: use [CreateFileFuncs] instead
 func AddFileFuncs(f map[string]interface{}) {
 	for k, v := range CreateFileFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/filepath.go
+++ b/funcs/filepath.go
@@ -8,13 +8,15 @@ import (
 )
 
 // FilePathNS - the Path namespace
+//
 // Deprecated: don't use
 func FilePathNS() *FilePathFuncs {
 	return &FilePathFuncs{}
 }
 
 // AddFilePathFuncs -
-// Deprecated: use CreateFilePathFuncs instead
+//
+// Deprecated: use [CreateFilePathFuncs] instead
 func AddFilePathFuncs(f map[string]interface{}) {
 	for k, v := range CreateFilePathFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/gcp.go
+++ b/funcs/gcp.go
@@ -8,13 +8,15 @@ import (
 )
 
 // GCPNS - the gcp namespace
+//
 // Deprecated: don't use
 func GCPNS() *GcpFuncs {
 	return &GcpFuncs{gcpopts: gcp.GetClientOptions()}
 }
 
 // AddGCPFuncs -
-// Deprecated: use CreateGCPFuncs instead
+//
+// Deprecated: use [CreateGCPFuncs] instead
 func AddGCPFuncs(f map[string]interface{}) {
 	for k, v := range CreateGCPFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/math.go
+++ b/funcs/math.go
@@ -12,13 +12,15 @@ import (
 )
 
 // MathNS - the math namespace
+//
 // Deprecated: don't use
 func MathNS() *MathFuncs {
 	return &MathFuncs{}
 }
 
 // AddMathFuncs -
-// Deprecated: use CreateMathFuncs instead
+//
+// Deprecated: use [CreateMathFuncs] instead
 func AddMathFuncs(f map[string]interface{}) {
 	for k, v := range CreateMathFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -14,13 +14,15 @@ import (
 )
 
 // NetNS - the net namespace
+//
 // Deprecated: don't use
 func NetNS() *NetFuncs {
 	return &NetFuncs{}
 }
 
 // AddNetFuncs -
-// Deprecated: use CreateNetFuncs instead
+//
+// Deprecated: use [CreateNetFuncs] instead
 func AddNetFuncs(f map[string]interface{}) {
 	for k, v := range CreateNetFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/path.go
+++ b/funcs/path.go
@@ -8,13 +8,15 @@ import (
 )
 
 // PathNS - the Path namespace
+//
 // Deprecated: don't use
 func PathNS() *PathFuncs {
 	return &PathFuncs{}
 }
 
 // AddPathFuncs -
-// Deprecated: use CreatePathFuncs instead
+//
+// Deprecated: use [CreatePathFuncs] instead
 func AddPathFuncs(f map[string]interface{}) {
 	for k, v := range CreatePathFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/random.go
+++ b/funcs/random.go
@@ -12,13 +12,15 @@ import (
 )
 
 // RandomNS -
+//
 // Deprecated: don't use
 func RandomNS() *RandomFuncs {
 	return &RandomFuncs{}
 }
 
 // AddRandomFuncs -
-// Deprecated: use CreateRandomFuncs instead
+//
+// Deprecated: use [CreateRandomFuncs] instead
 func AddRandomFuncs(f map[string]interface{}) {
 	for k, v := range CreateRandomFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/regexp.go
+++ b/funcs/regexp.go
@@ -10,13 +10,15 @@ import (
 )
 
 // ReNS -
+//
 // Deprecated: don't use
 func ReNS() *ReFuncs {
 	return &ReFuncs{}
 }
 
 // AddReFuncs -
-// Deprecated: use CreateReFuncs instead
+//
+// Deprecated: use [CreateReFuncs] instead
 func AddReFuncs(f map[string]interface{}) {
 	for k, v := range CreateReFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/sockaddr.go
+++ b/funcs/sockaddr.go
@@ -8,13 +8,15 @@ import (
 )
 
 // SockaddrNS - the sockaddr namespace
+//
 // Deprecated: don't use
 func SockaddrNS() *SockaddrFuncs {
 	return &SockaddrFuncs{}
 }
 
 // AddSockaddrFuncs -
-// Deprecated: use CreateSockaddrFuncs instead
+//
+// Deprecated: use [CreateSockaddrFuncs] instead
 func AddSockaddrFuncs(f map[string]interface{}) {
 	f["sockaddr"] = SockaddrNS
 }

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -25,13 +25,15 @@ import (
 )
 
 // StrNS -
+//
 // Deprecated: don't use
 func StrNS() *StringFuncs {
 	return &StringFuncs{}
 }
 
 // AddStringFuncs -
-// Deprecated: use CreateStringFuncs instead
+//
+// Deprecated: use [CreateStringFuncs] instead
 func AddStringFuncs(f map[string]interface{}) {
 	for k, v := range CreateStringFuncs(context.Background()) {
 		f[k] = v
@@ -132,7 +134,7 @@ func (StringFuncs) Repeat(count int, s interface{}) (string, error) {
 
 // Sort -
 //
-// Deprecated: use coll.Sort instead
+// Deprecated: use [CollFuncs.Sort] instead
 func (f *StringFuncs) Sort(list interface{}) ([]string, error) {
 	deprecated.WarnDeprecated(f.ctx, "strings.Sort is deprecated - use coll.Sort instead")
 

--- a/funcs/test.go
+++ b/funcs/test.go
@@ -11,13 +11,15 @@ import (
 )
 
 // TestNS -
+//
 // Deprecated: don't use
 func TestNS() *TestFuncs {
 	return &TestFuncs{}
 }
 
 // AddTestFuncs -
-// Deprecated: use CreateTestFuncs instead
+//
+// Deprecated: use [CreateTestFuncs] instead
 func AddTestFuncs(f map[string]interface{}) {
 	for k, v := range CreateTestFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/time.go
+++ b/funcs/time.go
@@ -13,6 +13,7 @@ import (
 )
 
 // TimeNS -
+//
 // Deprecated: don't use
 func TimeNS() *TimeFuncs {
 	return &TimeFuncs{
@@ -35,7 +36,8 @@ func TimeNS() *TimeFuncs {
 }
 
 // AddTimeFuncs -
-// Deprecated: use CreateTimeFuncs instead
+//
+// Deprecated: use [CreateTimeFuncs] instead
 func AddTimeFuncs(f map[string]interface{}) {
 	for k, v := range CreateTimeFuncs(context.Background()) {
 		f[k] = v

--- a/funcs/uuid.go
+++ b/funcs/uuid.go
@@ -9,13 +9,15 @@ import (
 )
 
 // UUIDNS -
+//
 // Deprecated: don't use
 func UUIDNS() *UUIDFuncs {
 	return &UUIDFuncs{}
 }
 
 // AddUUIDFuncs -
-// Deprecated: use CreateUUIDFuncs instead
+//
+// Deprecated: use [CreateUUIDFuncs] instead
 func AddUUIDFuncs(f map[string]interface{}) {
 	for k, v := range CreateUUIDFuncs(context.Background()) {
 		f[k] = v

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -31,7 +31,7 @@ func TestGetenvTemplates(t *testing.T) {
 	tr := NewRenderer(Options{
 		Funcs: template.FuncMap{
 			"getenv": env.Getenv,
-			"bool":   conv.Bool,
+			"bool":   conv.ToBool,
 		},
 	})
 	assert.Empty(t, testTemplate(t, tr, `{{getenv "BLAHBLAHBLAH"}}`))
@@ -42,7 +42,7 @@ func TestGetenvTemplates(t *testing.T) {
 func TestBoolTemplates(t *testing.T) {
 	g := NewRenderer(Options{
 		Funcs: template.FuncMap{
-			"bool": conv.Bool,
+			"bool": conv.ToBool,
 		},
 	})
 	assert.Equal(t, "true", testTemplate(t, g, `{{bool "true"}}`))
@@ -159,6 +159,7 @@ func TestSimpleNamer(t *testing.T) {
 func TestMappingNamer(t *testing.T) {
 	ctx := context.Background()
 	tr := &Renderer{
+		//nolint:staticcheck
 		data: &data.Data{},
 		funcs: map[string]interface{}{
 			"foo": func() string { return "foo" },

--- a/libkv/consul.go
+++ b/libkv/consul.go
@@ -144,7 +144,7 @@ func consulURL(u *url.URL) (c *url.URL, err error) {
 	case "consul+https", https:
 		c.Scheme = https
 	case "consul":
-		if conv.Bool(env.Getenv(consulapi.HTTPSSLEnvName)) {
+		if conv.ToBool(env.Getenv(consulapi.HTTPSSLEnvName)) {
 			c.Scheme = https
 		} else {
 			c.Scheme = http
@@ -187,7 +187,7 @@ func setupTLS() *consulapi.TLSConfig {
 	}
 
 	if v := env.Getenv(consulapi.HTTPSSLVerifyEnvName); v != "" {
-		verify := conv.Bool(v)
+		verify := conv.ToBool(v)
 		tlsConfig.InsecureSkipVerify = !verify
 	}
 	return &tlsConfig

--- a/render.go
+++ b/render.go
@@ -98,6 +98,7 @@ type Datasource struct {
 //
 // Experimental: subject to breaking changes before the next major release
 type Renderer struct {
+	//nolint:staticcheck
 	data        *data.Data
 	nested      config.Templates
 	funcs       template.FuncMap
@@ -117,10 +118,12 @@ func NewRenderer(opts Options) *Renderer {
 	}
 
 	tctxAliases := []string{}
+	//nolint:staticcheck
 	sources := map[string]*data.Source{}
 
 	for alias, ds := range opts.Context {
 		tctxAliases = append(tctxAliases, alias)
+		//nolint:staticcheck
 		sources[alias] = &data.Source{
 			Alias:  alias,
 			URL:    ds.URL,
@@ -128,6 +131,7 @@ func NewRenderer(opts Options) *Renderer {
 		}
 	}
 	for alias, ds := range opts.Datasources {
+		//nolint:staticcheck
 		sources[alias] = &data.Source{
 			Alias:  alias,
 			URL:    ds.URL,
@@ -145,6 +149,7 @@ func NewRenderer(opts Options) *Renderer {
 		}
 	}
 
+	//nolint:staticcheck
 	d := &data.Data{
 		ExtraHeaders: opts.ExtraHeaders,
 		Sources:      sources,


### PR DESCRIPTION
The `// Deprecated:` comment annotations need to have an empty line above for them to be properly interpreted by `go doc`. This fixes that, and also converts references to functions or packages to proper links.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>