### PR TITLE
Use one decoder for data.JSON, data.YAML. Deprecate data.JSONArray and data.YAMLArray

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -64,6 +64,10 @@ func decryptEJSON(in string) (map[string]interface{}, error) {
 		return nil, errors.WithStack(err)
 	}
 	delete(obj, ejsonJson.PublicKeyField)
+
+	ret, _ := stringifyMapKeys(obj)
+	obj = ret.(map[string]interface{})
+
 	return obj, nil
 }
 

--- a/data/datasource.go
+++ b/data/datasource.go
@@ -324,18 +324,14 @@ func (d *Data) Datasource(alias string, args ...string) (interface{}, error) {
 func parseData(mimeType, s string) (out interface{}, err error) {
 	switch mimeAlias(mimeType) {
 	case jsonMimetype:
-		out, err = JSON(s)
-		if err != nil {
-			// maybe it's a JSON array
-			out, err = JSONArray(s)
-		}
+		fallthrough
 	case jsonArrayMimetype:
-		out, err = JSONArray(s)
+		fallthrough
 	case yamlMimetype:
 		out, err = YAML(s)
 		if err != nil {
 			// maybe it's a YAML array
-			out, err = YAMLArray(s)
+			out, err = YAML(s)
 		}
 	case csvMimetype:
 		out, err = CSV(s)

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -201,18 +201,13 @@ $ gomplate -d person.json -f input.tmpl
 
 **Alias:** `json`
 
-Converts a JSON string into an object. Works for JSON Objects, but will
-also parse JSON Arrays. Will not parse other valid JSON types.
+Converts a JSON string into valid structure.
+Supports Objects, Arrays, strings, booleans and numbers.
+Objects are converted as `map[string]interface{}`.
 
-For more explict JSON Array support, see [`data.JSONArray`](#data-jsonarray).
+Uses YAML decoder, because valid JSON is actually valid YAML.
 
-#### Encrypted JSON support (EJSON)
-
-If the input is in the [EJSON](https://github.com/Shopify/ejson) format (i.e. has a `_public_key` field), this function will attempt to decrypt the document first. A private key must be provided by one of these methods:
-
-- set the `EJSON_KEY` environment variable to the private key's value
-- set the `EJSON_KEY_FILE` environment variable to the path to a file containing the private key
-- set the `EJSON_KEYDIR` environment variable to the path to a directory containing private keys (filename must be the public key), just like [`ejson decrypt`'s `--keydir`](https://github.com/Shopify/ejson/blob/master/man/man1/ejson.1.ronn) flag. Defaults to `/opt/ejson/keys`.
+**Notice:** This is only alias for [`data.Yaml`](#data-yaml), so conversional rules are the same.
 
 ### Usage
 
@@ -242,11 +237,11 @@ $ gomplate < input.tmpl
 Hello world
 ```
 
-## `data.JSONArray`
+## `data.JSONArray` _(deprecated)_
 
 **Alias:** `jsonArray`
 
-Converts a JSON string into a slice. Only works for JSON Arrays.
+**Deprecation Notice:** Please use [`data.Json`](#data-json), currently it is only alias for that
 
 ### Usage
 
@@ -276,14 +271,24 @@ $ gomplate < input.tmpl
 Hello world
 ```
 
-## `data.YAML`
+## `data.YAML` 
 
-**Alias:** `yaml`
+**Alias:** `yaml` 
 
-Converts a YAML string into an object. Works for YAML Objects but will
-also parse YAML Arrays. This can be used to access properties of YAML objects.
+Converts a YAML string into valid structure.
+Supports Objects, Arrays, strings, booleans and numbers.
+Objects are converted as `map[string]interface{}`.
 
-For more explict YAML Array support, see [`data.JSONArray`](#data-yamlarray).
+Also sucessfully converts valid JSON, because valid JSON is valid YAML.
+
+#### Encrypted JSON support (EJSON)
+
+If the input is in the [EJSON](https://github.com/Shopify/ejson) format (i.e. has a `_public_key` field), this function will attempt to decrypt the document first. A private key must be provided by one of these methods:
+
+- set the `EJSON_KEY` environment variable to the private key's value
+- set the `EJSON_KEY_FILE` environment variable to the path to a file containing the private key
+- set the `EJSON_KEYDIR` environment variable to the path to a directory containing private keys (filename must be the public key), just like [`ejson decrypt`'s `--keydir`](https://github.com/Shopify/ejson/blob/master/man/man1/ejson.1.ronn) flag. Defaults to `/opt/ejson/keys`.
+
 
 ### Usage
 
@@ -313,11 +318,11 @@ $ gomplate < input.tmpl
 Hello world
 ```
 
-## `data.YAMLArray`
+## `data.YAMLArray` _(deprecated)_
 
 **Alias:** `yamlArray`
 
-Converts a YAML string into a slice. Only works for YAML Arrays.
+**Deprecation Notice:** Please use [`data.Yaml`](#data-yaml), currently it is only alias for that
 
 ### Usage
 

--- a/funcs/data.go
+++ b/funcs/data.go
@@ -40,10 +40,10 @@ func CreateDataFuncs(ctx context.Context,
 
 	f["data"] = func() interface{} { return ns }
 
-	f["json"] = ns.JSON
-	f["jsonArray"] = ns.JSONArray
+	f["json"] = ns.YAML
+	f["jsonArray"] = ns.YAML
 	f["yaml"] = ns.YAML
-	f["yamlArray"] = ns.YAMLArray
+	f["yamlArray"] = ns.YAML
 	f["toml"] = ns.TOML
 	f["csv"] = ns.CSV
 	f["csvByRow"] = ns.CSVByRow
@@ -61,24 +61,9 @@ type DataFuncs struct {
 	ctx context.Context
 }
 
-// JSON -
-func (f *DataFuncs) JSON(in interface{}) (map[string]interface{}, error) {
-	return data.JSON(conv.ToString(in))
-}
-
-// JSONArray -
-func (f *DataFuncs) JSONArray(in interface{}) ([]interface{}, error) {
-	return data.JSONArray(conv.ToString(in))
-}
-
 // YAML -
-func (f *DataFuncs) YAML(in interface{}) (map[string]interface{}, error) {
+func (f *DataFuncs) YAML(in interface{}) (interface{}, error) {
 	return data.YAML(conv.ToString(in))
-}
-
-// YAMLArray -
-func (f *DataFuncs) YAMLArray(in interface{}) ([]interface{}, error) {
-	return data.YAMLArray(conv.ToString(in))
 }
 
 // TOML -

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -73,7 +73,7 @@ func TestEc2MetaTemplates_WithJSON(t *testing.T) {
 		Funcs: template.FuncMap{
 			"ec2meta":    ec2meta.Meta,
 			"ec2dynamic": ec2meta.Dynamic,
-			"json":       data.JSON,
+			"json":       data.YAML,
 		},
 	})
 
@@ -84,7 +84,7 @@ func TestEc2MetaTemplates_WithJSON(t *testing.T) {
 func TestJSONArrayTemplates(t *testing.T) {
 	g := NewRenderer(Options{
 		Funcs: template.FuncMap{
-			"jsonArray": data.JSONArray,
+			"jsonArray": data.YAML,
 		},
 	})
 
@@ -96,7 +96,7 @@ func TestYAMLTemplates(t *testing.T) {
 	g := NewRenderer(Options{
 		Funcs: template.FuncMap{
 			"yaml":      data.YAML,
-			"yamlArray": data.YAMLArray,
+			"yamlArray": data.YAML,
 		},
 	})
 


### PR DESCRIPTION
At first, thank you for very useful product.
I found it during searching for golang templating tool for DevOps needs after I started prototyping own tool with similar functionality, but now I decided to use gomplate and want to contribute.

During exploring and using gomplate, I faced with separation on converting on JSON and YAML data.
This separation was confused me, because from my point of view there's no need to have it.
So I decided to contribute some chages to make user experience smoother.

What actually changed in this PR:
- data.JSON and data.YAML is uses one unmarshaler (i.e. it now actually aliases) because valid JSON is valid YAML;
- both data.JSON and data.YAML supports convertion of any valid data types for this formats, including arrays;
- data.JSONArray and data.YAMLArray is deprecated, because this functionality can be achieved by using data.JSON and data.YAML, so it also only aliases, to keep compatibility;
- EJSON support is still here, but I added additinal stringifyMapKeys in output processing;

IMHO this changes will simplify usage of gomplate, because there's no need to decide which of YAML* or JSON* method use.
