### PR TITLE
Add strings.SkipLines function

### DIFF
--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -137,6 +137,29 @@ funcs:
       - |
         $ gomplate -i '{{ (coll.Slice "foo" "bar" "baz") | strings.Sort }}'
         [bar baz foo]
+  - name: strings.SkipLines
+    description: |
+      Skips the given number of lines (each ending in a `\n`), returning the
+      remainder.
+
+      If `skip` is greater than the number of lines in `in`, an empty string is
+      returned.
+    pipeline: true
+    arguments:
+      - name: skip
+        required: true
+        description: the number of lines to skip - must be a positive number
+      - name: in
+        required: true
+        description: the input string
+    examples:
+      - |
+        $ gomplate -i '{{ "foo\nbar\nbaz" | strings.SkipLines 2 }}'
+        baz
+      - |
+        $ gomplate -i '{{ strings.SkipLines 1 "foo\nbar\nbaz" }}'
+        bar
+        baz
   - name: strings.Split
     description: |
       _Not to be confused with [`split`](#split), which is deprecated._

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -207,6 +207,42 @@ $ gomplate -i '{{ (coll.Slice "foo" "bar" "baz") | strings.Sort }}'
 [bar baz foo]
 ```
 
+## `strings.SkipLines`
+
+Skips the given number of lines (each ending in a `\n`), returning the
+remainder.
+
+If `skip` is greater than the number of lines in `in`, an empty string is
+returned.
+
+### Usage
+
+```go
+strings.SkipLines skip in
+```
+```go
+in | strings.SkipLines skip
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `skip` | _(required)_ the number of lines to skip - must be a positive number |
+| `in` | _(required)_ the input string |
+
+### Examples
+
+```console
+$ gomplate -i '{{ "foo\nbar\nbaz" | strings.SkipLines 2 }}'
+baz
+```
+```console
+$ gomplate -i '{{ strings.SkipLines 1 "foo\nbar\nbaz" }}'
+bar
+baz
+```
+
 ## `strings.Split`
 
 _Not to be confused with [`split`](#split), which is deprecated._

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -184,6 +184,11 @@ func (StringFuncs) Repeat(count int, s interface{}) (string, error) {
 	return strings.Repeat(str, count), nil
 }
 
+// SkipLines -
+func (StringFuncs) SkipLines(skip int, in string) (string, error) {
+	return gompstrings.SkipLines(skip, in)
+}
+
 // Sort -
 //
 // Deprecated: use [CollFuncs.Sort] instead

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -2,6 +2,7 @@
 package strings
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -124,4 +125,23 @@ func wwDefaults(opts WordWrapOpts) WordWrapOpts {
 func WordWrap(in string, opts WordWrapOpts) string {
 	opts = wwDefaults(opts)
 	return goutils.WrapCustom(in, int(opts.Width), opts.LBSeq, false)
+}
+
+// SkipLines - skip the given number of lines (ending with \n) from the string.
+// If skip is greater than the number of lines in the string, an empty string is
+// returned.
+func SkipLines(skip int, in string) (string, error) {
+	if skip < 0 {
+		return "", fmt.Errorf("skip must be >= 0")
+	}
+	if skip == 0 {
+		return in, nil
+	}
+
+	lines := strings.SplitN(in, "\n", skip+1)
+	if skip >= len(lines) {
+		return "", nil
+	}
+
+	return lines[skip], nil
 }

--- a/strings/strings_test.go
+++ b/strings/strings_test.go
@@ -126,3 +126,18 @@ that has been set.`
 	// 	in = strings.ReplaceAll(out, "\n", " ")
 	// 	assert.Equal(t, out, WordWrap(in, WordWrapOpts{Width: 100}))
 }
+
+func TestSkipLines(t *testing.T) {
+	out, _ := SkipLines(2, "\nfoo\nbar\n\nbaz")
+	assert.Equal(t, "bar\n\nbaz", out)
+
+	out, _ = SkipLines(0, "foo\nbar\n\nbaz")
+	assert.Equal(t, "foo\nbar\n\nbaz", out)
+
+	_, err := SkipLines(-1, "foo\nbar\n\nbaz")
+	assert.Error(t, err)
+
+	out, err = SkipLines(4, "foo\nbar\n\nbaz")
+	assert.NoError(t, err)
+	assert.Equal(t, "", out)
+}


### PR DESCRIPTION
New `strings.SkipLines` function - basically a bit of syntactic sugar over `strings.SplitN`

Signed-off-by: Dave Henderson <dhenderson@gmail.com>