### PR TITLE
Fix output-map usage docs

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -97,7 +97,7 @@ And a datasource `filemap.json`:
 We can blend these two together:
 
 ```console
-$ gomplate -t out=out.t -c filemap.json --input-dir=in --output-map='{{ template "out" }}'
+$ gomplate -t out=out.t -c filemap.json --input-dir=in --output-map='{{ template "out" . }}'
 ```
 
 ### `--chmod`


### PR DESCRIPTION
Fixes #1686.

The example wasn't working, because the context wasn't being passed in to `template`.