### PR TITLE
Make `strings.Title` not lowercase acronyms

### DIFF
--- a/funcs/strings.go
+++ b/funcs/strings.go
@@ -235,7 +235,7 @@ func (StringFuncs) TrimSuffix(cutset string, s interface{}) string {
 
 // Title -
 func (f *StringFuncs) Title(s interface{}) string {
-	return cases.Title(f.tag).String(conv.ToString(s))
+	return cases.Title(f.tag, cases.NoLower).String(conv.ToString(s))
 }
 
 // ToUpper -

--- a/funcs/strings_test.go
+++ b/funcs/strings_test.go
@@ -80,6 +80,8 @@ func TestTitle(t *testing.T) {
 		{`ǉoo ǆar`, `ǈoo ǅar`},
 		{`foo bar᳇baz`, `Foo Bar᳇Baz`}, // ᳇ should be treated as punctuation
 		{`foo,bar&baz`, `Foo,Bar&Baz`},
+		{`FOO`, `FOO`},
+		{`bar FOO`, `Bar FOO`},
 	}
 
 	for _, d := range testdata {


### PR DESCRIPTION
Sets the `NoLower` option so that acronyms are not lowercased.