### PR TITLE
Clarified documentation of data.CSVBy* functions

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -278,7 +278,7 @@ func CSV(args ...string) ([][]string, error) {
 // parameters:
 //
 //	delim - (optional) the (single-character!) field delimiter, defaults to ","
-//	  hdr - (optional) character-separated list of column names using delim as separator,
+//	  hdr - (optional) list of column names separated by `delim`,
 //	        set to "" to get auto-named columns (A-Z), omit
 //	        to use the first line
 //	   in - the CSV-format string to parse

--- a/data/data.go
+++ b/data/data.go
@@ -305,7 +305,7 @@ func CSVByRow(args ...string) (rows []map[string]string, err error) {
 // parameters:
 //
 //	delim - (optional) the (single-character!) field delimiter, defaults to ","
-//	  hdr - (optional) character-separated list of column names using delim as separator,
+//	  hdr - (optional) list of column names separated by `delim`,
 //	        set to "" to get auto-named columns (A-Z), omit
 //	        to use the first line
 //	   in - the CSV-format string to parse

--- a/data/data.go
+++ b/data/data.go
@@ -278,7 +278,7 @@ func CSV(args ...string) ([][]string, error) {
 // parameters:
 //
 //	delim - (optional) the (single-character!) field delimiter, defaults to ","
-//	  hdr - (optional) character-separated list of column names using delim as separator
+//	  hdr - (optional) character-separated list of column names using delim as separator,
 //	        set to "" to get auto-named columns (A-Z), omit
 //	        to use the first line
 //	   in - the CSV-format string to parse
@@ -305,7 +305,7 @@ func CSVByRow(args ...string) (rows []map[string]string, err error) {
 // parameters:
 //
 //	delim - (optional) the (single-character!) field delimiter, defaults to ","
-//	  hdr - (optional) character-separated list of column names using delim as separator
+//	  hdr - (optional) character-separated list of column names using delim as separator,
 //	        set to "" to get auto-named columns (A-Z), omit
 //	        to use the first line
 //	   in - the CSV-format string to parse

--- a/data/data.go
+++ b/data/data.go
@@ -278,7 +278,7 @@ func CSV(args ...string) ([][]string, error) {
 // parameters:
 //
 //	delim - (optional) the (single-character!) field delimiter, defaults to ","
-//	  hdr - (optional) comma-separated list of column names,
+//	  hdr - (optional) character-separated list of column names using delim as separator
 //	        set to "" to get auto-named columns (A-Z), omit
 //	        to use the first line
 //	   in - the CSV-format string to parse
@@ -305,7 +305,7 @@ func CSVByRow(args ...string) (rows []map[string]string, err error) {
 // parameters:
 //
 //	delim - (optional) the (single-character!) field delimiter, defaults to ","
-//	  hdr - (optional) comma-separated list of column names,
+//	  hdr - (optional) character-separated list of column names using delim as separator
 //	        set to "" to get auto-named columns (A-Z), omit
 //	        to use the first line
 //	   in - the CSV-format string to parse

--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -312,7 +312,7 @@ funcs:
         description: the (single-character!) field delimiter, defaults to `","`
       - name: header
         required: false
-        description: character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
+        description: list of column names separated by `delim`, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
       - name: input
         required: true
         description: the CSV-format string to parse

--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -312,7 +312,7 @@ funcs:
         description: the (single-character!) field delimiter, defaults to `","`
       - name: header
         required: false
-        description: comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
+        description: character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
       - name: input
         required: true
         description: the CSV-format string to parse
@@ -347,7 +347,7 @@ funcs:
         description: the (single-character!) field delimiter, defaults to `","`
       - name: header
         required: false
-        description: comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
+        description: character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
       - name: input
         required: true
         description: the CSV-format string to parse

--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -347,7 +347,7 @@ funcs:
         description: the (single-character!) field delimiter, defaults to `","`
       - name: header
         required: false
-        description: character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
+        description: list of column names separated by `delim`, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input`
       - name: input
         required: true
         description: the CSV-format string to parse

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -456,7 +456,7 @@ input | data.CSVByRow [delim] [header]
 | name | description |
 |------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `header` | _(optional)_ comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
+| `header` | _(optional)_ character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
 | `input` | _(required)_ the CSV-format string to parse |
 
 ### Examples
@@ -500,7 +500,7 @@ input | data.CSVByColumn [delim] [header]
 | name | description |
 |------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `header` | _(optional)_ comma-separated list of column names, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
+| `header` | _(optional)_ character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
 | `input` | _(required)_ the CSV-format string to parse |
 
 ### Examples

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -456,7 +456,7 @@ input | data.CSVByRow [delim] [header]
 | name | description |
 |------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `header` | _(optional)_ character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
+| `header` | _(optional)_ list of column names separated by `delim`, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
 | `input` | _(required)_ the CSV-format string to parse |
 
 ### Examples
@@ -500,7 +500,7 @@ input | data.CSVByColumn [delim] [header]
 | name | description |
 |------|-------------|
 | `delim` | _(optional)_ the (single-character!) field delimiter, defaults to `","` |
-| `header` | _(optional)_ character-separated list of column names using delim as separator, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
+| `header` | _(optional)_ list of column names separated by `delim`, set to `""` to get auto-named columns (A-Z), defaults to using the first line of `input` |
 | `input` | _(required)_ the CSV-format string to parse |
 
 ### Examples


### PR DESCRIPTION
This updates the description of the header parameter to data.CSVBy* functions from *comma-separated list of column names* to *character-separated list of column names using delim as separator*.

Fixes #1711 
