### PR TITLE
Remove support for obsolete Vault app-id auth

### DIFF
--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -666,7 +666,6 @@ This table describes the currently-supported authentication mechanisms and how t
 | auth back-end | configuration |
 |-------------:|---------------|
 | [`approle`](https://www.vaultproject.io/docs/auth/approle.html) | Environment variables `$VAULT_ROLE_ID` and `$VAULT_SECRET_ID` must be set to the appropriate values.<br/> If the back-end is mounted to a different location, set `$VAULT_AUTH_APPROLE_MOUNT`. |
-| [`app-id`](https://www.vaultproject.io/docs/auth/app-id.html) | Environment variables `$VAULT_APP_ID` and `$VAULT_USER_ID` must be set to the appropriate values.<br/> If the back-end is mounted to a different location, set `$VAULT_AUTH_APP_ID_MOUNT`. |
 | [`github`](https://www.vaultproject.io/docs/auth/github.html) | Environment variable `$VAULT_AUTH_GITHUB_TOKEN` must be set to an appropriate value.<br/> If the back-end is mounted to a different location, set `$VAULT_AUTH_GITHUB_MOUNT`. |
 | [`userpass`](https://www.vaultproject.io/docs/auth/userpass.html) | Environment variables `$VAULT_AUTH_USERNAME` and `$VAULT_AUTH_PASSWORD` must be set to the appropriate values.<br/> If the back-end is mounted to a different location, set `$VAULT_AUTH_USERPASS_MOUNT`. |
 | [`token`](https://www.vaultproject.io/docs/auth/token.html) | Determined from either the `$VAULT_TOKEN` environment variable, or read from the file `~/.vault-token` |

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -19,7 +19,6 @@ func (v *Vault) GetToken() (string, error) {
 	// sorted in order of precedence
 	authFuncs := []func() (string, error){
 		v.AppRoleLogin,
-		v.AppIDLogin,
 		v.GitHubLogin,
 		v.UserPassLogin,
 		v.TokenLogin,
@@ -31,33 +30,6 @@ func (v *Vault) GetToken() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("no vault auth methods succeeded")
-}
-
-// AppIDLogin - app-id auth backend
-func (v *Vault) AppIDLogin() (string, error) {
-	appID := env.Getenv("VAULT_APP_ID")
-	userID := env.Getenv("VAULT_USER_ID")
-
-	if appID == "" || userID == "" {
-		return "", nil
-	}
-
-	mount := env.Getenv("VAULT_AUTH_APP_ID_MOUNT", "app-id")
-
-	vars := map[string]interface{}{
-		"user_id": userID,
-	}
-
-	path := fmt.Sprintf("auth/%s/login/%s", mount, appID)
-	secret, err := v.client.Logical().Write(path, vars)
-	if err != nil {
-		return "", fmt.Errorf("appID logon failed: %w", err)
-	}
-	if secret == nil {
-		return "", fmt.Errorf("empty response from AppID logon")
-	}
-
-	return secret.Auth.ClientToken, nil
 }
 
 // AppRoleLogin - approle auth backend


### PR DESCRIPTION
As of Vault 1.13.0, the AppID auth method is finally removed. See https://developer.hashicorp.com/vault/docs/deprecation/faq#q-what-should-i-do-if-i-use-mount-filters-appid-or-any-of-the-standalone-db-engines for details.

The AppID auth method has been deprecated since Vault 0.6.1, which came out in 2016. It therefore makes sense to remove gomplate support starting in the next major release.