### PR TITLE
Remove uses of pkg/errors

### DIFF
--- a/coll/jsonpath.go
+++ b/coll/jsonpath.go
@@ -1,9 +1,9 @@
 package coll
 
 import (
+	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/util/jsonpath"
 )
 
@@ -11,11 +11,11 @@ import (
 func JSONPath(p string, in interface{}) (interface{}, error) {
 	jp, err := parsePath(p)
 	if err != nil {
-		return nil, errors.Wrapf(err, "couldn't parse JSONPath %s", p)
+		return nil, fmt.Errorf("couldn't parse JSONPath %s: %w", p, err)
 	}
 	results, err := jp.FindResults(in)
 	if err != nil {
-		return nil, errors.Wrap(err, "executing JSONPath failed")
+		return nil, fmt.Errorf("executing JSONPath failed: %w", err)
 	}
 
 	var out interface{}
@@ -59,5 +59,5 @@ func extractResult(v reflect.Value) (interface{}, error) {
 		return v.Interface(), nil
 	}
 
-	return nil, errors.Errorf("JSONPath couldn't access field")
+	return nil, fmt.Errorf("JSONPath couldn't access field")
 }

--- a/conv/conv.go
+++ b/conv/conv.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
-	"github.com/pkg/errors"
 )
 
 // Bool converts a string to a boolean value, using strconv.ParseBool under the covers.
@@ -90,7 +89,7 @@ func Join(in interface{}, sep string) (out string, err error) {
 	if !ok {
 		a, err = iconv.InterfaceSlice(in)
 		if err != nil {
-			return "", errors.Wrap(err, "input to Join must be an array")
+			return "", fmt.Errorf("input to Join must be an array: %w", err)
 		}
 		ok = true
 	}
@@ -102,7 +101,7 @@ func Join(in interface{}, sep string) (out string, err error) {
 		return strings.Join(b, sep), nil
 	}
 
-	return "", errors.New("input to Join must be an array")
+	return "", fmt.Errorf("input to Join must be an array")
 }
 
 // Has determines whether or not a given object has a property with the given key

--- a/crypto/pbkdf2.go
+++ b/crypto/pbkdf2.go
@@ -5,9 +5,8 @@ import (
 	"crypto/sha1" //nolint: gosec
 	"crypto/sha256"
 	"crypto/sha512"
+	"fmt"
 	"hash"
-
-	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -43,7 +42,7 @@ func StrToHash(hash string) (crypto.Hash, error) {
 	case "SHA512_256", "SHA512/256", "SHA-512_256", "SHA-512/256":
 		return crypto.SHA512_256, nil
 	}
-	return 0, errors.Errorf("no such hash %s", hash)
+	return 0, fmt.Errorf("no such hash %s", hash)
 }
 
 // PBKDF2 - Run the Password-Based Key Derivation Function #2 as defined in
@@ -51,7 +50,7 @@ func StrToHash(hash string) (crypto.Hash, error) {
 func PBKDF2(password, salt []byte, iter, keylen int, hashFunc crypto.Hash) ([]byte, error) {
 	h, ok := hashFuncs[hashFunc]
 	if !ok {
-		return nil, errors.Errorf("hashFunc not supported: %v", hashFunc)
+		return nil, fmt.Errorf("hashFunc not supported: %v", hashFunc)
 	}
 	return pbkdf2.Key(password, salt, iter, keylen, h), nil
 }

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1,12 +1,11 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/ugorji/go/codec"
-
-	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 
@@ -59,9 +58,9 @@ escaped: "\"\/\\\b\f\n\r\t\u221e"
 
 	obj := make(map[string]interface{})
 	_, err := unmarshalObj(obj, "SOMETHING", func(in []byte, out interface{}) error {
-		return errors.New("fail")
+		return fmt.Errorf("fail")
 	})
-	assert.EqualError(t, err, "Unable to unmarshal object SOMETHING: fail")
+	assert.EqualError(t, err, "unable to unmarshal object SOMETHING: fail")
 }
 
 func TestUnmarshalArray(t *testing.T) {
@@ -139,9 +138,9 @@ this shouldn't be reached
 
 	obj := make([]interface{}, 1)
 	_, err = unmarshalArray(obj, "SOMETHING", func(in []byte, out interface{}) error {
-		return errors.New("fail")
+		return fmt.Errorf("fail")
 	})
-	assert.EqualError(t, err, "Unable to unmarshal array SOMETHING: fail")
+	assert.EqualError(t, err, "unable to unmarshal array SOMETHING: fail")
 }
 
 func TestMarshalObj(t *testing.T) {
@@ -152,7 +151,7 @@ func TestMarshalObj(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 	_, err = marshalObj(nil, func(in interface{}) ([]byte, error) {
-		return nil, errors.New("fail")
+		return nil, fmt.Errorf("fail")
 	})
 	assert.Error(t, err)
 }

--- a/data/datasource_awssmp.go
+++ b/data/datasource_awssmp.go
@@ -2,12 +2,12 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ssm"
-	"github.com/pkg/errors"
 
 	gaws "github.com/hairyhenderson/gomplate/v3/aws"
 )
@@ -48,7 +48,7 @@ func readAWSSMPParam(ctx context.Context, source *Source, paramPath string) ([]b
 	response, err := source.asmpg.GetParameterWithContext(ctx, input)
 
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error reading aws+smp from AWS using GetParameter with input %v", input)
+		return nil, fmt.Errorf("error reading aws+smp from AWS using GetParameter with input %v: %w", input, err)
 	}
 
 	result := *response.Parameter
@@ -65,7 +65,7 @@ func listAWSSMPParams(ctx context.Context, source *Source, paramPath string) ([]
 
 	response, err := source.asmpg.GetParametersByPathWithContext(ctx, input)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error reading aws+smp from AWS using GetParameter with input %v", input)
+		return nil, fmt.Errorf("error reading aws+smp from AWS using GetParameter with input %v: %w", input, err)
 	}
 
 	listing := make([]string, len(response.Parameters))

--- a/data/datasource_file.go
+++ b/data/datasource_file.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -11,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-
-	"github.com/pkg/errors"
 )
 
 func readFile(ctx context.Context, source *Source, args ...string) ([]byte, error) {
@@ -39,7 +38,7 @@ func readFile(ctx context.Context, source *Source, args ...string) ([]byte, erro
 	// make sure we can access the file
 	i, err := source.fs.Stat(p)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Can't stat %s", p)
+		return nil, fmt.Errorf("stat %s: %w", p, err)
 	}
 
 	if strings.HasSuffix(p, string(filepath.Separator)) {
@@ -47,19 +46,19 @@ func readFile(ctx context.Context, source *Source, args ...string) ([]byte, erro
 		if i.IsDir() {
 			return readFileDir(source, p)
 		}
-		return nil, errors.Errorf("%s is not a directory", p)
+		return nil, fmt.Errorf("%s is not a directory", p)
 	}
 
 	f, err := source.fs.OpenFile(p, os.O_RDONLY, 0)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Can't open %s", p)
+		return nil, fmt.Errorf("openFile %s: %w", p, err)
 	}
 
 	defer f.Close()
 
 	b, err := io.ReadAll(f)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Can't read %s", p)
+		return nil, fmt.Errorf("readAll %s: %w", p, err)
 	}
 	return b, nil
 }

--- a/data/datasource_http.go
+++ b/data/datasource_http.go
@@ -2,13 +2,12 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
 	"net/url"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 func buildURL(base *url.URL, args ...string) (*url.URL, error) {
@@ -17,7 +16,7 @@ func buildURL(base *url.URL, args ...string) (*url.URL, error) {
 	}
 	p, err := url.Parse(args[0])
 	if err != nil {
-		return nil, errors.Wrapf(err, "bad sub-path %s", args[0])
+		return nil, fmt.Errorf("bad sub-path %s: %w", args[0], err)
 	}
 	return base.ResolveReference(p), nil
 }
@@ -48,7 +47,7 @@ func readHTTP(ctx context.Context, source *Source, args ...string) ([]byte, erro
 		return nil, err
 	}
 	if res.StatusCode != 200 {
-		err := errors.Errorf("Unexpected HTTP status %d on GET from %s: %s", res.StatusCode, source.URL, string(body))
+		err := fmt.Errorf("unexpected HTTP status %d on GET from %s: %s", res.StatusCode, source.URL, string(body))
 		return nil, err
 	}
 	ctypeHdr := res.Header.Get("Content-Type")

--- a/data/datasource_merge.go
+++ b/data/datasource_merge.go
@@ -2,12 +2,11 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hairyhenderson/gomplate/v3/coll"
 	"github.com/hairyhenderson/gomplate/v3/internal/config"
-
-	"github.com/pkg/errors"
 )
 
 // readMerge demultiplexes a `merge:` datasource. The 'args' parameter currently
@@ -24,7 +23,7 @@ func (d *Data) readMerge(ctx context.Context, source *Source, args ...string) ([
 	opaque := source.URL.Opaque
 	parts := strings.Split(opaque, "|")
 	if len(parts) < 2 {
-		return nil, errors.New("need at least 2 datasources to merge")
+		return nil, fmt.Errorf("need at least 2 datasources to merge")
 	}
 	data := make([]map[string]interface{}, len(parts))
 	for i, part := range parts {
@@ -45,12 +44,12 @@ func (d *Data) readMerge(ctx context.Context, source *Source, args ...string) ([
 
 		b, err := d.readSource(ctx, subSource)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Couldn't read datasource '%s'", part)
+			return nil, fmt.Errorf("couldn't read datasource '%s': %w", part, err)
 		}
 
 		mimeType, err := subSource.mimeType("")
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to read datasource %s", subSource.URL)
+			return nil, fmt.Errorf("failed to read datasource %s: %w", subSource.URL, err)
 		}
 
 		data[i], err = parseMap(mimeType, string(b))
@@ -95,7 +94,7 @@ func parseMap(mimeType, data string) (map[string]interface{}, error) {
 	case map[string]interface{}:
 		m = datum
 	default:
-		return nil, errors.Errorf("unexpected data type '%T' for datasource (type %s); merge: can only merge maps", datum, mimeType)
+		return nil, fmt.Errorf("unexpected data type '%T' for datasource (type %s); merge: can only merge maps", datum, mimeType)
 	}
 	return m, nil
 }

--- a/data/datasource_stdin.go
+++ b/data/datasource_stdin.go
@@ -2,10 +2,9 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 func readStdin(ctx context.Context, source *Source, args ...string) ([]byte, error) {
@@ -13,7 +12,7 @@ func readStdin(ctx context.Context, source *Source, args ...string) ([]byte, err
 
 	b, err := io.ReadAll(stdin)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Can't read %s", stdin)
+		return nil, fmt.Errorf("can't read %s: %w", stdin, err)
 	}
 	return b, nil
 }

--- a/data/datasource_vault.go
+++ b/data/datasource_vault.go
@@ -2,9 +2,8 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/hairyhenderson/gomplate/v3/vault"
 )
@@ -41,7 +40,7 @@ func readVault(ctx context.Context, source *Source, args ...string) (data []byte
 	}
 
 	if len(data) == 0 {
-		return nil, errors.Errorf("no value found for path %s", p)
+		return nil, fmt.Errorf("no value found for path %s", p)
 	}
 
 	return data, nil

--- a/funcs/coll.go
+++ b/funcs/coll.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hairyhenderson/gomplate/v3/internal/texttemplate"
 
 	"github.com/hairyhenderson/gomplate/v3/coll"
-	"github.com/pkg/errors"
 )
 
 // CollNS -
@@ -143,7 +142,7 @@ func (CollFuncs) Sort(args ...interface{}) ([]interface{}, error) {
 		list interface{}
 	)
 	if len(args) == 0 || len(args) > 2 {
-		return nil, errors.Errorf("wrong number of args: wanted 1 or 2, got %d", len(args))
+		return nil, fmt.Errorf("wrong number of args: wanted 1 or 2, got %d", len(args))
 	}
 	if len(args) == 1 {
 		list = args[0]
@@ -168,7 +167,7 @@ func (f *CollFuncs) JQ(jqExpr string, in interface{}) (interface{}, error) {
 // Flatten -
 func (CollFuncs) Flatten(args ...interface{}) ([]interface{}, error) {
 	if len(args) == 0 || len(args) > 2 {
-		return nil, errors.Errorf("wrong number of args: wanted 1 or 2, got %d", len(args))
+		return nil, fmt.Errorf("wrong number of args: wanted 1 or 2, got %d", len(args))
 	}
 	list := args[0]
 	depth := -1
@@ -181,19 +180,19 @@ func (CollFuncs) Flatten(args ...interface{}) ([]interface{}, error) {
 
 func pickOmitArgs(args ...interface{}) (map[string]interface{}, []string, error) {
 	if len(args) <= 1 {
-		return nil, nil, errors.Errorf("wrong number of args: wanted 2 or more, got %d", len(args))
+		return nil, nil, fmt.Errorf("wrong number of args: wanted 2 or more, got %d", len(args))
 	}
 
 	m, ok := args[len(args)-1].(map[string]interface{})
 	if !ok {
-		return nil, nil, errors.Errorf("wrong map type: must be map[string]interface{}, got %T", args[len(args)-1])
+		return nil, nil, fmt.Errorf("wrong map type: must be map[string]interface{}, got %T", args[len(args)-1])
 	}
 
 	keys := make([]string, len(args)-1)
 	for i, v := range args[0 : len(args)-1] {
 		k, ok := v.(string)
 		if !ok {
-			return nil, nil, errors.Errorf("wrong key type: must be string, got %T (%+v)", args[i], args[i])
+			return nil, nil, fmt.Errorf("wrong key type: must be string, got %T (%+v)", args[i], args[i])
 		}
 		keys[i] = k
 	}

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -13,8 +13,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/pkg/errors"
-
 	"github.com/hairyhenderson/gomplate/v3/crypto"
 )
 
@@ -185,7 +183,7 @@ func (CryptoFuncs) Bcrypt(args ...interface{}) (string, error) {
 	input := ""
 	cost := bcrypt.DefaultCost
 	if len(args) == 0 {
-		return "", errors.Errorf("bcrypt requires at least an 'input' value")
+		return "", fmt.Errorf("bcrypt requires at least an 'input' value")
 	}
 	if len(args) == 1 {
 		input = conv.ToString(args[0])

--- a/funcs/random.go
+++ b/funcs/random.go
@@ -2,13 +2,13 @@ package funcs
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"unicode/utf8"
 
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
 	"github.com/hairyhenderson/gomplate/v3/random"
-	"github.com/pkg/errors"
 )
 
 // RandomNS -
@@ -59,7 +59,7 @@ func (RandomFuncs) AlphaNum(count interface{}) (string, error) {
 func (RandomFuncs) String(count interface{}, args ...interface{}) (s string, err error) {
 	c := conv.ToInt(count)
 	if c == 0 {
-		return "", errors.New("count must be greater than 0")
+		return "", fmt.Errorf("count must be greater than 0")
 	}
 	m := ""
 	switch len(args) {

--- a/funcs/regexp.go
+++ b/funcs/regexp.go
@@ -2,8 +2,7 @@ package funcs
 
 import (
 	"context"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/hairyhenderson/gomplate/v3/regexp"
@@ -58,7 +57,7 @@ func (ReFuncs) FindAll(args ...interface{}) ([]string, error) {
 		n = conv.ToInt(args[1])
 		input = conv.ToString(args[2])
 	default:
-		return nil, errors.Errorf("wrong number of args: want 2 or 3, got %d", len(args))
+		return nil, fmt.Errorf("wrong number of args: want 2 or 3, got %d", len(args))
 	}
 	return regexp.FindAll(re, n, input)
 }
@@ -101,7 +100,7 @@ func (ReFuncs) Split(args ...interface{}) ([]string, error) {
 		n = conv.ToInt(args[1])
 		input = conv.ToString(args[2])
 	default:
-		return nil, errors.Errorf("wrong number of args: want 2 or 3, got %d", len(args))
+		return nil, fmt.Errorf("wrong number of args: want 2 or 3, got %d", len(args))
 	}
 	return regexp.Split(re, n, input)
 }

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -9,19 +9,17 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/Masterminds/goutils"
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/hairyhenderson/gomplate/v3/internal/deprecated"
-	"github.com/pkg/errors"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
-	"strings"
+	gompstrings "github.com/hairyhenderson/gomplate/v3/strings"
 
 	"github.com/gosimple/slug"
-	gompstrings "github.com/hairyhenderson/gomplate/v3/strings"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // StrNS -
@@ -135,7 +133,7 @@ func (StringFuncs) Abbrev(args ...interface{}) (string, error) {
 	offset := 0
 	maxWidth := 0
 	if len(args) < 2 {
-		return "", errors.Errorf("abbrev requires a 'maxWidth' and 'input' argument")
+		return "", fmt.Errorf("abbrev requires a 'maxWidth' and 'input' argument")
 	}
 	if len(args) == 2 {
 		maxWidth = conv.ToInt(args[0])
@@ -175,11 +173,11 @@ func (StringFuncs) HasSuffix(suffix string, s interface{}) bool {
 // Repeat -
 func (StringFuncs) Repeat(count int, s interface{}) (string, error) {
 	if count < 0 {
-		return "", errors.Errorf("negative count %d", count)
+		return "", fmt.Errorf("negative count %d", count)
 	}
 	str := conv.ToString(s)
 	if count > 0 && len(str)*count/count != len(str) {
-		return "", errors.Errorf("count %d too long: causes overflow", count)
+		return "", fmt.Errorf("count %d too long: causes overflow", count)
 	}
 	return strings.Repeat(str, count), nil
 }
@@ -206,7 +204,7 @@ func (f *StringFuncs) Sort(list interface{}) ([]string, error) {
 		}
 		return gompstrings.Sort(b), nil
 	default:
-		return nil, errors.Errorf("wrong type for value; expected []string; got %T", list)
+		return nil, fmt.Errorf("wrong type for value; expected []string; got %T", list)
 	}
 }
 
@@ -272,18 +270,18 @@ func (StringFuncs) Indent(args ...interface{}) (string, error) {
 		if !ok {
 			width, ok = args[0].(int)
 			if !ok {
-				return "", errors.New("indent: invalid arguments")
+				return "", fmt.Errorf("indent: invalid arguments")
 			}
 			indent = " "
 		}
 	case 3:
 		width, ok = args[0].(int)
 		if !ok {
-			return "", errors.New("indent: invalid arguments")
+			return "", fmt.Errorf("indent: invalid arguments")
 		}
 		indent, ok = args[1].(string)
 		if !ok {
-			return "", errors.New("indent: invalid arguments")
+			return "", fmt.Errorf("indent: invalid arguments")
 		}
 	}
 	return gompstrings.Indent(width, indent, input), nil
@@ -342,7 +340,7 @@ func (StringFuncs) KebabCase(in interface{}) (string, error) {
 // WordWrap -
 func (StringFuncs) WordWrap(args ...interface{}) (string, error) {
 	if len(args) == 0 || len(args) > 3 {
-		return "", errors.Errorf("expected 1, 2, or 3 args, got %d", len(args))
+		return "", fmt.Errorf("expected 1, 2, or 3 args, got %d", len(args))
 	}
 	in := conv.ToString(args[len(args)-1])
 

--- a/funcs/test.go
+++ b/funcs/test.go
@@ -2,11 +2,10 @@ package funcs
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/pkg/errors"
-
 	"github.com/hairyhenderson/gomplate/v3/test"
 )
 
@@ -56,11 +55,11 @@ func (TestFuncs) Assert(args ...interface{}) (string, error) {
 	case 2:
 		message, ok := args[0].(string)
 		if !ok {
-			return "", errors.Errorf("at <1>: expected string; found %T", args[0])
+			return "", fmt.Errorf("at <1>: expected string; found %T", args[0])
 		}
 		return test.Assert(input, message)
 	default:
-		return "", errors.Errorf("wrong number of args: want 1 or 2, got %d", len(args))
+		return "", fmt.Errorf("wrong number of args: want 1 or 2, got %d", len(args))
 	}
 }
 
@@ -72,7 +71,7 @@ func (TestFuncs) Fail(args ...interface{}) (string, error) {
 	case 1:
 		return "", test.Fail(conv.ToString(args[0]))
 	default:
-		return "", errors.Errorf("wrong number of args: want 0 or 1, got %d", len(args))
+		return "", fmt.Errorf("wrong number of args: want 0 or 1, got %d", len(args))
 	}
 }
 
@@ -84,11 +83,11 @@ func (TestFuncs) Required(args ...interface{}) (interface{}, error) {
 	case 2:
 		message, ok := args[0].(string)
 		if !ok {
-			return nil, errors.Errorf("at <1>: expected string; found %T", args[0])
+			return nil, fmt.Errorf("at <1>: expected string; found %T", args[0])
 		}
 		return test.Required(message, args[1])
 	default:
-		return nil, errors.Errorf("wrong number of args: want 1 or 2, got %d", len(args))
+		return nil, fmt.Errorf("wrong number of args: want 1 or 2, got %d", len(args))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/itchyny/gojq v0.12.11
 	github.com/johannesboyne/gofakes3 v0.0.0-20220627085814-c3ac35da23b2
 	github.com/joho/godotenv v1.4.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.6.1

--- a/gomplate.go
+++ b/gomplate.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hairyhenderson/gomplate/v3/data"
 	"github.com/hairyhenderson/gomplate/v3/internal/config"
-	"github.com/pkg/errors"
 )
 
 // RunTemplates - run all gomplate templates specified by the given configuration
@@ -113,7 +112,7 @@ func mappingNamer(outMap string, tr *Renderer) func(context.Context, string) (st
 		err = tr.renderTemplatesWithData(ctx,
 			[]Template{{Name: "<OutputMap>", Text: outMap, Writer: out}}, tctx)
 		if err != nil {
-			return "", errors.Wrapf(err, "failed to render outputMap with ctx %+v and inPath %s", tctx, inPath)
+			return "", fmt.Errorf("failed to render outputMap with ctx %+v and inPath %s: %w", tctx, inPath, err)
 		}
 
 		return filepath.Clean(strings.TrimSpace(out.String())), nil

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
 	"github.com/hairyhenderson/yaml"
-	"github.com/pkg/errors"
 )
 
 // Parse a config file
@@ -625,7 +624,7 @@ func ParseSourceURL(value string) (*url.URL, error) {
 func absFileURL(value string) (*url.URL, error) {
 	wd, err := os.Getwd()
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't get working directory")
+		return nil, fmt.Errorf("can't get working directory: %w", err)
 	}
 	wd = filepath.ToSlash(wd)
 	baseURL := &url.URL{

--- a/internal/conv/conv.go
+++ b/internal/conv/conv.go
@@ -1,9 +1,8 @@
 package conv
 
 import (
+	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 )
 
 // InterfaceSlice converts an array or slice of any type into an []interface{}
@@ -24,6 +23,6 @@ func InterfaceSlice(slice interface{}) ([]interface{}, error) {
 		}
 		return ret, nil
 	default:
-		return nil, errors.Errorf("expected an array or slice, but got a %T", s)
+		return nil, fmt.Errorf("expected an array or slice, but got a %T", s)
 	}
 }

--- a/internal/tests/integration/datasources_vault_test.go
+++ b/internal/tests/integration/datasources_vault_test.go
@@ -124,7 +124,7 @@ func TestDatasources_Vault_TokenAuth(t *testing.T) {
 		withEnv("VAULT_ADDR", "http://"+v.addr).
 		withEnv("VAULT_TOKEN", tok).
 		run()
-	assert.ErrorContains(t, err, "error calling ds: Couldn't read datasource 'vault': no value found for path /secret/bar")
+	assert.ErrorContains(t, err, "error calling ds: couldn't read datasource 'vault': no value found for path /secret/bar")
 
 	tokFile := fs.NewFile(t, "test-vault-token", fs.WithContent(tok))
 	defer tokFile.Remove()

--- a/test/test.go
+++ b/test/test.go
@@ -3,16 +3,16 @@
 package test
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 )
 
 // Assert -
 func Assert(value bool, message string) (string, error) {
 	if !value {
 		if message != "" {
-			return "", errors.Errorf("assertion failed: %s", message)
+			return "", fmt.Errorf("assertion failed: %s", message)
 		}
-		return "", errors.New("assertion failed")
+		return "", fmt.Errorf("assertion failed")
 	}
 	return "", nil
 }
@@ -20,9 +20,9 @@ func Assert(value bool, message string) (string, error) {
 // Fail -
 func Fail(message string) error {
 	if message != "" {
-		return errors.Errorf("template generation failed: %s", message)
+		return fmt.Errorf("template generation failed: %s", message)
 	}
-	return errors.New("template generation failed")
+	return fmt.Errorf("template generation failed")
 }
 
 // Required -
@@ -32,7 +32,7 @@ func Required(message string, value interface{}) (interface{}, error) {
 	}
 
 	if s, ok := value.(string); value == nil || (ok && s == "") {
-		return nil, errors.New(message)
+		return nil, fmt.Errorf(message)
 	}
 
 	return value, nil

--- a/tmpl/tmpl.go
+++ b/tmpl/tmpl.go
@@ -3,10 +3,9 @@ package tmpl
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 // Template -
@@ -68,7 +67,7 @@ func (t *Template) Exec(name string, tmplcontext ...interface{}) (string, error)
 	}
 	tmpl := t.root.Lookup(name)
 	if tmpl == nil {
-		return "", errors.Errorf(`template "%s" not defined`, name)
+		return "", fmt.Errorf(`template "%s" not defined`, name)
 	}
 	return render(tmpl, ctx)
 }
@@ -87,11 +86,11 @@ func (t *Template) parseArgs(args ...interface{}) (name, in string, ctx interfac
 	ctx = t.defaultCtx
 
 	if len(args) == 0 || len(args) > 3 {
-		return "", "", nil, errors.Errorf("wrong number of args for tpl: want 1, 2, or 3 - got %d", len(args))
+		return "", "", nil, fmt.Errorf("wrong number of args for tpl: want 1, 2, or 3 - got %d", len(args))
 	}
 	first, ok := args[0].(string)
 	if !ok {
-		return "", "", nil, errors.Errorf("wrong input: first arg must be string, got %T", args[0])
+		return "", "", nil, fmt.Errorf("wrong input: first arg must be string, got %T", args[0])
 	}
 
 	switch len(args) {
@@ -112,7 +111,7 @@ func (t *Template) parseArgs(args ...interface{}) (name, in string, ctx interfac
 		var ok bool
 		in, ok = args[1].(string)
 		if !ok {
-			return "", "", nil, errors.Errorf("wrong input: second arg (in) must be string, got %T", args[0])
+			return "", "", nil, fmt.Errorf("wrong input: second arg (in) must be string, got %T", args[0])
 		}
 		ctx = args[2]
 	}

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hairyhenderson/gomplate/v3/conv"
 	"github.com/hairyhenderson/gomplate/v3/env"
 	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
-	"github.com/pkg/errors"
 )
 
 // GetToken -
@@ -31,7 +30,7 @@ func (v *Vault) GetToken() (string, error) {
 			return token, err
 		}
 	}
-	return "", errors.New("no vault auth methods succeeded")
+	return "", fmt.Errorf("no vault auth methods succeeded")
 }
 
 // AppIDLogin - app-id auth backend
@@ -52,10 +51,10 @@ func (v *Vault) AppIDLogin() (string, error) {
 	path := fmt.Sprintf("auth/%s/login/%s", mount, appID)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		return "", errors.Wrapf(err, "appID logon failed")
+		return "", fmt.Errorf("appID logon failed: %w", err)
 	}
 	if secret == nil {
-		return "", errors.New("empty response from AppID logon")
+		return "", fmt.Errorf("empty response from AppID logon")
 	}
 
 	return secret.Auth.ClientToken, nil
@@ -80,10 +79,10 @@ func (v *Vault) AppRoleLogin() (string, error) {
 	path := fmt.Sprintf("auth/%s/login", mount)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		return "", errors.Wrap(err, "appRole logon failed")
+		return "", fmt.Errorf("appRole logon failed: %w", err)
 	}
 	if secret == nil {
-		return "", errors.New("empty response from AppRole logon")
+		return "", fmt.Errorf("empty response from AppRole logon")
 	}
 
 	return secret.Auth.ClientToken, nil
@@ -106,10 +105,10 @@ func (v *Vault) GitHubLogin() (string, error) {
 	path := fmt.Sprintf("auth/%s/login", mount)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		return "", errors.Wrap(err, "appRole logon failed")
+		return "", fmt.Errorf("appRole logon failed: %w", err)
 	}
 	if secret == nil {
-		return "", errors.New("empty response from AppRole logon")
+		return "", fmt.Errorf("empty response from AppRole logon")
 	}
 
 	return secret.Auth.ClientToken, nil
@@ -133,10 +132,10 @@ func (v *Vault) UserPassLogin() (string, error) {
 	path := fmt.Sprintf("auth/%s/login/%s", mount, username)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		return "", errors.Wrap(err, "userPass logon failed")
+		return "", fmt.Errorf("userPass logon failed: %w", err)
 	}
 	if secret == nil {
-		return "", errors.New("empty response from UserPass logon")
+		return "", fmt.Errorf("empty response from UserPass logon")
 	}
 
 	return secret.Auth.ClientToken, nil
@@ -160,10 +159,10 @@ func (v *Vault) EC2Login() (string, error) {
 	path := fmt.Sprintf("auth/%s/login", mount)
 	secret, err := v.client.Logical().Write(path, vars)
 	if err != nil {
-		return "", errors.Wrapf(err, "AWS EC2 logon failed")
+		return "", fmt.Errorf("AWS EC2 logon failed: %w", err)
 	}
 	if secret == nil {
-		return "", errors.New("empty response from AWS EC2 logon")
+		return "", fmt.Errorf("empty response from AWS EC2 logon")
 	}
 
 	if output != "" {
@@ -172,14 +171,14 @@ func (v *Vault) EC2Login() (string, error) {
 		}
 		f, err := os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, iohelpers.NormalizeFileMode(0o600))
 		if err != nil {
-			return "", errors.Wrapf(err, "Error opening nonce output file")
+			return "", fmt.Errorf("error opening nonce output file: %w", err)
 		}
 		n, err := f.Write([]byte(nonce + "\n"))
 		if err != nil {
-			return "", errors.Wrapf(err, "Error writing nonce output file")
+			return "", fmt.Errorf("error writing nonce output file: %w", err)
 		}
 		if n == 0 {
-			return "", errors.Wrapf(err, "No bytes written to nonce output file")
+			return "", fmt.Errorf("no bytes written to nonce output file: %w", err)
 		}
 	}
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -3,9 +3,8 @@ package vault
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/url"
-
-	"github.com/pkg/errors"
 
 	vaultapi "github.com/hashicorp/vault/api"
 )
@@ -21,14 +20,14 @@ func New(u *url.URL) (*Vault, error) {
 
 	err := vaultConfig.ReadEnvironment()
 	if err != nil {
-		return nil, errors.Wrapf(err, "Vault setup failed")
+		return nil, fmt.Errorf("vault setup failed: %w", err)
 	}
 
 	setVaultURL(vaultConfig, u)
 
 	client, err := vaultapi.NewClient(vaultConfig)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Vault setup failed")
+		return nil, fmt.Errorf("vault setup failed: %w", err)
 	}
 
 	return &Vault{client}, nil
@@ -107,7 +106,7 @@ func (v *Vault) List(path string) ([]byte, error) {
 
 	keys, ok := secret.Data["keys"]
 	if !ok {
-		return nil, errors.Errorf("keys param missing from vault list")
+		return nil, fmt.Errorf("keys param missing from vault list")
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Replace uses of `github.com/pkg/errors` with `fmt.Errorf`. `pkg/errors` is now archived, and the `fmt.Errorf` support for error wrapping is now more idiomatic.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>