### PR TITLE
random: fix lint error on deprecated rand.Seed use

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -6,13 +6,8 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
-	"time"
 	"unicode"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // Default set, matches "[a-zA-Z0-9_.-]"
 const defaultSet = "-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
`math/rand` no longer seeds to `1` by default, so calling `rand.Seed(time.Now().UnixNano())` is no longer necessary (and triggers a lint error). It's safe enough to just use the global `rand` funcs now.