### PR TITLE
Update Makefile to use CGO_ENABLED environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,35 +106,35 @@ build-release: artifacts.cid
 docker-images: gomplate.iid
 
 $(PREFIX)/bin/$(PKG_NAME)_%v5$(call extension,$(GOOS)): $(shell find $(PREFIX) -type f -name "*.go")
-	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=5 CGO_ENABLED=0 \
+	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=5 CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build \
 			-ldflags "-w -s $(GO_LDFLAGS)" \
 			-o $@ \
 			./cmd/$(PKG_NAME)
 
 $(PREFIX)/bin/$(PKG_NAME)_%v6$(call extension,$(GOOS)): $(shell find $(PREFIX) -type f -name "*.go")
-	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=6 CGO_ENABLED=0 \
+	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=6 CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build \
 			-ldflags "-w -s $(GO_LDFLAGS)" \
 			-o $@ \
 			./cmd/$(PKG_NAME)
 
 $(PREFIX)/bin/$(PKG_NAME)_%v7$(call extension,$(GOOS)): $(shell find $(PREFIX) -type f -name "*.go")
-	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=7 CGO_ENABLED=0 \
+	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=7 CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build \
 			-ldflags "-w -s $(GO_LDFLAGS)" \
 			-o $@ \
 			./cmd/$(PKG_NAME)
 
 $(PREFIX)/bin/$(PKG_NAME)_windows-%.exe: $(shell find $(PREFIX) -type f -name "*.go")
-	GOOS=windows GOARCH=$* GOARM= CGO_ENABLED=0 \
+	GOOS=windows GOARCH=$* GOARM= CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build \
 			-ldflags "-w -s $(GO_LDFLAGS)" \
 			-o $@ \
 			./cmd/$(PKG_NAME)
 
 $(PREFIX)/bin/$(PKG_NAME)_%$(TARGETVARIANT)$(call extension,$(GOOS)): $(shell find $(PREFIX) -type f -name "*.go")
-	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=$(GOARM) CGO_ENABLED=0 \
+	GOOS=$(shell echo $* | cut -f1 -d-) GOARCH=$(shell echo $* | cut -f2 -d- ) GOARM=$(GOARM) CGO_ENABLED=$(CGO_ENABLED) \
 		$(GO) build \
 			-ldflags "-w -s $(GO_LDFLAGS)" \
 			-o $@ \

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ GO_LDFLAGS ?= $(COMMIT_FLAG) $(VERSION_FLAG)
 GOOS ?= $(shell $(GO) version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\1/')
 GOARCH ?= $(shell $(GO) version | sed 's/^.*\ \([a-z0-9]*\)\/\([a-z0-9]*\)/\2/')
 
+# allow overriding CGO_ENABLED for scenarios where gomplate must be compiled with CGO enabled, such as when using boringcrypto.
+CGO_ENABLED ?= 0
+
 ifeq ("$(TARGETVARIANT)","")
 ifneq ("$(GOARM)","")
 TARGETVARIANT := v$(GOARM)


### PR DESCRIPTION
There are scenarios in which `CGO_ENABLED=1` has to be set when building the `gomplate` binary. 
Specifically building the binary in FIPS-enabled mode requires that `CGO_ENABLED=1` and `GOEXPERIMENT=boringcrypto` are set.
However, this is not possible with the Makefile hardcoding `CGO_ENABLED=0`. 

This PR makes changes to allow the value of the `CGO_ENABLED` environment variable to be used if it is set. 
If the `CGO_ENABLED` environment variable is not set, then `CGO_ENABLED` defaults to 0.