### PR TITLE
Add make test-remote-windows target to run tests on remote Windows host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .git
 bin
+testbin
 report.xml
 ./gomplate
 *.cid

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,32 @@ test:
 	$(GO) test -race -coverprofile=c.out ./...
 endif
 
+.SECONDEXPANSION:
+$(shell go list -f '{{ if not (eq "" (join .TestGoFiles "")) }}testbin/{{.ImportPath}}.test.exe{{end}}' ./...): $$(shell go list -f '{{.Dir}}' $$(subst testbin/,,$$(subst .test.exe,,$$@)))
+	@GOOS=windows GOARCH=amd64 $(GO) test -c -o $@ $<
+
+.SECONDEXPANSION:
+$(shell go list -f '{{ if not (eq "" (join .TestGoFiles "")) }}testbin/{{.ImportPath}}.test{{end}}' ./...): $$(shell go list -f '{{.Dir}}' $$(subst testbin/,,$$(subst .test,,$$@)))
+	@$(GO) test -c -o $@ $<
+
+# this is a special target for testing a package on Windows from a non-Windows
+# host. It builds the Windows test binary, then SCPs it to the Windows host, and
+# runs the tests there. This depends on the GO_REMOTE_WINDOWS environment
+# variable being set as 'username@host'. The Windows host must have Git Bash
+# installed, or maybe MSYS2, so that a number of standard Unix tools are
+# available. Git must also be configured with a username and email address. See
+# the GitHub workflow config in .github/workflows/build.yml for hints.
+# A recent PowerShell is also required, such as version 7.3 or later.
+.SECONDEXPANSION:
+$(shell go list -f '{{ if not (eq "" (join .TestGoFiles "")) }}testbin/{{.ImportPath}}.test.exe.remote{{end}}' ./...): $$(shell go list -f '{{.Dir}}' $$(subst testbin/,,$$(subst .test.exe.remote,,$$@)))
+	@echo $<
+	@GOOS=windows GOARCH=amd64 $(GO) test -tags timetzdata -c -o $(PREFIX)/testbin/remote-test.exe $<
+	@scp -q $(PREFIX)/testbin/remote-test.exe $(GO_REMOTE_WINDOWS):/$(shell ssh $(GO_REMOTE_WINDOWS) 'echo %TEMP%' | cut -f2 -d= | sed -e 's#\\#/#g')/
+	@ssh $(GO_REMOTE_WINDOWS) '%TEMP%\remote-test.exe'
+
+# test-remote-windows runs the above target for all packages that have tests
+test-remote-windows: $(shell go list -f '{{ if not (eq "" (join .TestGoFiles "")) }}testbin/{{.ImportPath}}.test.exe.remote{{end}}' ./...)
+
 ifeq ($(OS),Windows_NT)
 integration: $(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS))
 	$(GO) test -v \
@@ -192,6 +218,6 @@ lint:
 ci-lint:
 	@golangci-lint run --verbose --max-same-issues=0 --max-issues-per-linter=0 --out-format=github-actions
 
-.PHONY: gen-changelog clean test build-x build-release build test-integration-docker gen-docs lint clean-images clean-containers docker-images
+.PHONY: gen-changelog clean test build-x build-release build test-integration-docker gen-docs lint clean-images clean-containers docker-images test-remote-windows integration testbins-windows
 .DELETE_ON_ERROR:
 .SECONDARY:

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -517,8 +517,7 @@ func TestDecryptEJSON(t *testing.T) {
 		"_unencrypted": "notsosecret"
 	}`
 
-	os.Setenv("EJSON_KEY", privateKey)
-	defer os.Unsetenv("EJSON_KEY")
+	t.Setenv("EJSON_KEY", privateKey)
 	actual, err := decryptEJSON(in)
 	assert.NoError(t, err)
 	assert.EqualValues(t, expected, actual)
@@ -530,19 +529,17 @@ func TestDecryptEJSON(t *testing.T) {
 	tmpDir := fs.NewDir(t, "gomplate-ejsontest",
 		fs.WithFile(publicKey, privateKey),
 	)
-	defer tmpDir.Remove()
+	t.Cleanup(tmpDir.Remove)
 
 	os.Unsetenv("EJSON_KEY")
-	os.Setenv("EJSON_KEY_FILE", tmpDir.Join(publicKey))
-	defer os.Unsetenv("EJSON_KEY_FILE")
+	t.Setenv("EJSON_KEY_FILE", tmpDir.Join(publicKey))
 	actual, err = decryptEJSON(in)
 	assert.NoError(t, err)
 	assert.EqualValues(t, expected, actual)
 
 	os.Unsetenv("EJSON_KEY")
 	os.Unsetenv("EJSON_KEY_FILE")
-	os.Setenv("EJSON_KEYDIR", tmpDir.Path())
-	defer os.Unsetenv("EJSON_KEYDIR")
+	t.Setenv("EJSON_KEYDIR", tmpDir.Path())
 	actual, err = decryptEJSON(in)
 	assert.NoError(t, err)
 	assert.EqualValues(t, expected, actual)

--- a/plugins.go
+++ b/plugins.go
@@ -146,7 +146,7 @@ func (p *plugin) run(args ...interface{}) (interface{}, error) {
 	start := time.Now()
 	err := c.Start()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("starting command: %w", err)
 	}
 
 	// make sure all signals are propagated

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBindPlugins(t *testing.T) {
@@ -69,7 +70,7 @@ func TestRun(t *testing.T) {
 		path:    "echo",
 	}
 	out, err := p.run("foo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.Equal(t, "foo", strings.TrimSpace(out.(string)))
 }


### PR DESCRIPTION
This adds a `test-remote-windows` make target that lets me run tests remotely on a Windows VM with a minimum of fuss. There are some rough edges, but it's a good start. This should help me fix Windows issues much faster in future...