### PR TITLE
expose SuppressEmpty in `gomplate.Config`

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	RDelim string
 
 	Templates []string
+
+	SuppressEmpty bool
 }
 
 // defaults - sets any unset fields to their default value (if applicable)
@@ -119,19 +121,20 @@ func (o *Config) String() string {
 
 func (o *Config) toNewConfig() (*config.Config, error) {
 	cfg := &config.Config{
-		Input:       o.Input,
-		InputFiles:  o.InputFiles,
-		InputDir:    o.InputDir,
-		ExcludeGlob: o.ExcludeGlob,
-		OutputFiles: o.OutputFiles,
-		OutputDir:   o.OutputDir,
-		OutputMap:   o.OutputMap,
-		OutMode:     o.OutMode,
-		LDelim:      o.LDelim,
-		RDelim:      o.RDelim,
-		Stdin:       os.Stdin,
-		Stdout:      &iohelpers.NopCloser{Writer: o.Out},
-		Stderr:      os.Stderr,
+		Input:         o.Input,
+		InputFiles:    o.InputFiles,
+		InputDir:      o.InputDir,
+		ExcludeGlob:   o.ExcludeGlob,
+		OutputFiles:   o.OutputFiles,
+		OutputDir:     o.OutputDir,
+		OutputMap:     o.OutputMap,
+		OutMode:       o.OutMode,
+		LDelim:        o.LDelim,
+		RDelim:        o.RDelim,
+		SuppressEmpty: o.SuppressEmpty,
+		Stdin:         os.Stdin,
+		Stdout:        &iohelpers.NopCloser{Writer: o.Out},
+		Stderr:        os.Stderr,
 	}
 	err := cfg.ParsePluginFlags(o.Plugins)
 	if err != nil {


### PR DESCRIPTION
This PR adds the currently missing `SuppressEmpty` config to the public `gomplate.Config` class, so people packaging gomplate into their apps can enable this functionality when using `gomplate.RunTemplates()`.