### PR TITLE
Bump to v4 module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,23 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-    day: sunday
-    time: "22:00"
+    day: saturday
+    time: "02:00"
     timezone: Canada/Eastern
   open-pull-requests-limit: 10
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: weekly
-    day: sunday
-    time: "22:00"
+    day: saturday
+    time: "02:00"
     timezone: Canada/Eastern
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
-    day: sunday
-    time: "22:00"
+    day: saturday
+    time: "02:00"
     timezone: Canada/Eastern
   open-pull-requests-limit: 10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Docker Build
 on:
   push:
     branches: [ main ]
-    tags: [ 'v*' ]
+    tags: [ 'v*', '!v*-pre*']
   pull_request:
     branches: [ main ]
 
@@ -26,9 +26,9 @@ jobs:
       uses: docker/setup-qemu-action@v2.1.0
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2.4.1
+      uses: docker/setup-buildx-action@v2.5.0
       with:
-        version: v0.5.1
+        version: v0.10.4
         driver-opts: |
           image=moby/buildkit:buildx-stable-1
           network=host

--- a/aws/ec2info.go
+++ b/aws/ec2info.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/env"
 )
 
 var describerClient InstanceDescriber

--- a/aws/ec2meta.go
+++ b/aws/ec2meta.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/env"
 )
 
 const (

--- a/aws/kms.go
+++ b/aws/kms.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	b64 "github.com/hairyhenderson/gomplate/v3/base64"
+	b64 "github.com/hairyhenderson/gomplate/v4/base64"
 
 	"github.com/aws/aws-sdk-go/service/kms"
 )

--- a/aws/kms_test.go
+++ b/aws/kms_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/kms"
-	b64 "github.com/hairyhenderson/gomplate/v3/base64"
+	b64 "github.com/hairyhenderson/gomplate/v4/base64"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/gomplate/main.go
+++ b/cmd/gomplate/main.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/cmd"
+	"github.com/hairyhenderson/gomplate/v4/internal/cmd"
 )
 
 func main() {

--- a/coll/coll.go
+++ b/coll/coll.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	iconv "github.com/hairyhenderson/gomplate/v4/internal/conv"
 )
 
 // Slice creates a slice from a bunch of arguments

--- a/config.go
+++ b/config.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 )
 
 // Config - values necessary for rendering templates with gomplate.
 // Mainly for use by the CLI
 //
 // Deprecated: this type will be phased out,
-// [github.com/hairyhenderson/gomplate/v3/internal/config.Config] is used
+// [github.com/hairyhenderson/gomplate/v4/internal/config.Config] is used
 // everywhere else, and will be exposed as API in a future version
 type Config struct {
 	Input       string

--- a/context.go
+++ b/context.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v4/data"
 )
 
 // context for templates

--- a/context_test.go
+++ b/context_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v4/data"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/conv/conv.go
+++ b/conv/conv.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
+	iconv "github.com/hairyhenderson/gomplate/v4/internal/conv"
 )
 
 // Bool converts a string to a boolean value, using strconv.ParseBool under the covers.
@@ -68,7 +68,7 @@ func ToBools(in ...interface{}) []bool {
 
 // Slice creates a slice from a bunch of arguments
 //
-// Deprecated: use [github.com/hairyhenderson/gomplate/v3/coll.Slice] instead
+// Deprecated: use [github.com/hairyhenderson/gomplate/v4/coll.Slice] instead
 func Slice(args ...interface{}) []interface{} {
 	return args
 }

--- a/data/data.go
+++ b/data/data.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/Shopify/ejson"
 	ejsonJson "github.com/Shopify/ejson/json"
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/env"
 	"github.com/joho/godotenv"
 
 	// XXX: replace once https://github.com/BurntSushi/toml/pull/179 is merged

--- a/data/datasource.go
+++ b/data/datasource.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/spf13/afero"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
-	"github.com/hairyhenderson/gomplate/v3/libkv"
-	"github.com/hairyhenderson/gomplate/v3/vault"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/libkv"
+	"github.com/hairyhenderson/gomplate/v4/vault"
 )
 
 func regExtension(ext, typ string) {

--- a/data/datasource_aws_sm.go
+++ b/data/datasource_aws_sm.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 
-	gaws "github.com/hairyhenderson/gomplate/v3/aws"
+	gaws "github.com/hairyhenderson/gomplate/v4/aws"
 )
 
 // awsSecretsManagerGetter - A subset of Secrets Manager API for use in unit testing

--- a/data/datasource_awssmp.go
+++ b/data/datasource_awssmp.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ssm"
 
-	gaws "github.com/hairyhenderson/gomplate/v3/aws"
+	gaws "github.com/hairyhenderson/gomplate/v4/aws"
 )
 
 // awssmpGetter - A subset of SSM API for use in unit testing

--- a/data/datasource_blob.go
+++ b/data/datasource_blob.go
@@ -11,8 +11,8 @@ import (
 	"path"
 	"strings"
 
-	gaws "github.com/hairyhenderson/gomplate/v3/aws"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	gaws "github.com/hairyhenderson/gomplate/v4/aws"
+	"github.com/hairyhenderson/gomplate/v4/env"
 
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/gcsblob"

--- a/data/datasource_consul.go
+++ b/data/datasource_consul.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/libkv"
+	"github.com/hairyhenderson/gomplate/v4/libkv"
 )
 
 func readConsul(ctx context.Context, source *Source, args ...string) (data []byte, err error) {

--- a/data/datasource_env.go
+++ b/data/datasource_env.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/env"
 )
 
 func readEnv(ctx context.Context, source *Source, args ...string) (b []byte, err error) {

--- a/data/datasource_git.go
+++ b/data/datasource_git.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/base64"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/base64"
+	"github.com/hairyhenderson/gomplate/v4/env"
 	"github.com/rs/zerolog"
 
 	"github.com/go-git/go-billy/v5"

--- a/data/datasource_merge.go
+++ b/data/datasource_merge.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/coll"
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/coll"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 )
 
 // readMerge demultiplexes a `merge:` datasource. The 'args' parameter currently

--- a/data/datasource_test.go
+++ b/data/datasource_test.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/assert"

--- a/data/datasource_vault.go
+++ b/data/datasource_vault.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/vault"
+	"github.com/hairyhenderson/gomplate/v4/vault"
 )
 
 func readVault(ctx context.Context, source *Source, args ...string) (data []byte, err error) {

--- a/data/datasource_vault_test.go
+++ b/data/datasource_vault_test.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/vault"
+	"github.com/hairyhenderson/gomplate/v4/vault"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/docs/content/installing.md
+++ b/docs/content/installing.md
@@ -117,7 +117,7 @@ $ gomplate --help
 If you're a Go developer, sometimes it's faster to just use `go install` to install `gomplate`:
 
 ```console
-$ go install github.com/hairyhenderson/gomplate/v3/cmd/gomplate@latest
+$ go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@latest
 $ gomplate --help
 ...
 ```

--- a/file/file.go
+++ b/file/file.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 
 	"github.com/spf13/afero"
 )

--- a/funcs.go
+++ b/funcs.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/v3/data"
-	"github.com/hairyhenderson/gomplate/v3/funcs" //nolint:staticcheck
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/data"
+	"github.com/hairyhenderson/gomplate/v4/funcs" //nolint:staticcheck
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 )
 
 // Funcs -

--- a/funcs/aws.go
+++ b/funcs/aws.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/v3/aws"
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/aws"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 )
 
 // AWSNS - the aws namespace

--- a/funcs/aws_test.go
+++ b/funcs/aws_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/aws"
+	"github.com/hairyhenderson/gomplate/v4/aws"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/funcs/base64.go
+++ b/funcs/base64.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"context"
 
-	"github.com/hairyhenderson/gomplate/v3/base64"
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/base64"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 )
 
 // Base64NS - the base64 namespace

--- a/funcs/coll.go
+++ b/funcs/coll.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/internal/deprecated"
-	"github.com/hairyhenderson/gomplate/v3/internal/texttemplate"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
+	"github.com/hairyhenderson/gomplate/v4/internal/texttemplate"
 
-	"github.com/hairyhenderson/gomplate/v3/coll"
+	"github.com/hairyhenderson/gomplate/v4/coll"
 )
 
 // CollNS -

--- a/funcs/conv.go
+++ b/funcs/conv.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/v3/coll"
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/internal/deprecated"
+	"github.com/hairyhenderson/gomplate/v4/coll"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
 )
 
 // ConvNS -

--- a/funcs/crypto.go
+++ b/funcs/crypto.go
@@ -12,8 +12,8 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/crypto"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/crypto"
 )
 
 // CryptoNS - the crypto namespace

--- a/funcs/crypto_test.go
+++ b/funcs/crypto_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/funcs/data.go
+++ b/funcs/data.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"context"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/data"
 )
 
 // DataNS -

--- a/funcs/env.go
+++ b/funcs/env.go
@@ -3,8 +3,8 @@ package funcs
 import (
 	"context"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/env"
 )
 
 // EnvNS - the Env namespace

--- a/funcs/file.go
+++ b/funcs/file.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"os"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/file"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/file"
 	"github.com/spf13/afero"
 )
 

--- a/funcs/filepath.go
+++ b/funcs/filepath.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 )
 
 // FilePathNS - the Path namespace

--- a/funcs/funcs.go
+++ b/funcs/funcs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 )
 
 func checkExperimental(ctx context.Context) error {

--- a/funcs/gcp.go
+++ b/funcs/gcp.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/hairyhenderson/gomplate/v3/gcp"
+	"github.com/hairyhenderson/gomplate/v4/gcp"
 )
 
 // GCPNS - the gcp namespace

--- a/funcs/math.go
+++ b/funcs/math.go
@@ -6,9 +6,9 @@ import (
 	gmath "math"
 	"strconv"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 
-	"github.com/hairyhenderson/gomplate/v3/math"
+	"github.com/hairyhenderson/gomplate/v4/math"
 )
 
 // MathNS - the math namespace

--- a/funcs/net.go
+++ b/funcs/net.go
@@ -7,10 +7,10 @@ import (
 	stdnet "net"
 	"net/netip"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/internal/cidr"
-	"github.com/hairyhenderson/gomplate/v3/internal/deprecated"
-	"github.com/hairyhenderson/gomplate/v3/net"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/internal/cidr"
+	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
+	"github.com/hairyhenderson/gomplate/v4/net"
 	"go4.org/netipx"
 	"inet.af/netaddr"
 )

--- a/funcs/net_test.go
+++ b/funcs/net_test.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"inet.af/netaddr"

--- a/funcs/path.go
+++ b/funcs/path.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"path"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 )
 
 // PathNS - the Path namespace

--- a/funcs/random.go
+++ b/funcs/random.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"unicode/utf8"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	iconv "github.com/hairyhenderson/gomplate/v3/internal/conv"
-	"github.com/hairyhenderson/gomplate/v3/random"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	iconv "github.com/hairyhenderson/gomplate/v4/internal/conv"
+	"github.com/hairyhenderson/gomplate/v4/random"
 )
 
 // RandomNS -

--- a/funcs/regexp.go
+++ b/funcs/regexp.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/regexp"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/regexp"
 )
 
 // ReNS -

--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -13,9 +13,9 @@ import (
 	"unicode/utf8"
 
 	"github.com/Masterminds/goutils"
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/internal/deprecated"
-	gompstrings "github.com/hairyhenderson/gomplate/v3/strings"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
+	gompstrings "github.com/hairyhenderson/gomplate/v4/strings"
 
 	"github.com/gosimple/slug"
 	"golang.org/x/text/cases"

--- a/funcs/test.go
+++ b/funcs/test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/test"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/test"
 )
 
 // TestNS -

--- a/funcs/time.go
+++ b/funcs/time.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	gotime "time"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/env"
-	"github.com/hairyhenderson/gomplate/v3/time"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/env"
+	"github.com/hairyhenderson/gomplate/v4/time"
 )
 
 // TimeNS -

--- a/funcs/uuid.go
+++ b/funcs/uuid.go
@@ -3,7 +3,7 @@ package funcs
 import (
 	"context"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 
 	"github.com/google/uuid"
 )

--- a/gcp/meta.go
+++ b/gcp/meta.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/env"
 )
 
 // DefaultEndpoint is the DNS name for the default GCP compute instance metadata service.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/hairyhenderson/gomplate/v3
+module github.com/hairyhenderson/gomplate/v4
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/goutils v1.1.1

--- a/gomplate.go
+++ b/gomplate.go
@@ -11,8 +11,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/data"
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/data"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 )
 
 // RunTemplates - run all gomplate templates specified by the given configuration

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -9,10 +9,10 @@ import (
 
 	"text/template"
 
-	"github.com/hairyhenderson/gomplate/v3/aws"
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/data"
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/aws"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/data"
+	"github.com/hairyhenderson/gomplate/v4/env"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/env"
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/env"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 
 	"github.com/rs/zerolog"
 

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"

--- a/internal/cmd/logger.go
+++ b/internal/cmd/logger.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/env"
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
 	"golang.org/x/term"

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -8,9 +8,9 @@ import (
 	"os/signal"
 
 	"github.com/hairyhenderson/go-fsimpl/filefs"
-	"github.com/hairyhenderson/gomplate/v3"
-	"github.com/hairyhenderson/gomplate/v3/env"
-	"github.com/hairyhenderson/gomplate/v3/version"
+	"github.com/hairyhenderson/gomplate/v4"
+	"github.com/hairyhenderson/gomplate/v4/env"
+	"github.com/hairyhenderson/gomplate/v4/version"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 	"github.com/hairyhenderson/yaml"
 )
 

--- a/internal/config/configfile_test.go
+++ b/internal/config/configfile_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 	"github.com/hairyhenderson/yaml"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/tests/integration/basic_test.go
+++ b/internal/tests/integration/basic_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 	testfs "gotest.tools/v3/fs"

--- a/internal/tests/integration/inputdir_test.go
+++ b/internal/tests/integration/inputdir_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 	tassert "github.com/stretchr/testify/assert"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/fs"

--- a/internal/tests/integration/integration_test.go
+++ b/internal/tests/integration/integration_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	gcmd "github.com/hairyhenderson/gomplate/v3/internal/cmd"
+	gcmd "github.com/hairyhenderson/gomplate/v4/internal/cmd"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"gotest.tools/v3/icmd"

--- a/libkv/consul.go
+++ b/libkv/consul.go
@@ -12,9 +12,9 @@ import (
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/env"
-	"github.com/hairyhenderson/gomplate/v3/vault"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/env"
+	"github.com/hairyhenderson/gomplate/v4/vault"
 	consulapi "github.com/hashicorp/consul/api"
 )
 

--- a/plugins.go
+++ b/plugins.go
@@ -13,8 +13,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 )
 
 // bindPlugins creates custom plugin functions for each plugin specified by

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -10,7 +10,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/render.go
+++ b/render.go
@@ -10,9 +10,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/data"
-	"github.com/hairyhenderson/gomplate/v3/funcs" //nolint:staticcheck
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/data"
+	"github.com/hairyhenderson/gomplate/v4/funcs" //nolint:staticcheck
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 )
 
 // Options for template rendering.

--- a/render_test.go
+++ b/render_test.go
@@ -11,7 +11,7 @@ import (
 	"testing/fstest"
 
 	"github.com/hairyhenderson/go-fsimpl"
-	"github.com/hairyhenderson/gomplate/v3/data"
+	"github.com/hairyhenderson/gomplate/v4/data"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/strings/strings.go
+++ b/strings/strings.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/goutils"
-	"github.com/hairyhenderson/gomplate/v3/conv"
+	"github.com/hairyhenderson/gomplate/v4/conv"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/template.go
+++ b/template.go
@@ -12,9 +12,9 @@ import (
 	"text/template"
 
 	"github.com/hairyhenderson/go-fsimpl"
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
-	"github.com/hairyhenderson/gomplate/v3/tmpl"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/tmpl"
 
 	"github.com/spf13/afero"
 	"github.com/zealic/xignore"

--- a/template_test.go
+++ b/template_test.go
@@ -11,8 +11,8 @@ import (
 	"text/template"
 
 	"github.com/hairyhenderson/go-fsimpl"
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/assert"

--- a/template_unix_test.go
+++ b/template_unix_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/assert"

--- a/template_windows_test.go
+++ b/template_windows_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hairyhenderson/gomplate/v3/internal/config"
+	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/assert"

--- a/time/time.go
+++ b/time/time.go
@@ -4,7 +4,7 @@ package time
 import (
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/env"
+	"github.com/hairyhenderson/gomplate/v4/env"
 )
 
 // ZoneName - a convenience function for determining the current timezone's name

--- a/vault/auth.go
+++ b/vault/auth.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hairyhenderson/gomplate/v3/aws"
-	"github.com/hairyhenderson/gomplate/v3/conv"
-	"github.com/hairyhenderson/gomplate/v3/env"
-	"github.com/hairyhenderson/gomplate/v3/internal/iohelpers"
+	"github.com/hairyhenderson/gomplate/v4/aws"
+	"github.com/hairyhenderson/gomplate/v4/conv"
+	"github.com/hairyhenderson/gomplate/v4/env"
+	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"
 )
 
 // GetToken -


### PR DESCRIPTION
In preparation for v4.0.0 release (which isn't coming any time soon!) - the module needs to be upped.

I'm also going to push a `v4.0.0-pre-0` tag at this commit so the prerelease version generation works too.