### PR TITLE
fix reading templates in `gomplate.RunTemplates()`

### DIFF
--- a/gomplate.go
+++ b/gomplate.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/hairyhenderson/go-fsimpl/filefs"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -23,7 +24,16 @@ func RunTemplates(o *Config) error {
 	if err != nil {
 		return err
 	}
-	return Run(context.Background(), cfg)
+
+	ctx := context.Background()
+
+	// inject a default filesystem provider for file:// URLs
+	// required for reading template files
+	if FSProviderFromContext(ctx) == nil {
+		ctx = ContextWithFSProvider(ctx, filefs.FS)
+	}
+
+	return Run(ctx, cfg)
 }
 
 // Run all gomplate templates specified by the given configuration


### PR DESCRIPTION
Currently, when a downstream go package imports `github.com/hairyhenderson/gomplate/v3` and invokes `gomplate.RunTemplates()` with a non-empty `Templates` list in its `gomplate.Config`, it will always get a nil pointer dereference error.

For example, here is some example code that fails before this PR, but succeeds after:

```go
import (
	gomplate "github.com/hairyhenderson/gomplate/v3"
)

gomplateConfig := &gomplate.Config{
	InputDir:  "MY_INPUT",
	OutputDir: "MY_OUTPUT",
	LDelim:    "{{",
	RDelim:    "}}",
	Contexts:  []string{"Values=values.yaml"},
	Templates: []string{"helpers=MY_HELPERS"},
}
err := gomplate.RunTemplates(gomplateConfig)
if err != nil {
	return err
}
```

---

This is because the `gomplate.RunTemplates()` only uses `context.Background()` for its context:

https://github.com/hairyhenderson/gomplate/blob/f3ba5d5b35a6db83b21d079eabb15d2eae37c906/gomplate.go#L21-L27

Which is missing the `filefs.FS` provider that the main gomplate CLI uses:

https://github.com/hairyhenderson/gomplate/blob/f3ba5d5b35a6db83b21d079eabb15d2eae37c906/internal/cmd/main.go#L170-L175

----

This PR fixes the `gomplate.RunTemplates()` function by using extending the background context it initializes with `filefs.FS`, just like the main gomplate CLI already does.