### PR TITLE
docs: List release versions for each function, add unreleased label 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ report.xml
 *.iid
 *.out
 .netlify
+docs/.hugo_build.lock

--- a/docs-src/content/functions/aws.yml
+++ b/docs-src/content/functions/aws.yml
@@ -20,6 +20,7 @@ preamble: |
 funcs:
   - name: aws.EC2Meta
     alias: ec2meta
+    released: v1.8.0
     description: |
       Queries AWS [EC2 Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `meta-data` path -- for data in the `dynamic` path use `aws.EC2Dynamic`.
 
@@ -38,6 +39,7 @@ funcs:
         i-12345678
   - name: aws.EC2Dynamic
     alias: ec2dynamic
+    released: v1.8.0
     description: |
       Queries AWS [EC2 Instance Dynamic Metadata](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for information. This only retrieves data in the `dynamic` path -- for data in the `meta-data` path use `aws.EC2Meta`.
 
@@ -56,6 +58,7 @@ funcs:
         us-east-1
   - name: aws.EC2Region
     alias: ec2region
+    released: v1.8.0
     description: |
       Queries AWS to get the region. An optional default can be provided, or returns
       `unknown` if it can't be determined for some reason.
@@ -80,6 +83,7 @@ funcs:
         ```
   - name: aws.EC2Tag
     alias: ec2tag
+    released: v3.8.0
     description: |
       Queries the AWS EC2 API to find the value of the given [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). An optional default
       can be provided.
@@ -100,6 +104,7 @@ funcs:
         I am a meat popsicle.
   - name: aws.EC2Tags
     alias: ec2tags
+    released: v3.8.0
     description: |
       Queries the AWS EC2 API to find all the tags/values [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
     pipeline: false
@@ -111,6 +116,7 @@ funcs:
         Name=bar
         svc:name=foobar
   - name: aws.KMSEncrypt
+    # released: v4.0.0
     description: |
       Encrypt an input string with the AWS Key Management Service (KMS).
 
@@ -145,6 +151,7 @@ funcs:
         $ export CIPHER=$(gomplate -i '{{ aws.KMSEncrypt "alias/gomplate" "hello world" }}')
         $ gomplate -i '{{ env.Getenv "CIPHER" | aws.KMSDecrypt }}'
   - name: aws.KMSDecrypt
+    released: v3.4.0
     description: |
       Decrypt ciphertext that was encrypted with the AWS Key Management Service
       (KMS).
@@ -165,6 +172,7 @@ funcs:
         $ export CIPHER=$(gomplate -i '{{ aws.KMSEncrypt "alias/gomplate" "hello world" }}')
         $ gomplate -i '{{ env.Getenv "CIPHER" | aws.KMSDecrypt }}'
   - name: aws.Account
+    released: v3.4.0
     description: |
       Returns the currently-authenticated AWS account ID number.
 
@@ -177,6 +185,7 @@ funcs:
         $ gomplate -i 'My account is {{ aws.Account }}'
         My account is 123456789012
   - name: aws.ARN
+    released: v3.4.0
     description: |
       Returns the AWS ARN (Amazon Resource Name) associated with the current authentication credentials.
 
@@ -189,6 +198,7 @@ funcs:
         $ gomplate -i 'Calling from {{ aws.ARN }}'
         Calling from arn:aws:iam::123456789012:user/Alice
   - name: aws.UserID
+    released: v3.4.0
     description: |
       Returns the unique identifier of the calling entity. The exact value
       depends on the type of entity making the call. The values returned are those

--- a/docs-src/content/functions/base64.yml
+++ b/docs-src/content/functions/base64.yml
@@ -2,6 +2,7 @@ ns: base64
 preamble: ''
 funcs:
   - name: base64.Encode
+    released: v1.8.0
     description: |
       Encode data as a Base64 string. Specifically, this uses the standard Base64 encoding as defined in [RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4) (and _not_ the URL-safe encoding).
     pipeline: true
@@ -17,6 +18,7 @@ funcs:
         $ gomplate -i '{{ "hello world" | base64.Encode }}'
         aGVsbG8gd29ybGQ=
   - name: base64.Decode
+    released: v1.8.0
     description: |
       Decode a Base64 string. This supports both standard ([RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4)) and URL-safe ([RFC4648 &sect;5](https://tools.ietf.org/html/rfc4648#section-5)) encodings.
 
@@ -36,6 +38,7 @@ funcs:
         $ gomplate -i '{{ "aGVsbG8gd29ybGQ=" | base64.Decode }}'
         hello world
   - name: base64.DecodeBytes
+    released: v3.8.0
     description: |
       Decode a Base64 string. This supports both standard ([RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4)) and URL-safe ([RFC4648 &sect;5](https://tools.ietf.org/html/rfc4648#section-5)) encodings.
 

--- a/docs-src/content/functions/coll.yml
+++ b/docs-src/content/functions/coll.yml
@@ -8,6 +8,7 @@ preamble: |
   input was a different type.
 funcs:
   - name: coll.Dict
+    released: v3.2.0
     alias: dict
     description: |
       Dict is a convenience function that creates a map with string keys.
@@ -43,6 +44,7 @@ funcs:
         Hello world!
         Hello everybody!
   - name: coll.Slice
+    released: v3.2.0
     deprecated: The `slice` alias is deprecated, use the full name `coll.Slice` instead.
     alias: slice
     description: |
@@ -59,6 +61,7 @@ funcs:
         Hello, Lisa
         Hello, Maggie
   - name: coll.GoSlice
+    # released: v4.0.0
     description: |
       This exposes the `slice` function from Go's [`text/template`](https://golang.org/pkg/text/template/#hdr-Functions)
       package. Note that using `slice` will use the `coll.Slice` function instead,
@@ -89,6 +92,7 @@ funcs:
         $ gomplate -i '{{ coll.GoSlice "hello world" 3 8 }}'
         lo wo
   - name: coll.Has
+    released: v3.2.0
     alias: has
     description: |
       Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
@@ -115,6 +119,7 @@ funcs:
         {{ if (has $o "foo") }}{{ $o.foo }}{{ else }}THERE IS NO FOO{{ end }}'
         THERE IS NO FOO
   - name: coll.Index
+    # released: v4.0.0
     description: |
       Returns the result of indexing the given map, slice, or array by the given
       key or index. This is similar to the built-in `index` function, but the
@@ -144,6 +149,7 @@ funcs:
         bar
   - name: coll.JSONPath
     alias: jsonpath
+    released: v3.4.0
     description: |
       Extracts portions of an input object or list using a [JSONPath][] expression.
 
@@ -166,6 +172,7 @@ funcs:
         [Alice's Adventures in Wonderland Gulliver's Travels]
   - name: coll.JQ
     alias: jq
+    # released: v4.0.0
     description: |
       Filters an input object or list using the [jq](https://stedolan.github.io/jq/) language, as implemented by [gojq](https://github.com/itchyny/gojq).
 
@@ -194,6 +201,7 @@ funcs:
            -c books=https://openlibrary.org/subjects/fantasy.json
         map[authors:[Lewis Carroll] published:1865 title:Alice's Adventures in Wonderland]
   - name: coll.Keys
+    released: v3.2.0
     alias: keys
     description: |
       Return a list of keys in one or more maps.
@@ -215,6 +223,7 @@ funcs:
         [bar foo baz qux]
   - name: coll.Values
     alias: values
+    released: v3.2.0
     description: |
       Return a list of values in one or more maps.
 
@@ -235,6 +244,7 @@ funcs:
         [2 1 3 4]
   - name: coll.Append
     alias: append
+    released: v3.2.0
     description: |
       Append a value to the end of a list.
 
@@ -255,6 +265,7 @@ funcs:
         [1 1 2 3 5]
   - name: coll.Prepend
     alias: prepend
+    released: v3.2.0
     description: |
       Prepend a value to the beginning of a list.
 
@@ -275,6 +286,7 @@ funcs:
         [5 4 3 2 1]
   - name: coll.Uniq
     alias: uniq
+    released: v3.2.0
     description: |
       Remove any duplicate values from the list, without changing order.
 
@@ -290,6 +302,7 @@ funcs:
         [1 2 3 4 5]
   - name: coll.Flatten
     alias: flatten
+    released: v3.6.0
     description: |
       Flatten a nested list. Defaults to completely flattening all nested lists,
       but can be limited with `depth`.
@@ -312,6 +325,7 @@ funcs:
         [1 2 3 4 [[5] 6] 7]
   - name: coll.Reverse
     alias: reverse
+    released: v3.2.0
     description: |
       Reverse a list.
 
@@ -327,6 +341,7 @@ funcs:
         [1 2 3 4]
   - name: coll.Sort
     alias: sort
+    released: v3.2.0
     description: |
       Sort a given list. Uses the natural sort order if possible. For inputs
       that are not sortable (either because the elements are of different types,
@@ -360,6 +375,7 @@ funcs:
         bar
   - name: coll.Merge
     alias: merge
+    released: v3.2.0
     description: |
       Merge maps together by overriding src with dst.
 
@@ -390,6 +406,7 @@ funcs:
         {{ coll.Merge $dst $src1 $src2 }}'
         map[foo:1 bar:5 baz:4]
   - name: coll.Pick
+    released: v3.7.0
     description: |
       Given a map, returns a new map with any entries that have the given keys.
 
@@ -412,6 +429,7 @@ funcs:
         {{ coll.Pick "foo" "baz" $data }}'
         map[baz:3 foo:1]
   - name: coll.Omit
+    released: v3.7.0
     description: |
       Given a map, returns a new map without any entries that have the given keys.
 

--- a/docs-src/content/functions/conv.yml
+++ b/docs-src/content/functions/conv.yml
@@ -6,6 +6,7 @@ preamble: |
 funcs:
   - name: conv.Bool
     alias: bool
+    released: v0.2.0
     description: |
       **Note:** See also [`conv.ToBool`](#conv-tobool) for a more flexible variant.
 
@@ -30,6 +31,7 @@ funcs:
         ```
   - name: conv.Default
     alias: default
+    released: v2.5.0
     description: |
       Provides a default value given an empty input. Empty inputs are `0` for numeric
       types, `""` for strings, `false` for booleans, empty arrays/maps, and `nil`.
@@ -52,6 +54,7 @@ funcs:
   - name: conv.Dict
     deprecated: Renamed to [`coll.Dict`](#coll-dict)
     alias: dict
+    released: v3.0.0
     description: |
       Dict is a convenience function that creates a map with string keys.
       Provide arguments as key/value pairs. If an odd number of arguments
@@ -88,6 +91,7 @@ funcs:
   - name: conv.Slice
     deprecated: Renamed to [`coll.Slice`](#coll-slice)
     alias: slice
+    released: v0.3.0
     description: |
       Creates a slice (like an array or list). Useful when needing to `range` over a bunch of variables.
     pipeline: false
@@ -104,6 +108,7 @@ funcs:
   - name: conv.Has
     deprecated: Renamed to [`coll.Has`](#coll-has)
     alias: has
+    released: v1.5.0
     description: |
       Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
     pipeline: false
@@ -130,6 +135,7 @@ funcs:
         THERE IS NO FOO
   - name: conv.Join
     alias: join
+    released: v0.4.0
     description: |
       Concatenates the elements of an array to create a string. The separator string `sep` is placed between elements in the resulting string.
     arguments:
@@ -145,6 +151,7 @@ funcs:
         1-2-3
   - name: conv.URL
     alias: urlParse
+    released: v2.0.0
     description: |
       Parses a string as a URL for later use. Equivalent to [url.Parse](https://golang.org/pkg/net/url/#Parse)
 
@@ -176,6 +183,7 @@ funcs:
         https://user:xxxxx@example.com
         ```
   - name: conv.ParseInt
+    released: v1.4.0
     description: |
       _**Note:**_ See [`conv.ToInt64`](#conv-toint64) instead for a simpler and more flexible variant of this function.
 
@@ -194,6 +202,7 @@ funcs:
         The value in decimal is 1984
         ```
   - name: conv.ParseFloat
+    released: v1.4.0
     description: |
       _**Note:**_ See [`conv.ToFloat`](#conv-tofloat) instead for a simpler and more flexible variant of this function.
 
@@ -213,6 +222,7 @@ funcs:
         pi is greater than 3
         ```
   - name: conv.ParseUint
+    released: v1.4.0
     description: |
       Parses a string as an uint64 for later use. Equivalent to [strconv.ParseUint](https://golang.org/pkg/strconv/#ParseUint)
     rawExamples:
@@ -229,6 +239,7 @@ funcs:
         18446744073709551615 is max uint64
         ```
   - name: conv.Atoi
+    released: v1.4.0
     description: |
       _**Note:**_ See [`conv.ToInt`](#conv-toint) and [`conv.ToInt64`](#conv-toint64) instead for simpler and more flexible variants of this function.
 
@@ -250,6 +261,7 @@ funcs:
         The number is greater than 5
         ```
   - name: conv.ToBool
+    released: v2.7.0
     description: |
       Converts the input to a boolean value.
       Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
@@ -266,6 +278,7 @@ funcs:
         $ gomplate -i '{{ conv.ToBool false }} {{ conv.ToBool "blah" }} {{ conv.ToBool 0 }}'
         false false false
   - name: conv.ToBools
+    released: v2.7.0
     description: |
       Converts a list of inputs to an array of boolean values.
       Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
@@ -282,6 +295,7 @@ funcs:
         $ gomplate -i '{{ conv.ToBools false "blah" 0 }}'
         [false false false]
   - name: conv.ToInt64
+    released: v2.2.0
     description: |
       Converts the input to an `int64` (64-bit signed integer).
 
@@ -306,6 +320,7 @@ funcs:
         $ gomplate -i '{{conv.ToInt64 true }}'
         1
   - name: conv.ToInt
+    released: v2.2.0
     description: |
       Converts the input to an `int` (signed integer, 32- or 64-bit depending
       on platform). This is similar to [`conv.ToInt64`](#conv-toint64) on 64-bit
@@ -333,6 +348,7 @@ funcs:
         $ gomplate -i '{{conv.ToInt true }}'
         1
   - name: conv.ToInt64s
+    released: v2.2.0
     description: |
       Converts the inputs to an array of `int64`s.
 
@@ -346,6 +362,7 @@ funcs:
         gomplate -i '{{ conv.ToInt64s true 0x42 "123,456.99" "1.2345e+3"}}'
         [1 66 123456 1234]
   - name: conv.ToInts
+    released: v2.2.0
     description: |
       Converts the inputs to an array of `int`s.
 
@@ -359,6 +376,7 @@ funcs:
         gomplate -i '{{ conv.ToInts true 0x42 "123,456.99" "1.2345e+3"}}'
         [1 66 123456 1234]
   - name: conv.ToFloat64
+    released: v2.2.0
     description: |
       Converts the input to a `float64`.
 
@@ -377,6 +395,7 @@ funcs:
         $ gomplate -i '{{ conv.ToFloat64 "9,000.09"}}'
         9000.09
   - name: conv.ToFloat64s
+    released: v2.2.0
     description: |
       Converts the inputs to an array of `float64`s.
 
@@ -390,6 +409,7 @@ funcs:
         $ gomplate -i '{{ conv.ToFloat64s true 0x42 "123,456.99" "1.2345e+3"}}'
         [1 66 123456.99 1234.5]
   - name: conv.ToString
+    released: v2.5.0
     description: |
       Converts the input (of any type) to a `string`.
 
@@ -407,6 +427,7 @@ funcs:
         $ gomplate -i '{{ conv.ToString nil }}'
         nil
   - name: conv.ToStrings
+    released: v2.5.0
     description: |
       Converts the inputs (of any type) to an array of `string`s
 

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -10,6 +10,7 @@ preamble: |
   before using gomplate for critical security infrastructure!_
 funcs:
   - name: crypto.Bcrypt
+    released: v2.6.0
     description: |
       Uses the [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) password hashing algorithm to generate the hash of a given string. Wraps the [`golang.org/x/crypto/brypt`](https://godoc.org/golang.org/x/crypto/bcrypt) package.
     pipeline: true
@@ -29,6 +30,7 @@ funcs:
         $2a$04$zjba3N38sjyYsw0Y7IRCme1H4gD0MJxH8Ixai0/sgsrf7s1MFUK1C
   - name: crypto.DecryptAES
     experimental: true
+    released: v3.11.0
     description: |
       Decrypts the given input using the given key. By default,
       uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -57,6 +59,7 @@ funcs:
         hello world
   - name: crypto.DecryptAESBytes
     experimental: true
+    released: v3.11.0
     description: |
       Decrypts the given input using the given key. By default,
       uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -84,6 +87,7 @@ funcs:
         hello world
   - name: crypto.EncryptAES
     experimental: true
+    released: v3.11.0
     description: |
       Encrypts the given input using the given key. By default,
       uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -108,6 +112,7 @@ funcs:
         MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
   - name: crypto.ECDSAGenerateKey
     experimental: true
+    released: v3.11.0
     description: |
       Generate a new Elliptic Curve Private Key and output in
       PEM-encoded PKCS#1 ASN.1 DER form.
@@ -131,6 +136,7 @@ funcs:
         ...
   - name: crypto.ECDSADerivePublicKey
     experimental: true
+    released: v3.11.0
     description: |
       Derive a public key from an elliptic curve private key and output in PKIX
       ASN.1 DER form.
@@ -153,6 +159,7 @@ funcs:
         aztsmrD79OXXnhUlURI=
         -----END PUBLIC KEY-----
   - name: crypto.PBKDF2
+    released: v2.3.0
     description: |
       Run the Password-Based Key Derivation Function &num;2 as defined in
       [RFC 8018 (PKCS &num;5 v2.1)](https://tools.ietf.org/html/rfc8018#section-5.2).
@@ -181,6 +188,7 @@ funcs:
         32c4907c3c80792b
   - name: crypto.RSADecrypt
     experimental: true
+    released: v3.8.0
     description: |
       Decrypt an RSA-encrypted input and print the output as a string. Note that
       this may result in unreadable text if the decrypted payload is binary. See
@@ -214,6 +222,7 @@ funcs:
         hello
   - name: crypto.RSADecryptBytes
     experimental: true
+    released: v3.8.0
     description: |
       Decrypt an RSA-encrypted input and output the decrypted byte array.
 
@@ -248,6 +257,7 @@ funcs:
         hello
   - name: crypto.RSAEncrypt
     experimental: true
+    released: v3.8.0
     description: |
       Encrypt the input with RSA and the padding scheme from PKCS#1 v1.5.
 
@@ -287,6 +297,7 @@ funcs:
         71729b87cccabb248b9e0e5173f0b12c01d9d2a0565bad18aef9d332ce984bde06acb8bb69334a01446f7f6430077f269e6fbf2ccacd972fe5856dd4719252ebddf599948d937d96ea41540dad291b868f6c0cf647dffdb5acb22cd33557f9a1ddd0ee6c1ad2bbafc910ba8f817b66ea0569afc06e5c7858fd9dc2638861fe7c97391b2f190e4c682b4aa2c9b0050081efe18b10aa8c2b2b5f5b68a42dcc06c9da35b37fca9b1509fddc940eb99f516a2e0195405bcb3993f0fa31bc038d53d2e7231dff08cc39448105ed2d0ac52d375cb543ca8a399f807cc5d007e2c44c69876d189667eee66361a393c4916826af77479382838cd4e004b8baa05636805a
   - name: crypto.RSAGenerateKey
     experimental: true
+    released: v3.8.0
     description: |
       Generate a new RSA Private Key and output in PEM-encoded PKCS#1 ASN.1 DER
       form.
@@ -317,6 +328,7 @@ funcs:
         hello
   - name: crypto.RSADerivePublicKey
     experimental: true
+    released: v3.8.0
     description: |
       Derive a public key from an RSA private key and output in PKIX ASN.1 DER
       form.
@@ -340,6 +352,7 @@ funcs:
           {{ crypto.RSADecrypt .privKey $enc }}'
         hello
   - rawName: "`crypto.SHA1`, `crypto.SHA224`, `crypto.SHA256`, `crypto.SHA384`, `crypto.SHA512`, `crypto.SHA512_224`, `crypto.SHA512_256`"
+    released: v2.3.0
     description: |
       Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
 
@@ -369,6 +382,7 @@ funcs:
         $ gomplate -i '{{ crypto.SHA512 "bar" }}'
         cc06808cbbee0510331aa97974132e8dc296aeb795be229d064bae784b0a87a5cf4281d82e8c99271b75db2148f08a026c1a60ed9cabdb8cac6d24242dac4063
   - rawName: "`crypto.SHA1Bytes`, `crypto.SHA224Bytes`, `crypto.SHA256Bytes`, `crypto.SHA384Bytes`, `crypto.SHA512Bytes`, `crypto.SHA512_224Bytes`, `crypto.SHA512_256Bytes`"
+    released: v3.11.0
     description: |
       Compute a checksum with a SHA-1 or SHA-2 algorithm as defined in [RFC 3174](https://tools.ietf.org/html/rfc3174) (SHA-1) and [FIPS 180-4](http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) (SHA-2).
 
@@ -395,6 +409,7 @@ funcs:
         $ gomplate -i '{{ crypto.SHA256Bytes "foo" | base64.Encode }}'
         LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=
   - name: crypto.WPAPSK
+    released: v2.3.0
     description: |
       This is really an alias to [`crypto.PBKDF2`](#crypto.PBKDF2) with the
       values necessary to convert ASCII passphrases to the WPA pre-shared keys for use with WiFi networks.

--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -4,6 +4,7 @@ preamble: |
 funcs:
   - name: datasource
     alias: ds
+    released: v0.5.0
     description: |
       Parses a given datasource (provided by the [`--datasource/-d`](../../usage/#datasource-d) argument or [`defineDatasource`](#definedatasource)).
 
@@ -30,6 +31,7 @@ funcs:
         Hello Dave
         ```
   - name: datasourceExists
+    released: v1.3.0
     description: |
       Tests whether or not a given datasource was defined on the commandline (with the
       [`--datasource/-d`](../../usage/#datasource-d) argument). This is intended mainly to allow
@@ -49,6 +51,7 @@ funcs:
         $ echo '{{if (datasourceExists "test")}}{{datasource "test"}}{{else}}no worries{{end}}' | gomplate
         no worries
   - name: datasourceReachable
+    released: v2.5.0
     description: |
       Tests whether or not a given datasource is defined and reachable, where the definition of "reachable" differs by datasource, but generally means the data is able to be read successfully.
 
@@ -63,6 +66,7 @@ funcs:
         $ gomplate -i '{{if (datasourceReachable "test")}}{{datasource "test"}}{{else}}no worries{{end}}' -d test=https://bogus.example.com/wontwork.json
         no worries
   - name: listDatasources
+    released: v3.11.0
     description: |
       Lists all the datasources defined, list returned will be sorted in ascending order.
     pipeline: false
@@ -72,6 +76,7 @@ funcs:
         Datasource-bar
         Datasource-person
   - name: defineDatasource
+    released: v2.7.0
     description: |
       Define a datasource alias with target URL inside the template. Overridden by the [`--datasource/-d`](../../usage/#datasource-d) flag.
 
@@ -102,6 +107,7 @@ funcs:
         Hello Daisy
         ```
   - name: include
+    released: v1.8.0
     description: |
       Includes the content of a given datasource (provided by the [`--datasource/-d`](../../usage/#datasource-d) argument).
 
@@ -140,6 +146,7 @@ funcs:
         ```
   - name: data.JSON
     alias: json
+    released: v1.4.0
     description: |
       Converts a JSON string into an object. Works for JSON Objects, but will
       also parse JSON Arrays. Will not parse other valid JSON types.
@@ -172,6 +179,7 @@ funcs:
         ```
   - name: data.JSONArray
     alias: jsonArray
+    released: v2.0.0
     description: |
       Converts a JSON string into a slice. Only works for JSON Arrays.
     pipeline: true
@@ -193,6 +201,7 @@ funcs:
         ```
   - name: data.YAML
     alias: yaml
+    released: v2.0.0
     description: |
       Converts a YAML string into an object. Works for YAML Objects but will
       also parse YAML Arrays. This can be used to access properties of YAML objects.
@@ -217,6 +226,7 @@ funcs:
         ```
   - name: data.YAMLArray
     alias: yamlArray
+    released: v2.0.0
     description: |
       Converts a YAML string into a slice. Only works for YAML Arrays.
     pipeline: true
@@ -238,6 +248,7 @@ funcs:
         ```
   - name: data.TOML
     alias: toml
+    released: v2.0.0
     description: |
       Converts a [TOML](https://github.com/toml-lang/toml) document into an object.
       This can be used to access properties of TOML documents.
@@ -263,6 +274,7 @@ funcs:
         ```
   - name: data.CSV
     alias: csv
+    released: v2.0.0
     description: |
       Converts a CSV-format string into a 2-dimensional string array.
 
@@ -296,6 +308,7 @@ funcs:
         ```
   - name: data.CSVByRow
     alias: csvByRow
+    released: v2.0.0
     description: |
       Converts a CSV-format string into a slice of maps.
 
@@ -337,6 +350,7 @@ funcs:
         ```
   - name: data.CSVByColumn
     alias: csvByColumn
+    released: v2.0.0
     description: |
       Like [`csvByRow`](#csvByRow), except that the data is presented as a columnar
       (column-oriented) map.
@@ -371,6 +385,7 @@ funcs:
         ```
   - name: data.ToJSON
     alias: toJSON
+    released: v2.0.0
     description: |
       Converts an object to a JSON document. Input objects may be the result of `json`, `yaml`, `jsonArray`, or `yamlArray` functions, or they could be provided by a `datasource`.
     pipeline: true
@@ -393,6 +408,7 @@ funcs:
         ```
   - name: data.ToJSONPretty
     alias: toJSONPretty
+    released: v2.0.0
     description: |
       Converts an object to a pretty-printed (or _indented_) JSON document.
       Input objects may be the result of functions like `data.JSON`, `data.YAML`,
@@ -423,6 +439,7 @@ funcs:
         ```
   - name: data.ToYAML
     alias: toYAML
+    released: v2.0.0
     description: |
       Converts an object to a YAML document. Input objects may be the result of
       `data.JSON`, `data.YAML`, `data.JSONArray`, or `data.YAMLArray` functions,
@@ -447,6 +464,7 @@ funcs:
         ```
   - name: data.ToTOML
     alias: toTOML
+    released: v2.0.0
     description: |
       Converts an object to a [TOML](https://github.com/toml-lang/toml) document.
     pipeline: true
@@ -460,6 +478,7 @@ funcs:
         foo = "bar"
   - name: data.ToCSV
     alias: toCSV
+    released: v2.0.0
     description: |
       Converts an object to a CSV document. The input object must be a 2-dimensional
       array of strings (a `[][]string`). Objects produced by [`data.CSVByRow`](#conv-csvbyrow)

--- a/docs-src/content/functions/env.yml
+++ b/docs-src/content/functions/env.yml
@@ -5,6 +5,7 @@ preamble: |
 funcs:
   - name: env.Getenv
     alias: getenv
+    released: v0.2.0
     description: |
       Exposes the [os.Getenv](https://golang.org/pkg/os/#Getenv) function.
 
@@ -39,6 +40,7 @@ funcs:
         $ gomplate -i 'Your secret is {{getenv "SECRET"}}'
         Your secret is safe
   - name: env.ExpandEnv
+    released: v2.5.0
     description: |
       Exposes the [os.ExpandEnv](https://golang.org/pkg/os/#ExpandEnv) function.
 

--- a/docs-src/content/functions/file.yml
+++ b/docs-src/content/functions/file.yml
@@ -3,6 +3,7 @@ preamble: |
   Functions for working with files.
 funcs:
   - name: file.Exists
+    released: v2.4.0
     description: |
       Reports whether a file or directory exists at the given path.
     pipeline: true
@@ -25,6 +26,7 @@ funcs:
         yes
         ```
   - name: file.IsDir
+    released: v2.4.0
     description: |
       Reports whether a given path is a directory.
     pipeline: true
@@ -50,6 +52,7 @@ funcs:
         yes
         ```
   - name: file.Read
+    released: v2.4.0
     description: |
       Reads a given file _as text_. Note that this will succeed if the given file is binary, but the output may be gibberish.
     pipeline: true
@@ -63,6 +66,7 @@ funcs:
         $ gomplate -i '{{file.Read "/tmp/hi"}}'
         hello world
   - name: file.ReadDir
+    released: v2.4.0
     description: |
       Reads a directory and lists the files and directories contained within.
     pipeline: true
@@ -81,6 +85,7 @@ funcs:
         c
         d
   - name: file.Stat
+    released: v2.4.0
     description: |
       Returns a [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo) describing the named path.
 
@@ -96,6 +101,7 @@ funcs:
         $ gomplate -i '{{ $s := file.Stat "/tmp/foo" }}{{ $s.Mode }} {{ $s.Size }} {{ $s.Name }}'
         -rw-r--r-- 12 foo
   - name: file.Walk
+    released: v2.6.0
     description: |
       Like a recursive [`file.ReadDir`](#file-readdir), recursively walks the file tree rooted at `path`, and returns an array of all files and directories contained within.
 
@@ -128,6 +134,7 @@ funcs:
         /tmp/foo/three is a file
         /tmp/foo/two is a file
   - name: file.Write
+    released: v2.4.0
     description: |
       Write the given data to the given file. If the file exists, it will be overwritten.
 

--- a/docs-src/content/functions/filepath.yml
+++ b/docs-src/content/functions/filepath.yml
@@ -9,6 +9,7 @@ preamble: |
   These functions are wrappers for Go's [`path/filepath`](https://golang.org/pkg/path/filepath/) package.
 funcs:
   - name: filepath.Base
+    released: v2.7.0
     description: |
       Returns the last element of path. Trailing path separators are removed before extracting the last element. If the path is empty, Base returns `.`. If the path consists entirely of separators, Base returns a single separator.
 
@@ -23,6 +24,7 @@ funcs:
         $ gomplate -i '{{ filepath.Base "/tmp/foo" }}'
         foo
   - name: filepath.Clean
+    released: v2.7.0
     description: |
       Clean returns the shortest path name equivalent to path by purely lexical processing.
 
@@ -37,6 +39,7 @@ funcs:
         $ gomplate -i '{{ filepath.Clean "/tmp//foo/../" }}'
         /tmp
   - name: filepath.Dir
+    released: v2.7.0
     description: |
       Returns all but the last element of path, typically the path's directory.
 
@@ -51,6 +54,7 @@ funcs:
         $ gomplate -i '{{ filepath.Dir "/tmp/foo" }}'
         /tmp
   - name: filepath.Ext
+    released: v2.7.0
     description: |
       Returns the file name extension used by path.
 
@@ -65,6 +69,7 @@ funcs:
         $ gomplate -i '{{ filepath.Ext "/tmp/foo.csv" }}'
         .csv
   - name: filepath.FromSlash
+    released: v2.7.0
     description: |
       Returns the result of replacing each slash (`/`) character in the path with the platform's separator character.
 
@@ -81,6 +86,7 @@ funcs:
         C:\> gomplate.exe -i '{{ filepath.FromSlash "/foo/bar" }}'
         C:\foo\bar
   - name: filepath.IsAbs
+    released: v2.7.0
     description: |
       Reports whether the path is absolute.
 
@@ -97,6 +103,7 @@ funcs:
         $ gomplate -i 'the path is {{ if (filepath.IsAbs "../foo.csv") }}absolute{{else}}relative{{end}}'
         the path is relative
   - name: filepath.Join
+    released: v2.7.0
     description: |
       Joins any number of path elements into a single path, adding a separator if necessary.
 
@@ -112,6 +119,7 @@ funcs:
         C:\> gomplate.exe -i '{{ filepath.Join "C:\tmp" "foo" "bar" }}'
         C:\tmp\foo\bar
   - name: filepath.Match
+    released: v2.7.0
     description: |
       Reports whether name matches the shell file name pattern.
 
@@ -128,6 +136,7 @@ funcs:
         $ gomplate -i '{{ filepath.Match "*.csv" "foo.csv" }}'
         true
   - name: filepath.Rel
+    released: v2.7.0
     description: |
       Returns a relative path that is lexically equivalent to targetpath when joined to basepath with an intervening separator.
 
@@ -144,6 +153,7 @@ funcs:
         $ gomplate -i '{{ filepath.Rel "/a" "/a/b/c" }}'
         b/c
   - name: filepath.Split
+    released: v2.7.0
     description: |
       Splits path immediately following the final path separator, separating it into a directory and file name component.
 
@@ -162,6 +172,7 @@ funcs:
         C:\> gomplate.exe -i '{{ $p := filepath.Split `C:\tmp\foo` }}{{ $dir := index $p 0 }}{{ $file := index $p 1 }}dir is {{$dir}}, file is {{$file}}'
         dir is C:\tmp\, file is foo
   - name: filepath.ToSlash
+    released: v2.7.0
     description: |
       Returns the result of replacing each separator character in path with a slash (`/`) character.
 
@@ -178,6 +189,7 @@ funcs:
         C:\> gomplate.exe -i '{{ filepath.ToSlash `foo\bar\baz` }}'
         foo/bar/baz
   - name: filepath.VolumeName
+    released: v2.7.0
     description: |
       Returns the leading volume name. Given `C:\foo\bar` it returns `C:` on Windows. Given a UNC like `\\host\share\foo` it returns `\\host\share`. On other platforms it returns an empty string.
 

--- a/docs-src/content/functions/func_doc.md.tmpl
+++ b/docs-src/content/functions/func_doc.md.tmpl
@@ -25,6 +25,7 @@ menu:
 {{ $data.preamble -}}
 
 {{- define "annotations" -}}
+{{ if not (has . "released") }}_(unreleased)_{{ end -}}
 {{ if has . "deprecated" }} _(deprecated)_{{ end -}}
 {{ if and (has . "experimental") (index . "experimental") }} _(experimental)_{{ end -}}
 {{ end -}}
@@ -32,6 +33,9 @@ menu:
 {{ range $_, $f := $data.funcs }}
 ## {{ if has $f "rawName" -}}
 {{ $f.rawName }}{{ else }}`{{ $f.name }}`{{ end }}{{ template "annotations" $f }}
+{{ if not (has . "released") -}}
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+{{ end -}}
 {{ if has $f "deprecated" -}}
 **Deprecation Notice:** {{ $f.deprecated }}
 {{ end -}}
@@ -47,6 +51,10 @@ menu:
 
 {{- if has $f "description" }}
 {{ $f.description }}
+{{ end -}}
+
+{{ if has . "released" -}}
+_Added in gomplate [{{ $f.released }}](https://github.com/hairyhenderson/gomplate/releases/tag/{{ $f.released }})_
 {{ end -}}
 
 {{ template "usage" $f }}

--- a/docs-src/content/functions/gcp.yml
+++ b/docs-src/content/functions/gcp.yml
@@ -15,6 +15,7 @@ preamble: |
   | `GCP_TIMEOUT` | _(Default `500`)_ Adjusts timeout for API requests, in milliseconds. |
 funcs:
   - name: gcp.Meta
+    released: v3.8.0
     description: |
       Queries GCP [Instance Metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata) for information.
 

--- a/docs-src/content/functions/math.yml
+++ b/docs-src/content/functions/math.yml
@@ -25,6 +25,7 @@ preamble: |
   ```
 funcs:
   - name: math.Abs
+    released: v2.6.0
     description: |
       Returns the absolute value of a given number. When the input is an integer, the result will be an `int64`, otherwise it will be a `float64`.
     arguments:
@@ -37,6 +38,7 @@ funcs:
         3.5 3.5 42
   - name: math.Add
     alias: add
+    released: v2.2.0
     description: |
       Adds all given operators. When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
     arguments:
@@ -48,6 +50,7 @@ funcs:
         $ gomplate -i '{{ math.Add 1 2 3 4 }} {{ math.Add 1.5 2 3 }}'
         10 6.5
   - name: math.Ceil
+    released: v2.6.0
     description: |
       Returns the least integer value greater than or equal to a given floating-point number. This wraps Go's [`math.Ceil`](https://golang.org/pkg/math/#Ceil).
 
@@ -68,6 +71,7 @@ funcs:
         ceil "-0" = 0
   - name: math.Div
     alias: div
+    released: v2.2.0
     description: |
       Divide the first number by the second. Division by zero is disallowed. The result will be a `float64`.
     pipeline: true
@@ -83,6 +87,7 @@ funcs:
         $ gomplate -i '{{ math.Div 8 2 }} {{ math.Div 3 2 }}'
         4 1.5
   - name: math.Floor
+    released: v2.6.0
     description: |
       Returns the greatest integer value less than or equal to a given floating-point number. This wraps Go's [`math.Floor`](https://golang.org/pkg/math/#Floor).
 
@@ -102,6 +107,7 @@ funcs:
         floor "Inf" = +Inf
         floor "-0" = 0
   - name: math.IsFloat
+    released: v2.6.0
     description: |
       Returns whether or not the given number can be interpreted as a floating-point literal, as defined by the [Go language reference](https://golang.org/ref/spec#Floating-point_literals).
 
@@ -120,6 +126,7 @@ funcs:
         NaN is a float
         Inf is a float
   - name: math.IsInt
+    released: v2.6.0
     description: |
       Returns whether or not the given number is an integer.
     arguments:
@@ -133,6 +140,7 @@ funcs:
         0xFF is an integer
         -0 is an integer
   - name: math.IsNum
+    released: v2.6.0
     description: |
       Returns whether the given input is a number. Useful for `if` conditions.
     arguments:
@@ -144,6 +152,7 @@ funcs:
         $ gomplate -i '{{ math.IsNum "foo" }} {{ math.IsNum 0xDeadBeef }}'
         false true
   - name: math.Max
+    released: v2.6.0
     description: |
       Returns the largest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Max`](https://golang.org/pkg/math/#Max) are followed.
     arguments:
@@ -155,6 +164,7 @@ funcs:
         $ gomplate -i '{{ math.Max 0 8.0 4.5 "-1.5e-11" }}'
         8
   - name: math.Min
+    released: v2.6.0
     description: |
       Returns the smallest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Min`](https://golang.org/pkg/math/#Min) are followed.
     arguments:
@@ -167,6 +177,7 @@ funcs:
         -1.5e-11
   - name: math.Mul
     alias: mul
+    released: v2.2.0
     description: |
       Multiply all given operators together.
     arguments:
@@ -179,6 +190,7 @@ funcs:
         128
   - name: math.Pow
     alias: pow
+    released: v2.2.0
     description: |
       Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://golang.org/pkg/math/#Pow). If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned.
     arguments:
@@ -198,6 +210,7 @@ funcs:
         2.2
   - name: math.Rem
     alias: rem
+    released: v2.2.0
     description: |
       Return the remainder from an integer division operation.
     pipeline: true
@@ -215,6 +228,7 @@ funcs:
         $ gomplate -i '{{ math.Rem -5 3 }}'
         -2
   - name: math.Round
+    released: v2.6.0
     description: |
       Returns the nearest integer, rounding half away from zero.
 
@@ -233,6 +247,7 @@ funcs:
         round 6.5 = 7
   - name: math.Seq
     alias: seq
+    released: v2.2.0
     description: |
       Return a sequence from `start` to `end`, in steps of `step`. Can handle counting
       down as well as up, including with negative numbers.
@@ -257,6 +272,7 @@ funcs:
         10, 8, 6, 4, 2, 0, -2
   - name: math.Sub
     alias: sub
+    released: v2.2.0
     description: |
       Subtract the second from the first of the given operators.  When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
     pipeline: true

--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -11,6 +11,7 @@ preamble: |
   [`net`]: https://pkg.go.dev/net
 funcs:
   - name: net.LookupIP
+    released: v1.9.0
     description: |
       Resolve an IPv4 address for a given host name. When multiple IP addresses
       are resolved, the first one is returned.
@@ -24,6 +25,7 @@ funcs:
         $ gomplate -i '{{ net.LookupIP "example.com" }}'
         93.184.216.34
   - name: net.LookupIPs
+    released: v1.9.0
     description: |
       Resolve all IPv4 addresses for a given host name. Returns an array of strings.
     pipeline: true
@@ -36,6 +38,7 @@ funcs:
         $ gomplate -i '{{ join (net.LookupIPs "twitter.com") "," }}'
         104.244.42.65,104.244.42.193
   - name: net.LookupCNAME
+    released: v1.9.0
     description: |
       Resolve the canonical name for a given host name. This does a DNS lookup for the
       `CNAME` record type. If no `CNAME` is present, a canonical form of the given name
@@ -50,6 +53,7 @@ funcs:
         $ gomplate -i '{{ net.LookupCNAME "www.amazon.com" }}'
         d3ag4hukkh62yn.cloudfront.net.
   - name: net.LookupSRV
+    released: v1.9.0
     description: |
       Resolve a DNS [`SRV` service record](https://en.wikipedia.org/wiki/SRV_record).
       This implementation supports the canonical [RFC2782](https://tools.ietf.org/html/rfc2782)
@@ -78,6 +82,7 @@ funcs:
           "Weight": 1
         }
   - name: net.LookupSRVs
+    released: v1.9.0
     description: |
       Resolve a DNS [`SRV` service record](https://en.wikipedia.org/wiki/SRV_record).
       This implementation supports the canonical [RFC2782](https://tools.ietf.org/html/rfc2782)
@@ -111,6 +116,7 @@ funcs:
         priority=20/port=5060
         ```
   - name: net.LookupTXT
+    released: v1.9.0
     description: |
       Resolve a DNS [`TXT` record](https://en.wikipedia.org/wiki/SRV_record).
 
@@ -127,6 +133,7 @@ funcs:
           "v=spf1 -all"
         ]
   - name: net.ParseAddr
+    # released: v4.0.0
     description: |
       Parse the given string as an IP address (a
       [`netip.Addr`](https://pkg.go.dev/net/netip#Addr)).
@@ -146,6 +153,7 @@ funcs:
           {{ $ip.Prefix 12 }}'
         93.176.0.0/12
   - name: net.ParseIP
+    released: v3.10.0
     deprecated: Use [`net.ParseAddr`](#net-parseaddr) instead.
     description: |
       Parse the given string as an IP address (a `netaddr.IP` from the
@@ -166,6 +174,7 @@ funcs:
           {{ $ip.Prefix 12 }}'
         93.176.0.0/12
   - name: net.ParsePrefix
+    # released: v4.0.0
     description: |
       Parse the given string as an IP address prefix (CIDR) representing an IP
       network (a [`netip.Prefix`](https://pkg.go.dev/net/netip#Prefix)).
@@ -189,6 +198,7 @@ funcs:
           {{ $net.Contains $ip }}'
         true
   - name: net.ParseIPPrefix
+    released: v3.10.0
     deprecated: Use [`net.ParsePrefix`](#net-parseprefix) instead.
     description: |
       Parse the given string as an IP address prefix (CIDR) representing an IP
@@ -218,6 +228,7 @@ funcs:
         93.176.0.0-93.191.255.255
   - name: net.ParseRange
     experimental: true
+    # released: v4.0.0
     description: |
       Parse the given string as an inclusive range of IP addresses from the same
       address family (a [`netipx.IPRange`](https://pkg.go.dev/go4.org/netipx#IPRange)
@@ -245,6 +256,7 @@ funcs:
           {{ $range.Prefixes }}'
         [1.2.3.0/25 1.2.3.128/26 1.2.3.192/27 1.2.3.224/29 1.2.3.232/31]
   - name: net.ParseIPRange
+    released: v3.10.0
     deprecated: Use [`net.ParseRange`](#net-parserange) instead.
     description: |
       Parse the given string as an inclusive range of IP addresses from the same
@@ -268,6 +280,7 @@ funcs:
         [1.2.3.0/25 1.2.3.128/26 1.2.3.192/27]
   - name: net.CIDRHost
     experimental: true
+    released: v3.11.0
     description: |
       Calculates a full host IP address for a given host number within a given IP network address prefix.
 
@@ -290,6 +303,7 @@ funcs:
         10.12.113.12
   - name: net.CIDRNetmask
     experimental: true
+    released: v3.11.0
     description: |
       The result is a subnet address formatted in the conventional dotted-decimal IPv4 address syntax or hexadecimal IPv6 address syntax, as expected by some software.
 
@@ -308,6 +322,7 @@ funcs:
         ffff:ffff:ffff:ffff:ff00::
   - name: net.CIDRSubnets
     experimental: true
+    released: v3.11.0
     description: |
       Calculates a subnet address within given IP network address prefix.
 
@@ -329,6 +344,7 @@ funcs:
         [10.0.0.0/18 10.0.64.0/18 10.0.128.0/18 10.0.192.0/18]
   - name: net.CIDRSubnetSizes
     experimental: true
+    released: v3.11.0
     description: |
       Calculates a sequence of consecutive IP address ranges within a particular CIDR prefix.
 

--- a/docs-src/content/functions/path.yml
+++ b/docs-src/content/functions/path.yml
@@ -9,6 +9,7 @@ preamble: |
   These functions are wrappers for Go's [`path`](https://golang.org/pkg/path/) and [`path/filepath`](https://golang.org/pkg/path/filepath/) packages.
 funcs:
   - name: path.Base
+    released: v2.7.0
     description: |
       Returns the last element of path. Trailing slashes are removed before extracting the last element. If the path is empty, Base returns `.`. If the path consists entirely of slashes, Base returns `/`.
 
@@ -23,6 +24,7 @@ funcs:
         $ gomplate -i '{{ path.Base "/tmp/foo" }}'
         foo
   - name: path.Clean
+    released: v2.7.0
     description: |
       Clean returns the shortest path name equivalent to path by purely lexical processing.
 
@@ -37,6 +39,7 @@ funcs:
         $ gomplate -i '{{ path.Clean "/tmp//foo/../" }}'
         /tmp
   - name: path.Dir
+    released: v2.7.0
     description: |
       Returns all but the last element of path, typically the path's directory.
 
@@ -51,6 +54,7 @@ funcs:
         $ gomplate -i '{{ path.Dir "/tmp/foo" }}'
         /tmp
   - name: path.Ext
+    released: v2.7.0
     description: |
       Returns the file name extension used by path.
 
@@ -65,6 +69,7 @@ funcs:
         $ gomplate -i '{{ path.Ext "/tmp/foo.csv" }}'
         .csv
   - name: path.IsAbs
+    released: v2.7.0
     description: |
       Reports whether the path is absolute.
 
@@ -81,6 +86,7 @@ funcs:
         $ gomplate -i 'the path is {{ if (path.IsAbs "../foo.csv") }}absolute{{else}}relative{{end}}'
         the path is relative
   - name: path.Join
+    released: v2.7.0
     description: |
       Joins any number of path elements into a single path, adding a separating slash if necessary.
 
@@ -94,6 +100,7 @@ funcs:
         $ gomplate -i '{{ path.Join "/tmp" "foo" "bar" }}'
         /tmp/foo/bar
   - name: path.Match
+    released: v2.7.0
     description: |
       Reports whether name matches the shell file name pattern.
 
@@ -110,6 +117,7 @@ funcs:
         $ gomplate -i '{{ path.Match "*.csv" "foo.csv" }}'
         true
   - name: path.Split
+    released: v2.7.0
     description: |
       Splits path immediately following the final slash, separating it into a directory and file name component.
 

--- a/docs-src/content/functions/random.yml
+++ b/docs-src/content/functions/random.yml
@@ -11,6 +11,7 @@ preamble: |
   these functions will not deplete system entropy.
 funcs:
   - name: random.ASCII
+    released: v3.4.0
     description: |
       Generates a random string of a desired length, containing the set of
       printable characters from the 7-bit [ASCII](https://en.wikipedia.org/wiki/ASCII)
@@ -25,6 +26,7 @@ funcs:
         $ gomplate -i '{{ random.ASCII 8 }}'
         _woJ%D&K
   - name: random.Alpha
+    released: v3.4.0
     description: |
       Generates a random alphabetical (`A-Z`, `a-z`) string of a desired length.
     pipeline: false
@@ -37,6 +39,7 @@ funcs:
         $ gomplate -i '{{ random.Alpha 42 }}'
         oAqHKxHiytYicMxTMGHnUnAfltPVZDhFkVkgDvatJK
   - name: random.AlphaNum
+    released: v3.4.0
     description: |
       Generates a random alphanumeric (`0-9`, `A-Z`, `a-z`) string of a desired length.
     pipeline: false
@@ -49,6 +52,7 @@ funcs:
         $ gomplate -i '{{ random.AlphaNum 16 }}'
         4olRl9mRmVp1nqSm
   - name: random.String
+    released: v3.4.0
     description: |
       Generates a random string of a desired length.
       
@@ -100,6 +104,7 @@ funcs:
         $ gomplate -i 'Poker time! {{ random.String 5 "\U0001f0a1" "\U0001f0de" }}'
         Poker time! 🂼🂺🂳🃅🂪
   - name: random.Item
+    released: v3.4.0
     description: |
       Pick an element at a random from a given slice or array.
     pipeline: true
@@ -116,6 +121,7 @@ funcs:
         $ gomplate -i '{{ getenv "SLICE" | jsonArray | random.Item }}'
         blue
   - name: random.Number
+    released: v3.4.0
     description: |
       Pick a random integer. By default, a number between `0` and `100`
       (inclusive) is chosen, but this range can be overridden.
@@ -142,6 +148,7 @@ funcs:
         $ gomplate -i '{{ random.Number 5 }}'
         2
   - name: random.Float
+    released: v3.4.0
     description: |
       Pick a random decimal floating-point number. By default, a number between
       `0.0` and `1.0` (_exclusive_, i.e. `[0.0,1.0)`) is chosen, but this range

--- a/docs-src/content/functions/regexp.yml
+++ b/docs-src/content/functions/regexp.yml
@@ -6,6 +6,7 @@ preamble: |
   and is the same general syntax used by Perl, Python, and other languages.
 funcs:
   - name: regexp.Find
+    released: v3.1.0
     description: |
       Returns a string holding the text of the leftmost match in `input`
       of the regular expression `expression`.
@@ -28,6 +29,7 @@ funcs:
         $ gomplate -i 'no {{ "will not match" | regexp.Find "[0-9]" }}numbers'
         no numbers
   - name: regexp.FindAll
+    released: v3.1.0
     description: |
       Returns a list of all successive matches of the regular expression.
 
@@ -56,6 +58,7 @@ funcs:
         $ gomplate -i '{{ "foo bar baz qux" | regexp.FindAll "[a-z]{3}" 3 | toJSON}}'
         ["foo", "bar", "baz"]
   - name: regexp.Match
+    released: v1.9.0
     description: |
       Returns `true` if a given regular expression matches a given input.
 
@@ -73,6 +76,7 @@ funcs:
         $ gomplate -i '{{ if (.Env.USER | regexp.Match `^h`) }}username ({{.Env.USER}}) starts with h!{{end}}'
         username (hairyhenderson) starts with h!
   - name: regexp.QuoteMeta
+    released: v3.7.0
     description: |
       Escapes all regular expression metacharacters in the input. The returned string is a regular expression matching the literal text.
 
@@ -88,6 +92,7 @@ funcs:
         $ gomplate -i '{{ `{hello}` | regexp.QuoteMeta }}'
         \{hello\}
   - name: regexp.Replace
+    released: v1.9.0
     description: |
       Replaces matches of a regular expression with the replacement string.
 
@@ -114,6 +119,7 @@ funcs:
         $ gomplate -i '{{ regexp.Replace "(?P<first>[a-zA-Z]+) (?P<last>[a-zA-Z]+)" "${last}, ${first}" "Alan Turing"}}'
         Turing, Alan
   - name: regexp.ReplaceLiteral
+    released: v3.1.0
     description: |
       Replaces matches of a regular expression with the replacement string.
 
@@ -141,6 +147,7 @@ funcs:
         $ gomplate -i '{{ `foo.bar,baz` | regexp.ReplaceLiteral `\W` `$` }}'
         foo$bar$baz
   - name: regexp.Split
+    released: v3.1.0
     description: |
       Splits `input` into sub-strings, separated by the expression.
 

--- a/docs-src/content/functions/sockaddr.yml
+++ b/docs-src/content/functions/sockaddr.yml
@@ -33,6 +33,7 @@ preamble: |
   [RFC 6890]: http://tools.ietf.org/html/rfc6890
 funcs:
   - name: sockaddr.GetAllInterfaces
+    released: v2.4.0
     description: |
       Iterates over all available network interfaces and finds all available IP
       addresses on each interface and converts them to `sockaddr.IPAddrs`, and returning
@@ -40,11 +41,13 @@ funcs:
 
       Should be piped through a further function to refine and extract attributes.
   - name: sockaddr.GetDefaultInterfaces
+    released: v2.4.0
     description: |
       Returns `IfAddrs` of the addresses attached to the default route.
 
       Should be piped through a further function to refine and extract attributes.
   - name: sockaddr.GetPrivateInterfaces
+    released: v2.4.0
     description: |
       Returns an array of `IfAddr`s containing every IP that matches
       [RFC 6890][], is attached to the interface with
@@ -57,12 +60,14 @@ funcs:
 
       Should be piped through a further function to refine and extract attributes.
   - name: sockaddr.GetPublicInterfaces
+    released: v2.4.0
     description: |
       Returns an array of `IfAddr`s that do not match [RFC 6890][],
       are attached to the default route, and are forwardable.
 
       Should be piped through a further function to refine and extract attributes.
   - name: sockaddr.Sort
+    released: v2.4.0
     description: |
       Returns an array of `IfAddr`s sorted based on the given selector. Multiple sort
       clauses can be passed in as a comma-delimited list without whitespace.
@@ -101,6 +106,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Sort "name,-address" }}'
         ```
   - name: sockaddr.Exclude
+    released: v2.4.0
     description: |
       Returns an array of `IfAddr`s filtered by interfaces that do not match the given
       selector's value.
@@ -144,6 +150,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Exclude "type" "ipv6" }}'
         ```
   - name: sockaddr.Include
+    released: v2.4.0
     description: |
       Returns an array of `IfAddr`s filtered by interfaces that match the given
       selector's value.
@@ -161,6 +168,7 @@ funcs:
         required: true
         description: the array of `IfAddr`s to consider
   - name: sockaddr.Attr
+    released: v2.4.0
     description: |
       Returns the named attribute as a string.
     pipeline: true
@@ -176,6 +184,7 @@ funcs:
         $ gomplate -i '{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ipv4") }}{{ . | sockaddr.Attr "name" }} {{end}}'
         lo0 en0
   - name: sockaddr.Join
+    released: v2.4.0
     description: |
       Selects the given attribute from each `IfAddr` in the source array, and joins
       the results with the given separator.
@@ -195,6 +204,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Join "name" "," }}'
         lo0,lo0,lo0,en0,en0
   - name: sockaddr.Limit
+    released: v2.4.0
     description: |
       Returns a slice of `IfAddr`s based on the specified limit.
     pipeline: true
@@ -210,6 +220,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Limit 2 | sockaddr.Join "name" "|" }}'
         lo0|lo0
   - name: sockaddr.Offset
+    released: v2.4.0
     description: |
       Returns a slice of `IfAddr`s based on the specified offset.
     pipeline: true
@@ -225,6 +236,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Limit 2 | sockaddr.Offset 1 | sockaddr.Attr "address" }}'
         ::1
   - name: sockaddr.Unique
+    released: v2.4.0
     description: |
       Creates a unique array of `IfAddr`s based on the matching selector. Assumes the input has
       already been sorted.
@@ -241,6 +253,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Unique "name" | sockaddr.Join "name" ", " }}'
         lo0, en0
   - name: sockaddr.Math
+    released: v2.4.0
     description: |
       Applies a math operation to each `IfAddr` in the input. Any failure will result in zero results.
 
@@ -262,6 +275,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Math "address" "+5" | sockaddr.Attr "address" }}'
         127.0.0.6
   - name: sockaddr.GetPrivateIP
+    released: v2.4.0
     description: |
       Returns a string with a single IP address that is part of [RFC 6890][] and has a
       default route. If the system can't determine its IP address or find an [RFC 6890][]
@@ -272,6 +286,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetPrivateIP }}'
         10.0.0.28
   - name: sockaddr.GetPrivateIPs
+    released: v2.4.0
     description: |
       Returns a space-separated string with all IP addresses that are part of [RFC 6890][]
       (regardless of whether or not there is a default route, unlike `GetPublicIP`).
@@ -283,6 +298,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetPrivateIPs }}'
         10.0.0.28 192.168.0.1
   - name: sockaddr.GetPublicIP
+    released: v2.4.0
     description: |
       Returns a string with a single IP address that is NOT part of [RFC 6890][] and
       has a default route. If the system can't determine its IP address or find a
@@ -293,6 +309,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetPublicIP }}'
         8.1.2.3
   - name: sockaddr.GetPublicIPs
+    released: v2.4.0
     description: |
       Returns a space-separated string with all IP addresses that are NOT part of
       [RFC 6890][] (regardless of whether or not there is a default route, unlike
@@ -304,6 +321,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetPublicIPs }}'
         8.1.2.3 8.2.3.4
   - name: sockaddr.GetInterfaceIP
+    released: v2.4.0
     description: |
       Returns a string with a single IP address sorted by the size of the network
       (i.e. IP addresses with a smaller netmask, larger network size, are sorted first).
@@ -317,6 +335,7 @@ funcs:
         $ gomplate -i '{{ sockaddr.GetInterfaceIP "en0" }}'
         10.0.0.28
   - name: sockaddr.GetInterfaceIPs
+    released: v2.4.0
     description: |
       Returns a string with all IPs, sorted by the size of the network (i.e. IP
       addresses with a smaller netmask, larger network size, are sorted first), on a

--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -2,6 +2,7 @@ ns: strings
 preamble: ''
 funcs:
   - name: strings.Abbrev
+    released: v2.6.0
     description: |
       Abbreviates a string using `...` (ellipses). Takes an optional offset from the beginning of the string, and a maximum final width (including added ellipses).
 
@@ -24,6 +25,7 @@ funcs:
         $ gomplate -i '{{ "foobarbazquxquux" | strings.Abbrev 6 9 }}'
         ...baz...
   - name: strings.Contains
+    released: v1.9.0
     description: |
       Reports whether a substring is contained within a string.
     pipeline: true
@@ -48,6 +50,7 @@ funcs:
         no
         ```
   - name: strings.HasPrefix
+    released: v1.9.0
     description: |
       Tests whether a string begins with a certain prefix.
     pipeline: true
@@ -65,6 +68,7 @@ funcs:
         $ URL=https://example.com gomplate -i '{{if .Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
         foo
   - name: strings.HasSuffix
+    released: v1.9.0
     description: |
       Tests whether a string ends with a certain suffix.
     pipeline: true
@@ -87,6 +91,7 @@ funcs:
         http://example.com:80
         ```
   - name: strings.Indent
+    released: v1.9.0
     alias: indent
     description: |
       Indents a string. If the input string has multiple lines, each line will be indented.
@@ -125,6 +130,7 @@ funcs:
             quuz: 42
         ```
   - name: strings.Sort
+    released: v2.7.0
     deprecated: Use [`coll.Sort`](../coll/#coll-sort) instead
     description: |
       Returns an alphanumerically-sorted copy of a given string list.
@@ -138,6 +144,7 @@ funcs:
         $ gomplate -i '{{ (coll.Slice "foo" "bar" "baz") | strings.Sort }}'
         [bar baz foo]
   - name: strings.SkipLines
+    # released: v4.0.0
     description: |
       Skips the given number of lines (each ending in a `\n`), returning the
       remainder.
@@ -161,6 +168,7 @@ funcs:
         bar
         baz
   - name: strings.Split
+    released: v1.9.0
     description: |
       _Not to be confused with [`split`](#split), which is deprecated._
 
@@ -198,6 +206,7 @@ funcs:
         Two
         Three
   - name: strings.SplitN
+    released: v1.9.0
     description: |
       _Not to be confused with [`splitN`](#splitn), which is deprecated._
 
@@ -232,6 +241,7 @@ funcs:
         foo
         bar:baz
   - name: strings.Quote
+    released: v3.1.0
     alias: quote
     description: |
       Surrounds an input string with double-quote characters (`"`). If the input is not a string, converts first.
@@ -255,6 +265,7 @@ funcs:
         $ gomplate -i '{{ strings.Quote 500 }}'
         "500"
   - name: strings.Repeat
+    released: v2.6.0
     description: |
       Returns a new string consisting of `count` copies of the input string.
 
@@ -274,6 +285,7 @@ funcs:
         $ gomplate -i '{{ "hello " | strings.Repeat 5 }}'
         hello hello hello hello hello
   - name: strings.ReplaceAll
+    released: v1.9.0
     alias: replaceAll
     description: |
       Replaces all occurrences of a given string with another.
@@ -295,6 +307,7 @@ funcs:
         $ gomplate -i '{{ "172.21.1.42" | strings.ReplaceAll "." "-" }}'
         172-21-1-42
   - name: strings.Slug
+    released: v2.6.0
     description: |
       Creates a a "slug" from a given string - supports Unicode correctly. This wraps the [github.com/gosimple/slug](https://github.com/gosimple/slug) package. See [the github.com/gosimple/slug docs](https://godoc.org/github.com/gosimple/slug) for more information.
     pipeline: true
@@ -311,6 +324,7 @@ funcs:
         rock-and-roll-at-cafe-wha
   - name: strings.ShellQuote
     alias: shellQuote
+    released: v3.6.0
     description: |
       Given a string, emits a version of that string that will evaluate to its literal data when expanded by any POSIX-compliant shell.
 
@@ -329,6 +343,7 @@ funcs:
         'it'"'"'s a banana'
   - name: strings.Squote
     alias: squote
+    released: v3.1.0
     description: |
       Surrounds an input string with a single-quote (apostrophe) character (`'`). If the input is not a string, converts first.
 
@@ -347,6 +362,7 @@ funcs:
         'it''s a banana'
   - name: strings.Title
     alias: title
+    released: v1.9.0
     description: |
       Convert to title-case.
     pipeline: true
@@ -360,6 +376,7 @@ funcs:
         Hello, World!
   - name: strings.ToLower
     alias: toLower
+    released: v1.9.0
     description: |
       Convert to lower-case.
     pipeline: true
@@ -373,6 +390,7 @@ funcs:
         hello, world!
   - name: strings.ToUpper
     alias: toUpper
+    released: v1.9.0
     description: |
       Convert to upper-case.
     pipeline: true
@@ -385,6 +403,7 @@ funcs:
         $ gomplate -i '{{strings.ToUpper "hello, world!"}}'
         HELLO, WORLD!
   - name: strings.Trim
+    released: v1.9.0
     description: |
       Trims a string by removing the given characters from the beginning and end of
       the string.
@@ -401,6 +420,7 @@ funcs:
         $ gomplate -i '{{ "_-foo-_" | strings.Trim "_-" }}
         foo
   - name: strings.TrimPrefix
+    released: v2.5.0
     description: |
       Returns a string without the provided leading prefix string, if the prefix is present.
 
@@ -419,6 +439,7 @@ funcs:
         world
   - name: strings.TrimSpace
     alias: trimSpace
+    released: v1.9.0
     description: |
       Trims a string by removing whitespace from the beginning and end of
       the string.
@@ -432,6 +453,7 @@ funcs:
         $ gomplate -i '{{ "  \n\t foo" | strings.TrimSpace }}'
         foo
   - name: strings.TrimSuffix
+    released: v2.6.0
     description: |
       Returns a string without the provided trailing suffix string, if the suffix is present.
 
@@ -449,6 +471,7 @@ funcs:
         $ gomplate -i '{{ "hello, world" | strings.TrimSuffix "world" }}jello'
         hello, jello
   - name: strings.Trunc
+    released: v2.6.0
     description: |
       Returns a string truncated to the given length.
 
@@ -466,6 +489,7 @@ funcs:
         $ gomplate -i '{{ "hello, world" | strings.Trunc 5 }}'
         hello
   - name: strings.CamelCase
+    released: v3.3.0
     description: |
       Converts a sentence to CamelCase, i.e. `The quick brown fox` becomes `TheQuickBrownFox`.
 
@@ -485,6 +509,7 @@ funcs:
         $ gomplate -i '{{ "hello jello" | strings.CamelCase }}'
         helloJello
   - name: strings.SnakeCase
+    released: v3.3.0
     description: |
       Converts a sentence to snake_case, i.e. `The quick brown fox` becomes `The_quick_brown_fox`.
 
@@ -504,6 +529,7 @@ funcs:
         $ gomplate -i '{{ "hello jello" | strings.SnakeCase }}'
         hello_jello
   - name: strings.KebabCase
+    released: v3.3.0
     description: |
       Converts a sentence to kebab-case, i.e. `The quick brown fox` becomes `The-quick-brown-fox`.
 
@@ -523,6 +549,7 @@ funcs:
         $ gomplate -i '{{ "hello jello" | strings.KebabCase }}'
         hello-jello
   - name: strings.WordWrap
+    released: v3.3.0
     description: |
       Inserts new line breaks into the input string so it ends up with lines that are at most `width` characters wide.
 
@@ -555,6 +582,7 @@ funcs:
         which should not be
         broken
   - name: strings.RuneCount
+    released: v3.4.0
     description: |
       Return the number of _runes_ (Unicode code-points) contained within the
       input. This is similar to the built-in `len` function, but `len` counts
@@ -579,6 +607,7 @@ funcs:
         ᐰ is 3 bytes and 1 runes
   - name: contains
     deprecated: Use [`strings.Contains`](#strings-contains) instead
+    released: v1.4.0
     description: |
       **See [`strings.Contains`](#strings-contains) for a pipeline-compatible version**
 
@@ -607,6 +636,7 @@ funcs:
         ```
   - name: hasPrefix
     deprecated: Use [`strings.HasPrefix`](#strings-hasprefix) instead
+    released: v1.4.0
     description: |
       **See [`strings.HasPrefix`](#strings-hasprefix) for a pipeline-compatible version**
 
@@ -635,6 +665,7 @@ funcs:
         ```
   - name: hasSuffix
     deprecated: Use [`strings.HasSuffix`](#strings-hassuffix) instead
+    released: v1.4.0
     description: |
       **See [`strings.HasSuffix`](#strings-hassuffix) for a pipeline-compatible version**
 
@@ -661,6 +692,7 @@ funcs:
         ```
   - name: split
     deprecated: Use [`strings.Split`](#strings-split) instead
+    released: v1.4.0
     description: |
       **See [`strings.Split`](#strings-split) for a pipeline-compatible version**
 
@@ -683,6 +715,7 @@ funcs:
         Hello, Maggie
   - name: splitN
     deprecated: Use [`strings.SplitN`](#strings-splitn) instead
+    released: v1.7.0
     description: |
       **See [`strings.SplitN`](#strings-splitn) for a pipeline-compatible version**
 
@@ -707,6 +740,7 @@ funcs:
         bar:baz
   - name: trim
     deprecated: Use [`strings.Trim`](#strings-trim) instead
+    released: v1.4.0
     description: |
       **See [`strings.Trim`](#strings-trim) for a pipeline-compatible version**
 

--- a/docs-src/content/functions/test.yml
+++ b/docs-src/content/functions/test.yml
@@ -5,6 +5,7 @@ preamble: |
 funcs:
   - name: test.Assert
     alias: assert
+    released: v2.7.0
     description: |
       Asserts that the given expression or value is `true`. If it is not, causes
       template generation to fail immediately with an optional message.
@@ -24,6 +25,7 @@ funcs:
         template: <arg>:1:3: executing "<arg>" at <assert "something ho...>: error calling assert: assertion failed: something horrible happened
   - name: test.Fail
     alias: fail
+    released: v2.7.0
     description: |
       Cause template generation to fail immediately, with an optional message.
     pipeline: true
@@ -39,6 +41,7 @@ funcs:
         template: <arg>:1:7: executing "<arg>" at <test.Fail>: error calling Fail: template generation failed: something is wrong!
   - name: test.IsKind
     alias: isKind
+    released: v3.8.0
     description: |
       Report whether the argument is of the given Kind. Can be used to render
       different templates depending on the kind of data.
@@ -88,6 +91,7 @@ funcs:
         - "key2": foobar
   - name: test.Kind
     alias: kind
+    released: v3.8.0
     description: |
       Report the _kind_ of the given argument. This differs from the _type_ of
       the argument in specificity; for example, while a slice of strings may
@@ -110,6 +114,7 @@ funcs:
         map
   - name: test.Required
     alias: required
+    released: v3.0.0
     description: |
       Passes through the given value, if it's non-empty, and non-`nil`. Otherwise,
       exits and prints a given error message so the user can adjust as necessary.
@@ -149,6 +154,7 @@ funcs:
         template: <arg>:1:7: executing "<arg>" at <"config">: map has no entry for key "bogus"
   - name: test.Ternary
     alias: ternary
+    released: v3.1.0
     description: |
       Returns one of two values depending on whether the third is true. Note that the third value does not have to be a boolean - it is converted first by the [`conv.ToBool`](../conv/#conv-tobool) function (values like `true`, `1`, `"true"`, `"Yes"`, etc... are considered true).
 

--- a/docs-src/content/functions/time.yml
+++ b/docs-src/content/functions/time.yml
@@ -70,6 +70,7 @@ preamble: |
   For other durations, such as `2h10m`, [`time.ParseDuration`](#time-parseduration) can be used.
 funcs:
   - name: time.Now
+    released: v2.1.0
     description: |
       Returns the current local time, as a `time.Time`. This wraps [`time.Now`](https://golang.org/pkg/time/#Now).
 
@@ -103,6 +104,7 @@ funcs:
         ... ... BEEP
         ```
   - name: time.Parse
+    released: v2.1.0
     description: |
       Parses a timestamp defined by the given layout. This wraps [`time.Parse`](https://golang.org/pkg/time/#Parse).
 
@@ -129,6 +131,7 @@ funcs:
         Saturday October 23, 1993 UTC
         ```
   - name: time.ParseDuration
+    released: v2.1.0
     description: |
       Parses a duration string. This wraps [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration).
 
@@ -147,6 +150,7 @@ funcs:
         12:43AM
         3:13AM
   - name: time.ParseLocal
+    released: v2.2.0
     description: |
       Same as [`time.Parse`](#time-parse), except that in the absence of a time zone
       indicator, the timestamp wil be parsed in the local timezone.
@@ -166,6 +170,7 @@ funcs:
         06:00 EST
         ```
   - name: time.ParseInLocation
+    released: v2.2.0
     description: |
       Same as [`time.Parse`](#time-parse), except that the time is parsed in the given location's time zone.
 
@@ -189,6 +194,7 @@ funcs:
         06:00 LMT
         ```
   - name: time.Since
+    released: v2.5.0
     description: |
       Returns the time elapsed since a given time. This wraps [`time.Since`](https://golang.org/pkg/time/#Since).
 
@@ -203,6 +209,7 @@ funcs:
         $ gomplate -i '{{ $t := time.Parse time.RFC3339 "1970-01-01T00:00:00Z" }}time since the epoch:{{ time.Since $t }}'
         time since the epoch:423365h0m24.353828924s
   - name: time.Unix
+    released: v2.1.0
     description: |
       Returns the local `Time` corresponding to the given Unix time, in seconds since
       January 1, 1970 UTC. Note that fractional seconds can be used to denote
@@ -226,6 +233,7 @@ funcs:
         Jan  2 10:17:36.789
         ```
   - name: time.Until
+    released: v2.5.0
     description: |
       Returns the duration until a given time. This wraps [`time.Until`](https://golang.org/pkg/time/#Until).
 
@@ -248,6 +256,7 @@ funcs:
         only 14923h0m0s to go...
         ```
   - name: time.ZoneName
+    released: v2.1.0
     description: |
       Return the local system's time zone's name.
     pipeline: false
@@ -256,6 +265,7 @@ funcs:
         $ gomplate -i '{{time.ZoneName}}'
         EDT
   - name: time.ZoneOffset
+    released: v2.2.0
     description: |
       Return the local system's time zone offset, in seconds east of UTC.
     pipeline: false

--- a/docs-src/content/functions/tmpl.yml
+++ b/docs-src/content/functions/tmpl.yml
@@ -4,6 +4,7 @@ preamble: |
   Functions for defining or executing templates.
 funcs:
   - name: tmpl.Exec
+    released: v3.3.0
     description: |
       Execute (render) the named template. This is equivalent to using the [`template`](https://golang.org/pkg/text/template/#hdr-Actions) action, except the result is returned as a string.
 
@@ -25,6 +26,7 @@ funcs:
         Hello, World!
   - name: tmpl.Inline
     alias: tpl
+    released: v3.3.0
     description: |
       Render the given string as a template, just like a nested template.
 
@@ -56,6 +58,7 @@ funcs:
         hello world
         goodbye world
   - name: tmpl.Path
+    released: v3.11.0
     description: |
       Output the path of the current template, if it came from a file. For
       inline templates, this will be an empty string.
@@ -75,6 +78,7 @@ funcs:
         this template is in subdir/input.tpl
         ```
   - name: tmpl.PathDir
+    released: v3.11.0
     description: |
       Output the current template's directory. For inline templates, this will
       be an empty string.

--- a/docs-src/content/functions/uuid.yml
+++ b/docs-src/content/functions/uuid.yml
@@ -14,6 +14,7 @@ preamble: |
   [log an issue]: https://github.com/hairyhenderson/gomplate/issues/new
 funcs:
   - name: uuid.V1
+    released: v3.4.0
     description: |
       Create a version 1 UUID (based on the current MAC address and the current date/time).
 
@@ -24,6 +25,7 @@ funcs:
         $ gomplate -i '{{ uuid.V1 }}'
         4d757e54-446d-11e9-a8fa-72000877c7b0
   - name: uuid.V4
+    released: v3.4.0
     description: |
       Create a version 4 UUID (randomly generated).
 
@@ -34,6 +36,7 @@ funcs:
         $ gomplate -i '{{ uuid.V4 }}'
         40b3c2d2-e491-4b19-94cd-461e6fa35a60
   - name: uuid.Nil
+    released: v3.4.0
     description: |
       Returns the _nil_ UUID, that is, `00000000-0000-0000-0000-000000000000`,
       mostly for testing scenarios.
@@ -43,6 +46,7 @@ funcs:
         $ gomplate -i '{{ uuid.Nil }}'
         00000000-0000-0000-0000-000000000000
   - name: uuid.IsValid
+    released: v3.4.0
     description: |
       Checks that the given UUID is in the correct format. It does not validate
       whether the version or variant are correct.
@@ -59,6 +63,7 @@ funcs:
         $ gomplate -i '{{ uuid.IsValid "urn:uuid:12345678-90ab-cdef-fedc-ba9876543210" }}'
         true
   - name: uuid.Parse
+    released: v3.4.0
     description: |
       Parse a UUID for further manipulation or inspection.
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,7 @@
 ---
 title: gomplate
 type: index
+archetype: "home"
 weight: 1
 menu:
   main:

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -31,9 +31,10 @@ Queries AWS [EC2 Instance Metadata](http://docs.aws.amazon.com/AWSEC2/latest/Use
 
 For times when running outside EC2, or when the metadata API can't be reached, a `default` value can be provided.
 
+_Added in gomplate [v1.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.8.0)_
 ### Usage
 
-```go
+```
 aws.EC2Meta key [default]
 ```
 
@@ -59,9 +60,10 @@ Queries AWS [EC2 Instance Dynamic Metadata](http://docs.aws.amazon.com/AWSEC2/la
 
 For times when running outside EC2, or when the metadata API can't be reached, a `default` value can be provided.
 
+_Added in gomplate [v1.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.8.0)_
 ### Usage
 
-```go
+```
 aws.EC2Dynamic key [default]
 ```
 
@@ -86,9 +88,10 @@ us-east-1
 Queries AWS to get the region. An optional default can be provided, or returns
 `unknown` if it can't be determined for some reason.
 
+_Added in gomplate [v1.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.8.0)_
 ### Usage
 
-```go
+```
 aws.EC2Region [default]
 ```
 
@@ -120,9 +123,10 @@ foo
 Queries the AWS EC2 API to find the value of the given [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html). An optional default
 can be provided.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 aws.EC2Tag tag [default]
 ```
 
@@ -150,9 +154,10 @@ I am a meat popsicle.
 
 Queries the AWS EC2 API to find all the tags/values [user-defined tag](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 aws.EC2Tags
 ```
 
@@ -170,7 +175,8 @@ Name=bar
 svc:name=foobar
 ```
 
-## `aws.KMSEncrypt`
+## `aws.KMSEncrypt`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 Encrypt an input string with the AWS Key Management Service (KMS).
 
@@ -195,10 +201,10 @@ See also [`aws.KMSDecrypt`](#aws-kmsdecrypt).
 
 ### Usage
 
-```go
+```
 aws.KMSEncrypt keyID input
 ```
-```go
+```
 input | aws.KMSEncrypt keyID
 ```
 
@@ -228,12 +234,13 @@ for more details.
 
 See also [`aws.KMSEncrypt`](#aws-kmsencrypt).
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 aws.KMSDecrypt input
 ```
-```go
+```
 input | aws.KMSDecrypt
 ```
 
@@ -258,9 +265,10 @@ Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/API
 
 See also [`aws.UserID`](#aws-userid) and [`aws.ARN`](#aws-arn).
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 aws.Account
 ```
 
@@ -280,9 +288,10 @@ Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/API
 
 See also [`aws.UserID`](#aws-userid) and [`aws.Account`](#aws-account).
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 aws.ARN
 ```
 
@@ -305,9 +314,10 @@ Wraps the [STS GetCallerIdentity API](https://docs.aws.amazon.com/STS/latest/API
 
 See also [`aws.ARN`](#aws-arn) and [`aws.Account`](#aws-account).
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 aws.UserID
 ```
 

--- a/docs/content/functions/base64.md
+++ b/docs/content/functions/base64.md
@@ -10,12 +10,13 @@ menu:
 
 Encode data as a Base64 string. Specifically, this uses the standard Base64 encoding as defined in [RFC4648 &sect;4](https://tools.ietf.org/html/rfc4648#section-4) (and _not_ the URL-safe encoding).
 
+_Added in gomplate [v1.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.8.0)_
 ### Usage
 
-```go
+```
 base64.Encode input
 ```
-```go
+```
 input | base64.Encode
 ```
 
@@ -44,12 +45,13 @@ This function outputs the data as a string, so it may not be appropriate
 for decoding binary data. Use [`base64.DecodeBytes`](#base64.DecodeBytes)
 for binary data.
 
+_Added in gomplate [v1.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.8.0)_
 ### Usage
 
-```go
+```
 base64.Decode input
 ```
-```go
+```
 input | base64.Decode
 ```
 
@@ -78,9 +80,10 @@ This function outputs the data as a byte array, so it's most useful for
 outputting binary data that will be processed further.
 Use [`base64.Decode`](#base64.Decode) to output a plain string.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 base64.DecodeBytes input
 ```
 

--- a/docs/content/functions/coll.md
+++ b/docs/content/functions/coll.md
@@ -29,9 +29,10 @@ For creating more complex maps, see [`data.JSON`](../data/#data-json) or [`data.
 
 For creating arrays, see [`coll.Slice`](#coll-slice).
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Dict in...
 ```
 
@@ -67,9 +68,10 @@ Hello everybody!
 
 Creates a slice (like an array or list). Useful when needing to `range` over a bunch of variables.
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Slice in...
 ```
 
@@ -88,7 +90,8 @@ Hello, Lisa
 Hello, Maggie
 ```
 
-## `coll.GoSlice`
+## `coll.GoSlice`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 This exposes the `slice` function from Go's [`text/template`](https://golang.org/pkg/text/template/#hdr-Functions)
 package. Note that using `slice` will use the `coll.Slice` function instead,
@@ -109,7 +112,7 @@ more details.
 
 ### Usage
 
-```go
+```
 coll.GoSlice item [indexes...]
 ```
 
@@ -133,9 +136,10 @@ lo wo
 
 Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Has in item
 ```
 
@@ -165,7 +169,8 @@ $ gomplate -i '{{ $o := data.JSON (getenv "DATA") -}}
 THERE IS NO FOO
 ```
 
-## `coll.Index`
+## `coll.Index`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 Returns the result of indexing the given map, slice, or array by the given
 key or index. This is similar to the built-in `index` function, but the
@@ -177,10 +182,10 @@ Multiple indexes may be given, for nested indexing.
 
 ### Usage
 
-```go
+```
 coll.Index indexes... in
 ```
-```go
+```
 in | coll.Index indexes...
 ```
 
@@ -219,12 +224,13 @@ JSONPath expressions can be validated at https://jsonpath.com
 
 [JSONPath]: https://goessner.net/articles/JsonPath
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 coll.JSONPath expression in
 ```
-```go
+```
 in | coll.JSONPath expression
 ```
 
@@ -242,7 +248,8 @@ $ gomplate -i '{{ .books | jsonpath `$..works[?( @.edition_count > 400 )].title`
 [Alice's Adventures in Wonderland Gulliver's Travels]
 ```
 
-## `coll.JQ`
+## `coll.JQ`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 **Alias:** `jq`
 
@@ -261,10 +268,10 @@ See also:
 
 ### Usage
 
-```go
+```
 coll.JQ expression in
 ```
-```go
+```
 in | coll.JQ expression
 ```
 
@@ -295,12 +302,13 @@ then alphabetically.
 
 See also [`coll.Values`](#coll-values).
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Keys in...
 ```
-```go
+```
 in... | coll.Keys
 ```
 
@@ -330,12 +338,13 @@ then alphabetically by key.
 
 See also [`coll.Keys`](#coll-keys).
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Values in...
 ```
-```go
+```
 in... | coll.Values
 ```
 
@@ -364,12 +373,13 @@ _Note that this function does not change the given list; it always produces a ne
 
 See also [`coll.Prepend`](#coll-prepend).
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Append value list...
 ```
-```go
+```
 list... | coll.Append value
 ```
 
@@ -397,12 +407,13 @@ _Note that this function does not change the given list; it always produces a ne
 
 See also [`coll.Append`](#coll-append).
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Prepend value list...
 ```
-```go
+```
 list... | coll.Prepend value
 ```
 
@@ -428,12 +439,13 @@ Remove any duplicate values from the list, without changing order.
 
 _Note that this function does not change the given list; it always produces a new one._
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Uniq list
 ```
-```go
+```
 list | coll.Uniq
 ```
 
@@ -459,12 +471,13 @@ but can be limited with `depth`.
 
 _Note that this function does not change the given list; it always produces a new one._
 
+_Added in gomplate [v3.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.6.0)_
 ### Usage
 
-```go
+```
 coll.Flatten [depth] list
 ```
-```go
+```
 list | coll.Flatten [depth]
 ```
 
@@ -494,12 +507,13 @@ Reverse a list.
 
 _Note that this function does not change the given list; it always produces a new one._
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Reverse list
 ```
-```go
+```
 list | coll.Reverse
 ```
 
@@ -528,12 +542,13 @@ Maps and structs can be sorted by a named key.
 
 _Note that this function does not modify the input._
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Sort [key] list
 ```
-```go
+```
 list | coll.Sort [key]
 ```
 
@@ -577,12 +592,13 @@ Many source maps can be provided. Precedence is in left-to-right order.
 
 _Note that this function does not modify the input._
 
+_Added in gomplate [v3.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.2.0)_
 ### Usage
 
-```go
+```
 coll.Merge dst srcs...
 ```
-```go
+```
 srcs... | coll.Merge dst
 ```
 
@@ -619,12 +635,13 @@ This is the inverse of [`coll.Omit`](#coll-omit).
 
 _Note that this function does not modify the input._
 
+_Added in gomplate [v3.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.7.0)_
 ### Usage
 
-```go
+```
 coll.Pick keys... map
 ```
-```go
+```
 map | coll.Pick keys...
 ```
 
@@ -649,16 +666,17 @@ Given a map, returns a new map without any entries that have the given keys.
 
 All keys are converted to strings.
 
-This is the inverse of [`coll.Pic`](#coll-pick).
+This is the inverse of [`coll.Pick`](#coll-pick).
 
 _Note that this function does not modify the input._
 
+_Added in gomplate [v3.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.7.0)_
 ### Usage
 
-```go
+```
 coll.Omit keys... map
 ```
-```go
+```
 map | coll.Omit keys...
 ```
 

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -16,12 +16,13 @@ to another - generally from a `string` to something else, and vice-versa.
 
 Converts a true-ish string to a boolean. Can be used to simplify conditional statements based on environment variables or other text input.
 
+_Added in gomplate [v0.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v0.2.0)_
 ### Usage
 
-```go
+```
 conv.Bool in
 ```
-```go
+```
 in | conv.Bool
 ```
 
@@ -56,12 +57,13 @@ Note that this will not provide a default for the case where the input is undefi
 (i.e. referencing things like `.foo` where there is no `foo` field of `.`), but
 [`conv.Has`](#conv-has) can be used for that.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 conv.Default default in
 ```
-```go
+```
 in | conv.Default default
 ```
 
@@ -98,9 +100,10 @@ For creating more complex maps, see [`data.JSON`](../data/#data-json) or [`data.
 
 For creating arrays, see [`coll.Slice`](#coll-slice).
 
+_Added in gomplate [v3.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.0.0)_
 ### Usage
 
-```go
+```
 conv.Dict in...
 ```
 
@@ -136,9 +139,10 @@ Hello everybody!
 
 Creates a slice (like an array or list). Useful when needing to `range` over a bunch of variables.
 
+_Added in gomplate [v0.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v0.3.0)_
 ### Usage
 
-```go
+```
 conv.Slice in...
 ```
 
@@ -164,9 +168,10 @@ Hello, Maggie
 
 Reports whether a given object has a property with the given key, or whether a given array/slice contains the given value. Can be used with `if` to prevent the template from trying to access a non-existent property in an object.
 
+_Added in gomplate [v1.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.5.0)_
 ### Usage
 
-```go
+```
 conv.Has in item
 ```
 
@@ -202,9 +207,10 @@ THERE IS NO FOO
 
 Concatenates the elements of an array to create a string. The separator string `sep` is placed between elements in the resulting string.
 
+_Added in gomplate [v0.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v0.4.0)_
 ### Usage
 
-```go
+```
 conv.Join in sep
 ```
 
@@ -230,9 +236,10 @@ Parses a string as a URL for later use. Equivalent to [url.Parse](https://golang
 
 Any of `url.URL`'s methods can be called on the result.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 conv.URL in
 ```
 
@@ -270,9 +277,10 @@ _**Note:**_ See [`conv.ToInt64`](#conv-toint64) instead for a simpler and more f
 
 Parses a string as an int64. Equivalent to [strconv.ParseInt](https://golang.org/pkg/strconv/#ParseInt)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 conv.ParseInt
 ```
 
@@ -297,9 +305,10 @@ _**Note:**_ See [`conv.ToFloat`](#conv-tofloat) instead for a simpler and more f
 
 Parses a string as an float64 for later use. Equivalent to [strconv.ParseFloat](https://golang.org/pkg/strconv/#ParseFloat)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 conv.ParseFloat
 ```
 
@@ -323,9 +332,10 @@ pi is greater than 3
 
 Parses a string as an uint64 for later use. Equivalent to [strconv.ParseUint](https://golang.org/pkg/strconv/#ParseUint)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 conv.ParseUint
 ```
 
@@ -350,9 +360,10 @@ _**Note:**_ See [`conv.ToInt`](#conv-toint) and [`conv.ToInt64`](#conv-toint64) 
 
 Parses a string as an int for later use. Equivalent to [strconv.Atoi](https://golang.org/pkg/strconv/#Atoi)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 conv.Atoi
 ```
 
@@ -380,12 +391,13 @@ Converts the input to a boolean value.
 Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
 (any capitalizations). All other values are considered `false`.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 conv.ToBool input
 ```
-```go
+```
 input | conv.ToBool
 ```
 
@@ -410,12 +422,13 @@ Converts a list of inputs to an array of boolean values.
 Possible `true` values are: `1` or the strings `"t"`, `"true"`, or `"yes"`
 (any capitalizations). All other values are considered `false`.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 conv.ToBools input
 ```
-```go
+```
 input | conv.ToBools
 ```
 
@@ -445,9 +458,10 @@ errors, or `0` or `-1`.
 
 Floating-point numbers (with decimal points) are truncated.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 conv.ToInt64 in
 ```
 
@@ -486,9 +500,10 @@ the result is `-1`. This is done to protect against
 
 See also [`conv.ToInt64`](#conv-toint64).
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 conv.ToInt in
 ```
 
@@ -519,9 +534,10 @@ Converts the inputs to an array of `int64`s.
 
 This delegates to [`conv.ToInt64`](#conv-toint64) for each input argument.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 conv.ToInt64s in...
 ```
 
@@ -544,9 +560,10 @@ Converts the inputs to an array of `int`s.
 
 This delegates to [`conv.ToInt`](#conv-toint) for each input argument.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 conv.ToInts in...
 ```
 
@@ -572,9 +589,10 @@ and booleans), but behaviour when the input can not be converted is
 undefined and subject to change. Unconvertable inputs may result in
 errors, or `0` or `-1`.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 conv.ToFloat64 in
 ```
 
@@ -599,9 +617,10 @@ Converts the inputs to an array of `float64`s.
 
 This delegates to [`conv.ToFloat64`](#conv-tofloat64) for each input argument.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 conv.ToFloat64s in...
 ```
 
@@ -624,9 +643,10 @@ Converts the input (of any type) to a `string`.
 
 The input will always be represented in _some_ way.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 conv.ToString in
 ```
 
@@ -653,9 +673,10 @@ Converts the inputs (of any type) to an array of `string`s
 
 This delegates to [`conv.ToString`](#conv-tostring) for each input argument.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 conv.ToStrings in...
 ```
 

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -18,12 +18,13 @@ before using gomplate for critical security infrastructure!_
 
 Uses the [bcrypt](https://en.wikipedia.org/wiki/Bcrypt) password hashing algorithm to generate the hash of a given string. Wraps the [`golang.org/x/crypto/brypt`](https://godoc.org/golang.org/x/crypto/bcrypt) package.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 crypto.Bcrypt [cost] input
 ```
-```go
+```
 input | crypto.Bcrypt [cost]
 ```
 
@@ -61,12 +62,13 @@ This function is suitable for decrypting data that was encrypted by
 Helm's `encryptAES` function, when the input is base64-decoded, and when
 using 256-bit keys.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 crypto.DecryptAES key [keyBits] input
 ```
-```go
+```
 input | crypto.DecryptAES key [keyBits]
 ```
 
@@ -100,12 +102,13 @@ This function is suitable for decrypting data that was encrypted by
 Helm's `encryptAES` function, when the input is base64-decoded, and when
 using 256-bit keys.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 crypto.DecryptAESBytes key [keyBits] input
 ```
-```go
+```
 input | crypto.DecryptAESBytes key [keyBits]
 ```
 
@@ -136,12 +139,13 @@ This function is suitable for encrypting data that will be decrypted by
 Helm's `decryptAES` function, when the output is base64-encoded, and when
 using 256-bit keys.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 crypto.EncryptAES key [keyBits] input
 ```
-```go
+```
 input | crypto.EncryptAES key [keyBits]
 ```
 
@@ -174,12 +178,13 @@ supported.
 Default curve is P-256 and can be overridden with the optional `curve`
 parameter.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 crypto.ECDSAGenerateKey [curve]
 ```
-```go
+```
 curve | crypto.ECDSAGenerateKey
 ```
 
@@ -207,12 +212,13 @@ $ gomplate -i '{{ crypto.ECDSAGenerateKey }}'
 Derive a public key from an elliptic curve private key and output in PKIX
 ASN.1 DER form.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 crypto.ECDSADerivePublicKey key
 ```
-```go
+```
 key | crypto.ECDSADerivePublicKey
 ```
 
@@ -246,9 +252,10 @@ Run the Password-Based Key Derivation Function &num;2 as defined in
 
 This function outputs the binary result as a hexadecimal string.
 
+_Added in gomplate [v2.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.3.0)_
 ### Usage
 
-```go
+```
 crypto.PBKDF2 password salt iter keylen [hashfunc]
 ```
 
@@ -286,12 +293,13 @@ convertible to a byte array. To decrypt base64-encoded input, you must
 first decode with the [`base64.DecodeBytes`](../base64/#base64.DecodeBytes)
 function.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 crypto.RSADecrypt key input
 ```
-```go
+```
 input | crypto.RSADecrypt key
 ```
 
@@ -335,12 +343,13 @@ function.
 See [`crypto.RSADecrypt`](#crypto.RSADecrypt) for a function that outputs
 a string.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 crypto.RSADecryptBytes key input
 ```
-```go
+```
 input | crypto.RSADecryptBytes key
 ```
 
@@ -390,12 +399,13 @@ _Warning:_ Using this function may not be safe. See the warning on Go's
 [`rsa.EncryptPKCS1v15`](https://golang.org/pkg/crypto/rsa/#EncryptPKCS1v15)
 documentation.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 crypto.RSAEncrypt key input
 ```
-```go
+```
 input | crypto.RSAEncrypt key
 ```
 
@@ -437,12 +447,13 @@ keys shorter than `2048` bits may not be generated.
 The output is a string, suitable for use with the other `crypto.RSA*`
 functions.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 crypto.RSAGenerateKey [bits]
 ```
-```go
+```
 bits | crypto.RSAGenerateKey
 ```
 
@@ -478,12 +489,13 @@ form.
 The output is a string, suitable for use with other `crypto.RSA*`
 functions.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 crypto.RSADerivePublicKey key
 ```
-```go
+```
 key | crypto.RSADerivePublicKey
 ```
 
@@ -516,6 +528,7 @@ These functions output the binary result as a hexadecimal string.
 
 _Warning: SHA-1 is cryptographically broken and should not be used for secure applications._
 
+_Added in gomplate [v2.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.3.0)_
 ### Usage
 ```
 crypto.SHA1 input
@@ -552,6 +565,7 @@ These functions output the raw binary result, suitable for piping to other funct
 
 _Warning: SHA-1 is cryptographically broken and should not be used for secure applications._
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 ```
 crypto.SHA1Bytes input
@@ -583,9 +597,10 @@ values necessary to convert ASCII passphrases to the WPA pre-shared keys for use
 
 This can be used, for example, to help generate a configuration for [wpa_supplicant](http://w1.fi/wpa_supplicant/).
 
+_Added in gomplate [v2.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.3.0)_
 ### Usage
 
-```go
+```
 crypto.WPAPSK ssid password
 ```
 

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -17,9 +17,10 @@ If the `alias` is undefined, but is a valid URL, `datasource` will dynamically r
 
 See [Datasources](../../datasources) for (much!) more information.
 
+_Added in gomplate [v0.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v0.5.0)_
 ### Usage
 
-```go
+```
 datasource alias [subpath]
 ```
 
@@ -53,9 +54,10 @@ Note: this does _not_ verify if the datasource is reachable.
 
 Useful when used in an `if`/`else` block.
 
+_Added in gomplate [v1.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.3.0)_
 ### Usage
 
-```go
+```
 datasourceExists alias
 ```
 
@@ -78,9 +80,10 @@ Tests whether or not a given datasource is defined and reachable, where the defi
 
 Useful when used in an `if`/`else` block.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 datasourceReachable alias
 ```
 
@@ -101,9 +104,10 @@ no worries
 
 Lists all the datasources defined, list returned will be sorted in ascending order.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 listDatasources
 ```
 
@@ -126,9 +130,10 @@ This function can provide a good way to set a default datasource when sharing te
 
 See [Datasources](../../datasources) for (much!) more information.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 defineDatasource alias url
 ```
 
@@ -159,9 +164,10 @@ Includes the content of a given datasource (provided by the [`--datasource/-d`](
 
 This is similar to [`datasource`](#datasource), except that the data is not parsed. There is no restriction on the type of data included, except that it should be textual.
 
+_Added in gomplate [v1.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.8.0)_
 ### Usage
 
-```go
+```
 include alias [subpath]
 ```
 
@@ -214,12 +220,13 @@ If the input is in the [EJSON](https://github.com/Shopify/ejson) format (i.e. ha
 - set the `EJSON_KEY_FILE` environment variable to the path to a file containing the private key
 - set the `EJSON_KEYDIR` environment variable to the path to a directory containing private keys (filename must be the public key), just like [`ejson decrypt`'s `--keydir`](https://github.com/Shopify/ejson/blob/master/man/man1/ejson.1.ronn) flag. Defaults to `/opt/ejson/keys`.
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 data.JSON in
 ```
-```go
+```
 in | data.JSON
 ```
 
@@ -248,12 +255,13 @@ Hello world
 
 Converts a JSON string into a slice. Only works for JSON Arrays.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.JSONArray in
 ```
-```go
+```
 in | data.JSONArray
 ```
 
@@ -285,12 +293,13 @@ also parse YAML Arrays. This can be used to access properties of YAML objects.
 
 For more explict YAML Array support, see [`data.JSONArray`](#data-yamlarray).
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.YAML in
 ```
-```go
+```
 in | data.YAML
 ```
 
@@ -319,12 +328,13 @@ Hello world
 
 Converts a YAML string into a slice. Only works for YAML Arrays.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.YAMLArray in
 ```
-```go
+```
 in | data.YAMLArray
 ```
 
@@ -356,12 +366,13 @@ This can be used to access properties of TOML documents.
 
 Compatible with [TOML v0.4.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md).
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.TOML input
 ```
-```go
+```
 input | data.TOML
 ```
 
@@ -394,12 +405,13 @@ Converts a CSV-format string into a 2-dimensional string array.
 By default, the [RFC 4180](https://tools.ietf.org/html/rfc4180) format is
 supported, but any single-character delimiter can be specified.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.CSV [delim] input
 ```
-```go
+```
 input | data.CSV [delim]
 ```
 
@@ -442,12 +454,13 @@ Also by default, the first line of the string will be assumed to be the header,
 but this can be overridden by providing an explicit header, or auto-indexing
 can be used.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.CSVByRow [delim] [header] input
 ```
-```go
+```
 input | data.CSVByRow [delim] [header]
 ```
 
@@ -486,12 +499,13 @@ COBOL has 357 keywords.
 Like [`csvByRow`](#csvByRow), except that the data is presented as a columnar
 (column-oriented) map.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.CSVByColumn [delim] [header] input
 ```
-```go
+```
 input | data.CSVByColumn [delim] [header]
 ```
 
@@ -528,12 +542,13 @@ COBOL
 
 Converts an object to a JSON document. Input objects may be the result of `json`, `yaml`, `jsonArray`, or `yamlArray` functions, or they could be provided by a `datasource`.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.ToJSON obj
 ```
-```go
+```
 obj | data.ToJSON
 ```
 
@@ -568,12 +583,13 @@ by a [`datasource`](../general/datasource).
 
 The indent string must be provided as an argument.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.ToJSONPretty indent obj
 ```
-```go
+```
 obj | data.ToJSONPretty indent
 ```
 
@@ -606,12 +622,13 @@ Converts an object to a YAML document. Input objects may be the result of
 `data.JSON`, `data.YAML`, `data.JSONArray`, or `data.YAMLArray` functions,
 or they could be provided by a [`datasource`](../general/datasource).
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.ToYAML obj
 ```
-```go
+```
 obj | data.ToYAML
 ```
 
@@ -641,12 +658,13 @@ hello: world
 
 Converts an object to a [TOML](https://github.com/toml-lang/toml) document.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.ToTOML obj
 ```
-```go
+```
 obj | data.ToTOML
 ```
 
@@ -677,12 +695,13 @@ which means that line terminators are `CRLF` (Windows format, or `\r\n`). If
 you require `LF` (UNIX format, or `\n`), the output can be piped through
 [`strings.ReplaceAll`](../strings/#strings-replaceall) to replace `"\r\n"` with `"\n"`.
 
+_Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage
 
-```go
+```
 data.ToCSV [delim] input
 ```
-```go
+```
 input | data.ToCSV [delim]
 ```
 

--- a/docs/content/functions/env.md
+++ b/docs/content/functions/env.md
@@ -26,9 +26,10 @@ The `_FILE` fallback is especially useful for use with [12-factor][]-style
 applications configurable only by environment variables, and especially in
 conjunction with features like [Docker Secrets][].
 
+_Added in gomplate [v0.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v0.2.0)_
 ### Usage
 
-```go
+```
 env.Getenv var [default]
 ```
 
@@ -63,9 +64,10 @@ current environment variables. References to undefined variables are replaced by
 
 Like [`env.Getenv`](#env-getenv), the `_FILE` variant of a variable is used.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 env.ExpandEnv input
 ```
 

--- a/docs/content/functions/file.md
+++ b/docs/content/functions/file.md
@@ -11,12 +11,13 @@ Functions for working with files.
 
 Reports whether a file or directory exists at the given path.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 file.Exists path
 ```
-```go
+```
 path | file.Exists
 ```
 
@@ -45,12 +46,13 @@ yes
 
 Reports whether a given path is a directory.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 file.IsDir path
 ```
-```go
+```
 path | file.IsDir
 ```
 
@@ -82,12 +84,13 @@ yes
 
 Reads a given file _as text_. Note that this will succeed if the given file is binary, but the output may be gibberish.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 file.Read path
 ```
-```go
+```
 path | file.Read
 ```
 
@@ -109,12 +112,13 @@ hello world
 
 Reads a directory and lists the files and directories contained within.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 file.ReadDir path
 ```
-```go
+```
 path | file.ReadDir
 ```
 
@@ -143,12 +147,13 @@ Returns a [`os.FileInfo`](https://golang.org/pkg/os/#FileInfo) describing the na
 
 Essentially a wrapper for Go's [`os.Stat`](https://golang.org/pkg/os/#Stat) function.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 file.Stat path
 ```
-```go
+```
 path | file.Stat
 ```
 
@@ -176,12 +181,13 @@ Walk does not follow symbolic links.
 
 Similar to Go's [`filepath.Walk`](https://golang.org/pkg/path/filepath/#Walk) function.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 file.Walk path
 ```
-```go
+```
 path | file.Walk
 ```
 
@@ -222,12 +228,13 @@ Non-existing directories in the output path will be created.
 
 If the data is a byte array (`[]byte`), it will be written as-is. Otherwise, it will be converted to a string before being written.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 file.Write filename data
 ```
-```go
+```
 data | file.Write filename
 ```
 

--- a/docs/content/functions/filepath.md
+++ b/docs/content/functions/filepath.md
@@ -19,12 +19,13 @@ Returns the last element of path. Trailing path separators are removed before ex
 
 A wrapper for Go's [`filepath.Base`](https://golang.org/pkg/path/filepath/#Base) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Base path
 ```
-```go
+```
 path | filepath.Base
 ```
 
@@ -47,12 +48,13 @@ Clean returns the shortest path name equivalent to path by purely lexical proces
 
 A wrapper for Go's [`filepath.Clean`](https://golang.org/pkg/path/filepath/#Clean) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Clean path
 ```
-```go
+```
 path | filepath.Clean
 ```
 
@@ -75,12 +77,13 @@ Returns all but the last element of path, typically the path's directory.
 
 A wrapper for Go's [`filepath.Dir`](https://golang.org/pkg/path/filepath/#Dir) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Dir path
 ```
-```go
+```
 path | filepath.Dir
 ```
 
@@ -103,12 +106,13 @@ Returns the file name extension used by path.
 
 A wrapper for Go's [`filepath.Ext`](https://golang.org/pkg/path/filepath/#Ext) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Ext path
 ```
-```go
+```
 path | filepath.Ext
 ```
 
@@ -131,12 +135,13 @@ Returns the result of replacing each slash (`/`) character in the path with the 
 
 A wrapper for Go's [`filepath.FromSlash`](https://golang.org/pkg/path/filepath/#FromSlash) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.FromSlash path
 ```
-```go
+```
 path | filepath.FromSlash
 ```
 
@@ -161,12 +166,13 @@ Reports whether the path is absolute.
 
 A wrapper for Go's [`filepath.IsAbs`](https://golang.org/pkg/path/filepath/#IsAbs) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.IsAbs path
 ```
-```go
+```
 path | filepath.IsAbs
 ```
 
@@ -191,9 +197,10 @@ Joins any number of path elements into a single path, adding a separator if nece
 
 A wrapper for Go's [`filepath.Join`](https://golang.org/pkg/path/filepath/#Join) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Join elem...
 ```
 
@@ -218,9 +225,10 @@ Reports whether name matches the shell file name pattern.
 
 A wrapper for Go's [`filepath.Match`](https://golang.org/pkg/path/filepath/#Match) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Match pattern path
 ```
 
@@ -244,9 +252,10 @@ Returns a relative path that is lexically equivalent to targetpath when joined t
 
 A wrapper for Go's [`filepath.Rel`](https://golang.org/pkg/path/filepath/#Rel) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Rel basepath targetpath
 ```
 
@@ -272,12 +281,13 @@ The function returns an array with two values, the first being the diretory, and
 
 A wrapper for Go's [`filepath.Split`](https://golang.org/pkg/path/filepath/#Split) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.Split path
 ```
-```go
+```
 path | filepath.Split
 ```
 
@@ -302,12 +312,13 @@ Returns the result of replacing each separator character in path with a slash (`
 
 A wrapper for Go's [`filepath.ToSlash`](https://golang.org/pkg/path/filepath/#ToSlash) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.ToSlash path
 ```
-```go
+```
 path | filepath.ToSlash
 ```
 
@@ -332,12 +343,13 @@ Returns the leading volume name. Given `C:\foo\bar` it returns `C:` on Windows. 
 
 A wrapper for Go's [`filepath.VolumeName`](https://golang.org/pkg/path/filepath/#VolumeName) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 filepath.VolumeName path
 ```
-```go
+```
 path | filepath.VolumeName
 ```
 

--- a/docs/content/functions/gcp.md
+++ b/docs/content/functions/gcp.md
@@ -25,9 +25,10 @@ Queries GCP [Instance Metadata](https://cloud.google.com/compute/docs/storing-re
 
 For times when running outside GCP, or when the metadata API can't be reached, a `default` value can be provided.
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 gcp.Meta key [default]
 ```
 

--- a/docs/content/functions/math.md
+++ b/docs/content/functions/math.md
@@ -33,9 +33,10 @@ $ gomplate -i '{{ add 2.5 2.5 }}'
 
 Returns the absolute value of a given number. When the input is an integer, the result will be an `int64`, otherwise it will be a `float64`.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.Abs num
 ```
 
@@ -58,9 +59,10 @@ $ gomplate -i '{{ math.Abs -3.5 }} {{ math.Abs 3.5 }} {{ math.Abs -42 }}'
 
 Adds all given operators. When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Add n...
 ```
 
@@ -83,9 +85,10 @@ Returns the least integer value greater than or equal to a given floating-point 
 
 **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.Ceil num
 ```
 
@@ -114,12 +117,13 @@ ceil "-0" = 0
 
 Divide the first number by the second. Division by zero is disallowed. The result will be a `float64`.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Div a b
 ```
-```go
+```
 b | math.Div a
 ```
 
@@ -143,9 +147,10 @@ Returns the greatest integer value less than or equal to a given floating-point 
 
 **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.Floor num
 ```
 
@@ -174,9 +179,10 @@ Returns whether or not the given number can be interpreted as a floating-point l
 
 **Note:** If a decimal point is part of the input number, it will be considered a floating-point number, even if the decimal is `0`.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.IsFloat num
 ```
 
@@ -202,9 +208,10 @@ Inf is a float
 
 Returns whether or not the given number is an integer.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.IsInt num
 ```
 
@@ -227,9 +234,10 @@ $ gomplate -i '{{ range (coll.Slice 1.0 "-1.0" 5.1 42 "3.14" "foo" "0xFF" "NaN" 
 
 Returns whether the given input is a number. Useful for `if` conditions.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.IsNum in
 ```
 
@@ -250,9 +258,10 @@ false true
 
 Returns the largest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Max`](https://golang.org/pkg/math/#Max) are followed.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.Max nums...
 ```
 
@@ -273,9 +282,10 @@ $ gomplate -i '{{ math.Max 0 8.0 4.5 "-1.5e-11" }}'
 
 Returns the smallest number provided. If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned. The same special-cases as Go's [`math.Min`](https://golang.org/pkg/math/#Min) are followed.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.Min nums...
 ```
 
@@ -298,9 +308,10 @@ $ gomplate -i '{{ math.Min 0 8 4.5 "-1.5e-11" }}'
 
 Multiply all given operators together.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Mul n...
 ```
 
@@ -323,9 +334,10 @@ $ gomplate -i '{{ math.Mul 8 8 2 }}'
 
 Calculate an exponent - _b<sup>n</sup>_. This wraps Go's [`math.Pow`](https://golang.org/pkg/math/#Pow). If any values are floating-point numbers, a `float64` is returned, otherwise an `int64` is returned.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Pow b n
 ```
 
@@ -353,12 +365,13 @@ $ gomplate -i '{{ math.Pow 1.5 2 }}'
 
 Return the remainder from an integer division operation.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Rem a b
 ```
-```go
+```
 b | math.Rem a
 ```
 
@@ -384,9 +397,10 @@ Returns the nearest integer, rounding half away from zero.
 
 **Note:** the return value of this function is a `float64` so that the special-cases `NaN` and `Inf` can be returned appropriately.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 math.Round num
 ```
 
@@ -416,9 +430,10 @@ down as well as up, including with negative numbers.
 
 Note that the sequence _may_ not end at `end`, if `end` is not divisible by `step`.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Seq [start] end [step]
 ```
 
@@ -447,12 +462,13 @@ $ gomplate -i '{{ conv.Join (math.Seq 10 -3 2) ", " }}'
 
 Subtract the second from the first of the given operators.  When one of the inputs is a floating-point number, the result will be a `float64`, otherwise it will be an `int64`.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 math.Sub a b
 ```
-```go
+```
 b | math.Sub a
 ```
 

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -20,12 +20,13 @@ calculations.
 Resolve an IPv4 address for a given host name. When multiple IP addresses
 are resolved, the first one is returned.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 net.LookupIP name
 ```
-```go
+```
 name | net.LookupIP
 ```
 
@@ -46,12 +47,13 @@ $ gomplate -i '{{ net.LookupIP "example.com" }}'
 
 Resolve all IPv4 addresses for a given host name. Returns an array of strings.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 net.LookupIPs name
 ```
-```go
+```
 name | net.LookupIPs
 ```
 
@@ -74,12 +76,13 @@ Resolve the canonical name for a given host name. This does a DNS lookup for the
 `CNAME` record type. If no `CNAME` is present, a canonical form of the given name
 is returned -- e.g. `net.LookupCNAME "localhost"` will return `"localhost."`.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 net.LookupCNAME name
 ```
-```go
+```
 name | net.LookupCNAME
 ```
 
@@ -111,12 +114,13 @@ following properties are available:
 - `Port` - _(uint16)_ the service's port
 - `Priority`, `Weight` - see [RFC2782](https://tools.ietf.org/html/rfc2782) for details
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 net.LookupSRV name
 ```
-```go
+```
 name | net.LookupSRV
 ```
 
@@ -153,12 +157,13 @@ returned. For each element, the following properties are available:
 - `Port` - _(uint16)_ the service's port
 - `Priority`, `Weight` - see [RFC2782](https://tools.ietf.org/html/rfc2782) for details
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 net.LookupSRVs name
 ```
-```go
+```
 name | net.LookupSRVs
 ```
 
@@ -189,12 +194,13 @@ Resolve a DNS [`TXT` record](https://en.wikipedia.org/wiki/SRV_record).
 
 This function returns all available TXT records as an array of strings.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 net.LookupTXT name
 ```
-```go
+```
 name | net.LookupTXT
 ```
 
@@ -213,7 +219,8 @@ $ gomplate -i '{{net.LookupTXT "example.com" | data.ToJSONPretty "  " }}'
 ]
 ```
 
-## `net.ParseAddr`
+## `net.ParseAddr`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 Parse the given string as an IP address (a
 [`netip.Addr`](https://pkg.go.dev/net/netip#Addr)).
@@ -223,10 +230,10 @@ Any of `netip.Addr`'s methods may be called on the resulting value. See
 
 ### Usage
 
-```go
+```
 net.ParseAddr addr
 ```
-```go
+```
 addr | net.ParseAddr
 ```
 
@@ -255,12 +262,13 @@ Parse the given string as an IP address (a `netaddr.IP` from the
 Any of `netaddr.IP`'s methods may be called on the resulting value. See
 [the docs](https://pkg.go.dev/inet.af/netaddr) for details.
 
+_Added in gomplate [v3.10.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0)_
 ### Usage
 
-```go
+```
 net.ParseIP ip
 ```
-```go
+```
 ip | net.ParseIP
 ```
 
@@ -280,7 +288,8 @@ $ gomplate -i '{{ $ip := net.ParseIP (net.LookupIP "example.com") -}}
 93.176.0.0/12
 ```
 
-## `net.ParsePrefix`
+## `net.ParsePrefix`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 Parse the given string as an IP address prefix (CIDR) representing an IP
 network (a [`netip.Prefix`](https://pkg.go.dev/net/netip#Prefix)).
@@ -293,10 +302,10 @@ Any of `netip.Prefix`'s methods may be called on the resulting value. See
 
 ### Usage
 
-```go
+```
 net.ParsePrefix prefix
 ```
-```go
+```
 prefix | net.ParsePrefix
 ```
 
@@ -330,12 +339,13 @@ the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
 Any of `netaddr.IPPrefix`'s methods may be called on the resulting value.
 See [the docs][`inet.af/netaddr`] for details.
 
+_Added in gomplate [v3.10.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0)_
 ### Usage
 
-```go
+```
 net.ParseIPPrefix ipprefix
 ```
-```go
+```
 ipprefix | net.ParseIPPrefix
 ```
 
@@ -359,7 +369,8 @@ $ gomplate -i '{{ $net := net.ParseIPPrefix "93.184.0.0/12" -}}
 93.176.0.0-93.191.255.255
 ```
 
-## `net.ParseRange` _(experimental)_
+## `net.ParseRange`_(unreleased)_ _(experimental)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 **Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
 
 [experimental]: ../config/#experimental
@@ -380,10 +391,10 @@ breaking changes to this function.
 
 ### Usage
 
-```go
+```
 net.ParseRange iprange
 ```
-```go
+```
 iprange | net.ParseRange
 ```
 
@@ -414,12 +425,13 @@ The string must contain a hyphen (`-`).
 Any of `netaddr.IPRange`'s methods may be called on the resulting value.
 See [the docs][`inet.af/netaddr`] for details.
 
+_Added in gomplate [v3.10.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0)_
 ### Usage
 
-```go
+```
 net.ParseIPRange iprange
 ```
-```go
+```
 iprange | net.ParseIPRange
 ```
 
@@ -452,12 +464,13 @@ the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
 Any of `netip.Addr`'s methods may be called on the resulting value. See
 [the docs](https://pkg.go.dev/net/netip#Addr) for details.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 net.CIDRHost hostnum prefix
 ```
-```go
+```
 prefix | net.CIDRHost hostnum
 ```
 
@@ -485,12 +498,13 @@ The result is a subnet address formatted in the conventional dotted-decimal IPv4
 Any of `netip.Addr`'s methods may be called on the resulting value. See
 [the docs](https://pkg.go.dev/net/netip#Addr) for details.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 net.CIDRNetmask prefix
 ```
-```go
+```
 prefix | net.CIDRNetmask
 ```
 
@@ -519,12 +533,13 @@ Calculates a subnet address within given IP network address prefix.
 Any of `netip.Prefix`'s methods may be called on the resulting values. See
 [the docs](https://pkg.go.dev/net/netip#Prefix) for details.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 net.CIDRSubnets newbits prefix
 ```
-```go
+```
 prefix | net.CIDRSubnets newbits
 ```
 
@@ -554,12 +569,13 @@ Calculates a sequence of consecutive IP address ranges within a particular CIDR 
 Any of `netip.Prefix`'s methods may be called on the resulting values. See
 [the docs](https://pkg.go.dev/net/netip#Prefix) for details.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 net.CIDRSubnetSizes newbits... prefix
 ```
-```go
+```
 prefix | net.CIDRSubnetSizes newbits...
 ```
 

--- a/docs/content/functions/path.md
+++ b/docs/content/functions/path.md
@@ -19,12 +19,13 @@ Returns the last element of path. Trailing slashes are removed before extracting
 
 A wrapper for Go's [`path.Base`](https://golang.org/pkg/path/#Base) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Base path
 ```
-```go
+```
 path | path.Base
 ```
 
@@ -47,12 +48,13 @@ Clean returns the shortest path name equivalent to path by purely lexical proces
 
 A wrapper for Go's [`path.Clean`](https://golang.org/pkg/path/#Clean) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Clean path
 ```
-```go
+```
 path | path.Clean
 ```
 
@@ -75,12 +77,13 @@ Returns all but the last element of path, typically the path's directory.
 
 A wrapper for Go's [`path.Dir`](https://golang.org/pkg/path/#Dir) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Dir path
 ```
-```go
+```
 path | path.Dir
 ```
 
@@ -103,12 +106,13 @@ Returns the file name extension used by path.
 
 A wrapper for Go's [`path.Ext`](https://golang.org/pkg/path/#Ext) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Ext path
 ```
-```go
+```
 path | path.Ext
 ```
 
@@ -131,12 +135,13 @@ Reports whether the path is absolute.
 
 A wrapper for Go's [`path.IsAbs`](https://golang.org/pkg/path/#IsAbs) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.IsAbs path
 ```
-```go
+```
 path | path.IsAbs
 ```
 
@@ -161,9 +166,10 @@ Joins any number of path elements into a single path, adding a separating slash 
 
 A wrapper for Go's [`path.Join`](https://golang.org/pkg/path/#Join) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Join elem...
 ```
 
@@ -186,9 +192,10 @@ Reports whether name matches the shell file name pattern.
 
 A wrapper for Go's [`path.Match`](https://golang.org/pkg/path/#Match) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Match pattern path
 ```
 
@@ -214,12 +221,13 @@ The function returns an array with two values, the first being the directory, an
 
 A wrapper for Go's [`path.Split`](https://golang.org/pkg/path/#Split) function.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 path.Split path
 ```
-```go
+```
 path | path.Split
 ```
 

--- a/docs/content/functions/random.md
+++ b/docs/content/functions/random.md
@@ -20,9 +20,10 @@ Generates a random string of a desired length, containing the set of
 printable characters from the 7-bit [ASCII](https://en.wikipedia.org/wiki/ASCII)
 set. This includes _space_ (' '), but no other whitespace characters.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.ASCII count
 ```
 
@@ -43,9 +44,10 @@ _woJ%D&K
 
 Generates a random alphabetical (`A-Z`, `a-z`) string of a desired length.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.Alpha count
 ```
 
@@ -66,9 +68,10 @@ oAqHKxHiytYicMxTMGHnUnAfltPVZDhFkVkgDvatJK
 
 Generates a random alphanumeric (`0-9`, `A-Z`, `a-z`) string of a desired length.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.AlphaNum count
 ```
 
@@ -104,9 +107,10 @@ smaller set of possible characters than intended, so check
 the [Unicode character code charts](http://www.unicode.org/charts/) to
 verify the correct code-points.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.String count [regex] [lower] [upper]
 ```
 
@@ -150,12 +154,13 @@ Poker time! 🂼🂺🂳🃅🂪
 
 Pick an element at a random from a given slice or array.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.Item items
 ```
-```go
+```
 items | random.Item
 ```
 
@@ -186,9 +191,10 @@ Note that the difference between `min` and `max` can not be larger than a
 63-bit integer (i.e. the unsigned portion of a 64-bit signed integer).
 The result is given as an `int64`.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.Number [min] [max]
 ```
 
@@ -222,9 +228,10 @@ can be overridden.
 
 The result is given as a `float64`.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 random.Float [min] [max]
 ```
 

--- a/docs/content/functions/regexp.md
+++ b/docs/content/functions/regexp.md
@@ -18,12 +18,13 @@ of the regular expression `expression`.
 This function provides the same behaviour as Go's
 [`regexp.FindString`](https://golang.org/pkg/regexp/#Regexp.FindString) function.
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 regexp.Find expression input
 ```
-```go
+```
 input | regexp.Find expression
 ```
 
@@ -56,12 +57,13 @@ to be returned.
 This function provides the same behaviour as Go's
 [`regexp.FindAllString`](https://golang.org/pkg/regexp/#Regexp.FindAllString) function.
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 regexp.FindAll expression [n] input
 ```
-```go
+```
 input | regexp.FindAll expression [n]
 ```
 
@@ -90,12 +92,13 @@ Returns `true` if a given regular expression matches a given input.
 
 This returns a boolean which can be used in an `if` condition, for example.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 regexp.Match expression input
 ```
-```go
+```
 input | regexp.Match expression
 ```
 
@@ -120,12 +123,13 @@ Escapes all regular expression metacharacters in the input. The returned string 
 This function provides the same behaviour as Go's
 [`regexp.QuoteMeta`](https://golang.org/pkg/regexp/#Regexp.QuoteMeta) function.
 
+_Added in gomplate [v3.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.7.0)_
 ### Usage
 
-```go
+```
 regexp.QuoteMeta input
 ```
-```go
+```
 input | regexp.QuoteMeta
 ```
 
@@ -151,12 +155,13 @@ The replacement is substituted after expanding variables beginning with `$`.
 This function provides the same behaviour as Go's
 [`regexp.ReplaceAllString`](https://golang.org/pkg/regexp/#Regexp.ReplaceAllString) function.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 regexp.Replace expression replacement input
 ```
-```go
+```
 input | regexp.Replace expression replacement
 ```
 
@@ -189,12 +194,13 @@ beginning with `$`.
 This function provides the same behaviour as Go's
 [`regexp.ReplaceAllLiteralString`](https://golang.org/pkg/regexp/#Regexp.ReplaceAllLiteralString) function.
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 regexp.ReplaceLiteral expression replacement input
 ```
-```go
+```
 input | regexp.ReplaceLiteral expression replacement
 ```
 
@@ -231,12 +237,13 @@ except that regular expressions are supported.
 This function provides the same behaviour as Go's
 [`regexp.Split`](https://golang.org/pkg/regexp/#Regexp.Split) function.
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 regexp.Split expression [n] input
 ```
-```go
+```
 input | regexp.Split expression [n]
 ```
 

--- a/docs/content/functions/sockaddr.md
+++ b/docs/content/functions/sockaddr.md
@@ -20,10 +20,15 @@ the specific attributes you're interested in.
 
 To demonstrate how this can be used, here's an example that lists all of the IPv4 addresses available on the system:
 
-```console
-$ gomplate -i '{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ipv4") -}}
+_in.tmpl:_
+```
+{{ range (sockaddr.GetAllInterfaces | sockaddr.Include "type" "ipv4") -}}
 {{ . | sockaddr.Attr "address" }}
-{{end}}'
+{{end}}
+```
+
+```console
+$ gomplate -f in.tmpl
 127.0.0.1
 10.0.0.8
 132.79.79.79
@@ -40,9 +45,10 @@ the result as an array of `IfAddr`.
 
 Should be piped through a further function to refine and extract attributes.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetAllInterfaces
 ```
 
@@ -53,9 +59,10 @@ Returns `IfAddrs` of the addresses attached to the default route.
 
 Should be piped through a further function to refine and extract attributes.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetDefaultInterfaces
 ```
 
@@ -73,9 +80,10 @@ address also excludes non-forwardable IP addresses (as defined by the IETF).
 
 Should be piped through a further function to refine and extract attributes.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetPrivateInterfaces
 ```
 
@@ -87,9 +95,10 @@ are attached to the default route, and are forwardable.
 
 Should be piped through a further function to refine and extract attributes.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetPublicInterfaces
 ```
 
@@ -119,12 +128,13 @@ to make explicit that the sort is ascending.
 `IfAddr`s that are not comparable will be at the end of the list and in a
 non-deterministic order.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Sort selector <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Sort selector
 ```
 
@@ -169,12 +179,13 @@ These flags are supported by the `flag` selector:
 `link-local multicast`, `link-local unicast`, `loopback`, `multicast`, `point-to-point`,
 `unspecified`, `up`
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Exclude selector value <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Exclude selector value
 ```
 
@@ -200,12 +211,13 @@ selector's value.
 
 This is the inverse of `sockaddr.Exclude`. See [`sockaddr.Exclude`](#sockaddr.Exclude) for details.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Include selector value <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Include selector value
 ```
 
@@ -221,12 +233,13 @@ sockaddr.Include selector value <array-of-IfAddrs>
 
 Returns the named attribute as a string.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Attr selector <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Attr selector
 ```
 
@@ -249,12 +262,13 @@ lo0 en0
 Selects the given attribute from each `IfAddr` in the source array, and joins
 the results with the given separator.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Join selector separator <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Join selector separator
 ```
 
@@ -277,12 +291,13 @@ lo0,lo0,lo0,en0,en0
 
 Returns a slice of `IfAddr`s based on the specified limit.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Limit limit <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Limit limit
 ```
 
@@ -304,12 +319,13 @@ lo0|lo0
 
 Returns a slice of `IfAddr`s based on the specified offset.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Offset offset <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Offset offset
 ```
 
@@ -332,12 +348,13 @@ $ gomplate -i '{{ sockaddr.GetAllInterfaces | sockaddr.Limit 2 | sockaddr.Offset
 Creates a unique array of `IfAddr`s based on the matching selector. Assumes the input has
 already been sorted.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Unique selector <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Unique selector
 ```
 
@@ -362,12 +379,13 @@ Applies a math operation to each `IfAddr` in the input. Any failure will result 
 See [the source code](https://github.com/hashicorp/go-sockaddr/blob/master/ifaddrs.go#L725)
 for details.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.Math selector operation <array-of-IfAddrs>
 ```
-```go
+```
 <array-of-IfAddrs> | sockaddr.Math selector operation
 ```
 
@@ -392,9 +410,10 @@ Returns a string with a single IP address that is part of [RFC 6890][] and has a
 default route. If the system can't determine its IP address or find an [RFC 6890][]
 IP address, an empty string will be returned instead.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetPrivateIP
 ```
 
@@ -413,9 +432,10 @@ Returns a space-separated string with all IP addresses that are part of [RFC 689
 If the system can't find any [RFC 6890][] IP addresses, an empty string will be
 returned instead.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetPrivateIPs
 ```
 
@@ -433,9 +453,10 @@ Returns a string with a single IP address that is NOT part of [RFC 6890][] and
 has a default route. If the system can't determine its IP address or find a
 non-[RFC 6890][] IP address, an empty string will be returned instead.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetPublicIP
 ```
 
@@ -454,9 +475,10 @@ Returns a space-separated string with all IP addresses that are NOT part of
 `GetPublicIP`). If the system can't find any non-[RFC 6890][] IP addresses, an
 empty string will be returned instead.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetPublicIPs
 ```
 
@@ -473,9 +495,10 @@ $ gomplate -i '{{ sockaddr.GetPublicIPs }}'
 Returns a string with a single IP address sorted by the size of the network
 (i.e. IP addresses with a smaller netmask, larger network size, are sorted first).
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetInterfaceIP name
 ```
 
@@ -498,9 +521,10 @@ Returns a string with all IPs, sorted by the size of the network (i.e. IP
 addresses with a smaller netmask, larger network size, are sorted first), on a
 named interface.
 
+_Added in gomplate [v2.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.4.0)_
 ### Usage
 
-```go
+```
 sockaddr.GetInterfaceIPs name
 ```
 

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -12,12 +12,13 @@ Abbreviates a string using `...` (ellipses). Takes an optional offset from the b
 
 _Also see [`strings.Trunc`](#strings-trunc)._
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 strings.Abbrev [offset] width input
 ```
-```go
+```
 input | strings.Abbrev [offset] width
 ```
 
@@ -42,12 +43,13 @@ $ gomplate -i '{{ "foobarbazquxquux" | strings.Abbrev 6 9 }}'
 
 Reports whether a substring is contained within a string.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.Contains substr input
 ```
-```go
+```
 input | strings.Contains substr
 ```
 
@@ -76,12 +78,13 @@ no
 
 Tests whether a string begins with a certain prefix.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.HasPrefix prefix input
 ```
-```go
+```
 input | strings.HasPrefix prefix
 ```
 
@@ -105,12 +108,13 @@ foo
 
 Tests whether a string ends with a certain suffix.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.HasSuffix suffix input
 ```
-```go
+```
 input | strings.HasSuffix suffix
 ```
 
@@ -139,12 +143,13 @@ http://example.com:80
 
 Indents a string. If the input string has multiple lines, each line will be indented.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.Indent [width] [indent] input
 ```
-```go
+```
 input | strings.Indent [width] [indent]
 ```
 
@@ -185,12 +190,13 @@ foo:
 
 Returns an alphanumerically-sorted copy of a given string list.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 strings.Sort list
 ```
-```go
+```
 list | strings.Sort
 ```
 
@@ -207,7 +213,8 @@ $ gomplate -i '{{ (coll.Slice "foo" "bar" "baz") | strings.Sort }}'
 [bar baz foo]
 ```
 
-## `strings.SkipLines`
+## `strings.SkipLines`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
 Skips the given number of lines (each ending in a `\n`), returning the
 remainder.
@@ -217,10 +224,10 @@ returned.
 
 ### Usage
 
-```go
+```
 strings.SkipLines skip in
 ```
-```go
+```
 in | strings.SkipLines skip
 ```
 
@@ -261,12 +268,13 @@ of `-1`.
 
 Note that the delimiter is not included in the resulting elements.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.Split separator input
 ```
-```go
+```
 input | strings.Split separator
 ```
 
@@ -311,12 +319,13 @@ The `count` determines the number of substrings to return:
 
 See [`strings.Split`](#strings-split) for more details.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.SplitN separator count input
 ```
-```go
+```
 input | strings.SplitN separator count
 ```
 
@@ -351,12 +360,13 @@ This is a convenience function which is equivalent to:
 {{ print "%q" "input string" }}
 ```
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 strings.Quote in
 ```
-```go
+```
 in | strings.Quote
 ```
 
@@ -383,12 +393,13 @@ It errors if `count` is negative or if the length of `input` multiplied by `coun
 
 This wraps Go's [`strings.Repeat`](https://golang.org/pkg/strings/#Repeat).
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 strings.Repeat count input
 ```
-```go
+```
 input | strings.Repeat count
 ```
 
@@ -412,12 +423,13 @@ hello hello hello hello hello
 
 Replaces all occurrences of a given string with another.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.ReplaceAll old new input
 ```
-```go
+```
 input | strings.ReplaceAll old new
 ```
 
@@ -442,12 +454,13 @@ $ gomplate -i '{{ "172.21.1.42" | strings.ReplaceAll "." "-" }}'
 
 Creates a a "slug" from a given string - supports Unicode correctly. This wraps the [github.com/gosimple/slug](https://github.com/gosimple/slug) package. See [the github.com/gosimple/slug docs](https://godoc.org/github.com/gosimple/slug) for more information.
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 strings.Slug input
 ```
-```go
+```
 input | strings.Slug
 ```
 
@@ -476,12 +489,13 @@ Given a string, emits a version of that string that will evaluate to its literal
 
 Given an array or slice, emit a single string which will evaluate to a series of shell words, one per item in that array or slice.
 
+_Added in gomplate [v3.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.6.0)_
 ### Usage
 
-```go
+```
 strings.ShellQuote in
 ```
-```go
+```
 in | strings.ShellQuote
 ```
 
@@ -510,12 +524,13 @@ Surrounds an input string with a single-quote (apostrophe) character (`'`). If t
 
 `'` characters in the input are first escaped in the YAML-style (by repetition: `''`).
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 strings.Squote in
 ```
-```go
+```
 in | strings.Squote
 ```
 
@@ -542,12 +557,13 @@ $ gomplate -i "{{ strings.Squote \"it's a banana\" }}"
 
 Convert to title-case.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.Title input
 ```
-```go
+```
 input | strings.Title
 ```
 
@@ -570,12 +586,13 @@ Hello, World!
 
 Convert to lower-case.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.ToLower input
 ```
-```go
+```
 input | strings.ToLower
 ```
 
@@ -598,12 +615,13 @@ hello, world!
 
 Convert to upper-case.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.ToUpper input
 ```
-```go
+```
 input | strings.ToUpper
 ```
 
@@ -625,12 +643,13 @@ HELLO, WORLD!
 Trims a string by removing the given characters from the beginning and end of
 the string.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.Trim cutset input
 ```
-```go
+```
 input | strings.Trim cutset
 ```
 
@@ -654,12 +673,13 @@ Returns a string without the provided leading prefix string, if the prefix is pr
 
 This wraps Go's [`strings.TrimPrefix`](https://golang.org/pkg/strings/#TrimPrefix).
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 strings.TrimPrefix prefix input
 ```
-```go
+```
 input | strings.TrimPrefix prefix
 ```
 
@@ -684,12 +704,13 @@ world
 Trims a string by removing whitespace from the beginning and end of
 the string.
 
+_Added in gomplate [v1.9.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.9.0)_
 ### Usage
 
-```go
+```
 strings.TrimSpace input
 ```
-```go
+```
 input | strings.TrimSpace
 ```
 
@@ -712,12 +733,13 @@ Returns a string without the provided trailing suffix string, if the suffix is p
 
 This wraps Go's [`strings.TrimSuffix`](https://golang.org/pkg/strings/#TrimSuffix).
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 strings.TrimSuffix suffix input
 ```
-```go
+```
 input | strings.TrimSuffix suffix
 ```
 
@@ -741,12 +763,13 @@ Returns a string truncated to the given length.
 
 _Also see [`strings.Abbrev`](#strings-abbrev)._
 
+_Added in gomplate [v2.6.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.6.0)_
 ### Usage
 
-```go
+```
 strings.Trunc length input
 ```
-```go
+```
 input | strings.Trunc length
 ```
 
@@ -772,12 +795,13 @@ All non-alphanumeric characters are stripped, and the beginnings of words are up
 
 See [CamelCase on Wikipedia](https://en.wikipedia.org/wiki/Camel_case) for more details.
 
+_Added in gomplate [v3.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.3.0)_
 ### Usage
 
-```go
+```
 strings.CamelCase in
 ```
-```go
+```
 in | strings.CamelCase
 ```
 
@@ -806,12 +830,13 @@ All non-alphanumeric characters are stripped, and spaces are replaced with an un
 
 See [Snake Case on Wikipedia](https://en.wikipedia.org/wiki/Snake_case) for more details.
 
+_Added in gomplate [v3.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.3.0)_
 ### Usage
 
-```go
+```
 strings.SnakeCase in
 ```
-```go
+```
 in | strings.SnakeCase
 ```
 
@@ -840,12 +865,13 @@ All non-alphanumeric characters are stripped, and spaces are replaced with a hyp
 
 See [Kebab Case on Wikipedia](https://en.wikipedia.org/wiki/Kebab_case) for more details.
 
+_Added in gomplate [v3.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.3.0)_
 ### Usage
 
-```go
+```
 strings.KebabCase in
 ```
-```go
+```
 in | strings.KebabCase
 ```
 
@@ -876,12 +902,13 @@ When words that are longer than the desired width are encountered (e.g. long URL
 
 The line-break sequence defaults to `\n` (i.e. the LF/Line Feed character), regardless of OS.
 
+_Added in gomplate [v3.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.3.0)_
 ### Usage
 
-```go
+```
 strings.WordWrap [width] [lbseq] in
 ```
-```go
+```
 in | strings.WordWrap [width] [lbseq]
 ```
 
@@ -922,12 +949,13 @@ concatenated.
 This wraps Go's [`utf8.RuneCountInString`](https://golang.org/pkg/unicode/utf8/#RuneCountInString)
 function.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 strings.RuneCount input
 ```
-```go
+```
 input | strings.RuneCount
 ```
 
@@ -954,9 +982,10 @@ $ gomplate -i '{{ range (coll.Slice "\u03a9" "\u0030" "\u1430") }}{{ printf "%s 
 Contains reports whether the second string is contained within the first. Equivalent to
 [strings.Contains](https://golang.org/pkg/strings#Contains)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 contains input substring
 ```
 
@@ -989,9 +1018,10 @@ no
 Tests whether the string begins with a certain substring. Equivalent to
 [strings.HasPrefix](https://golang.org/pkg/strings#HasPrefix)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 hasPrefix input prefix
 ```
 
@@ -1024,9 +1054,10 @@ foo
 Tests whether the string ends with a certain substring. Equivalent to
 [strings.HasSuffix](https://golang.org/pkg/strings#HasSuffix)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 hasSuffix input suffix
 ```
 
@@ -1057,9 +1088,10 @@ http://example.com:80
 Creates a slice by splitting a string on a given delimiter. Equivalent to
 [strings.Split](https://golang.org/pkg/strings#Split)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 split input separator
 ```
 
@@ -1088,9 +1120,10 @@ Hello, Maggie
 Creates a slice by splitting a string on a given delimiter. The count determines
 the number of substrings to return. Equivalent to [strings.SplitN](https://golang.org/pkg/strings#SplitN)
 
+_Added in gomplate [v1.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.7.0)_
 ### Usage
 
-```go
+```
 splitN input separator count
 ```
 
@@ -1119,9 +1152,10 @@ bar:baz
 Trims a string by removing the given characters from the beginning and end of
 the string. Equivalent to [strings.Trim](https://golang.org/pkg/strings/#Trim)
 
+_Added in gomplate [v1.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v1.4.0)_
 ### Usage
 
-```go
+```
 trim input cutset
 ```
 

--- a/docs/content/functions/test.md
+++ b/docs/content/functions/test.md
@@ -15,12 +15,13 @@ assumptions and can cause template generation to fail in specific cases.
 Asserts that the given expression or value is `true`. If it is not, causes
 template generation to fail immediately with an optional message.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 test.Assert [message] value
 ```
-```go
+```
 value | test.Assert [message]
 ```
 
@@ -46,12 +47,13 @@ template: <arg>:1:3: executing "<arg>" at <assert "something ho...>: error calli
 
 Cause template generation to fail immediately, with an optional message.
 
+_Added in gomplate [v2.7.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.7.0)_
 ### Usage
 
-```go
+```
 test.Fail [message]
 ```
-```go
+```
 message | test.Fail
 ```
 
@@ -94,12 +96,13 @@ This is useful when the specific numeric type is unknown.
 
 See also [`test.Kind`](test-kind).
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 test.IsKind kind value
 ```
-```go
+```
 value | test.IsKind kind
 ```
 
@@ -145,12 +148,13 @@ If you need to know the precise type of a value, use `printf "%T" $value`.
 
 See also [`test.IsKind`](test-iskind).
 
+_Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
 ### Usage
 
-```go
+```
 test.Kind value
 ```
-```go
+```
 value | test.Kind
 ```
 
@@ -187,12 +191,13 @@ but has slightly different behaviour. Notably, gomplate will always fail in
 cases where a referenced _key_ is missing, and this function will have no
 effect.
 
+_Added in gomplate [v3.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.0.0)_
 ### Usage
 
-```go
+```
 test.Required [message] value
 ```
-```go
+```
 value | test.Required [message]
 ```
 
@@ -238,12 +243,13 @@ This is effectively a short-form of the following template:
 
 Keep in mind that using an explicit `if`/`else` block is often easier to understand than ternary expressions!
 
+_Added in gomplate [v3.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.1.0)_
 ### Usage
 
-```go
+```
 test.Ternary truevalue falsevalue condition
 ```
-```go
+```
 condition | test.Ternary truevalue falsevalue
 ```
 

--- a/docs/content/functions/time.md
+++ b/docs/content/functions/time.md
@@ -80,9 +80,10 @@ Returns the current local time, as a `time.Time`. This wraps [`time.Now`](https:
 
 Usually, further functions are called using the value returned by `Now`.
 
+_Added in gomplate [v2.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.1.0)_
 ### Usage
 
-```go
+```
 time.Now
 ```
 
@@ -125,12 +126,13 @@ other functions.
 
 _Note: In the absence of a time zone indicator, `time.Parse` returns a time in UTC._
 
+_Added in gomplate [v2.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.1.0)_
 ### Usage
 
-```go
+```
 time.Parse layout timestamp
 ```
-```go
+```
 timestamp | time.Parse layout
 ```
 
@@ -157,12 +159,13 @@ A duration string is a possibly signed sequence of decimal numbers, each with
 optional fraction and a unit suffix, such as `300ms`, `-1.5h` or `2h45m`. Valid
 time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 
+_Added in gomplate [v2.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.1.0)_
 ### Usage
 
-```go
+```
 time.ParseDuration duration
 ```
-```go
+```
 duration | time.ParseDuration
 ```
 
@@ -186,12 +189,13 @@ $ gomplate -i '{{ (time.Now).Format time.Kitchen }}
 Same as [`time.Parse`](#time-parse), except that in the absence of a time zone
 indicator, the timestamp wil be parsed in the local timezone.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 time.ParseLocal layout timestamp
 ```
-```go
+```
 timestamp | time.ParseLocal layout
 ```
 
@@ -216,12 +220,13 @@ Same as [`time.Parse`](#time-parse), except that the time is parsed in the given
 
 This wraps [`time.ParseInLocation`](https://golang.org/pkg/time/#ParseInLocation).
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 time.ParseInLocation layout location timestamp
 ```
-```go
+```
 timestamp | time.ParseInLocation layout location
 ```
 
@@ -247,12 +252,13 @@ Returns the time elapsed since a given time. This wraps [`time.Since`](https://g
 
 It is shorthand for `time.Now.Sub t`.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 time.Since t
 ```
-```go
+```
 t | time.Since
 ```
 
@@ -275,12 +281,13 @@ Returns the local `Time` corresponding to the given Unix time, in seconds since
 January 1, 1970 UTC. Note that fractional seconds can be used to denote
 milliseconds, but must be specified as a string, not a floating point number.
 
+_Added in gomplate [v2.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.1.0)_
 ### Usage
 
-```go
+```
 time.Unix time
 ```
-```go
+```
 time | time.Unix
 ```
 
@@ -310,12 +317,13 @@ Returns the duration until a given time. This wraps [`time.Until`](https://golan
 
 It is shorthand for `$t.Sub time.Now`.
 
+_Added in gomplate [v2.5.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.5.0)_
 ### Usage
 
-```go
+```
 time.Until t
 ```
-```go
+```
 t | time.Until
 ```
 
@@ -342,9 +350,10 @@ only 14923h0m0s to go...
 
 Return the local system's time zone's name.
 
+_Added in gomplate [v2.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.1.0)_
 ### Usage
 
-```go
+```
 time.ZoneName
 ```
 
@@ -360,9 +369,10 @@ EDT
 
 Return the local system's time zone offset, in seconds east of UTC.
 
+_Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
 
-```go
+```
 time.ZoneOffset
 ```
 

--- a/docs/content/functions/tmpl.md
+++ b/docs/content/functions/tmpl.md
@@ -13,12 +13,13 @@ Execute (render) the named template. This is equivalent to using the [`template`
 
 This allows for post-processing of templates.
 
+_Added in gomplate [v3.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.3.0)_
 ### Usage
 
-```go
+```
 tmpl.Exec name [context]
 ```
-```go
+```
 context | tmpl.Exec name
 ```
 
@@ -50,9 +51,10 @@ If the template is given a name (see `name` argument below), it can be re-used l
 
 A context can be provided, otherwise the default gomplate context will be used.
 
+_Added in gomplate [v3.3.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.3.0)_
 ### Usage
 
-```go
+```
 tmpl.Inline [name] in [context]
 ```
 
@@ -89,9 +91,10 @@ inline templates, this will be an empty string.
 Note that if this function is called from a nested template, the path
 of the main template will be returned instead.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 tmpl.Path
 ```
 
@@ -116,9 +119,10 @@ be an empty string.
 Note that if this function is called from a nested template, the path
 of the main template will be used instead.
 
+_Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.11.0)_
 ### Usage
 
-```go
+```
 tmpl.PathDir
 ```
 

--- a/docs/content/functions/uuid.md
+++ b/docs/content/functions/uuid.md
@@ -23,9 +23,10 @@ Create a version 1 UUID (based on the current MAC address and the current date/t
 
 Use [`uuid.V4`](#uuid-v4) instead in most cases.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 uuid.V1
 ```
 
@@ -43,9 +44,10 @@ Create a version 4 UUID (randomly generated).
 
 This function consumes entropy.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 uuid.V4
 ```
 
@@ -62,9 +64,10 @@ $ gomplate -i '{{ uuid.V4 }}'
 Returns the _nil_ UUID, that is, `00000000-0000-0000-0000-000000000000`,
 mostly for testing scenarios.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 uuid.Nil
 ```
 
@@ -81,12 +84,13 @@ $ gomplate -i '{{ uuid.Nil }}'
 Checks that the given UUID is in the correct format. It does not validate
 whether the version or variant are correct.
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 uuid.IsValid uuid
 ```
-```go
+```
 uuid | uuid.IsValid
 ```
 
@@ -118,12 +122,13 @@ Both the standard UUID forms of `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` and
 Microsoft encoding `{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}` and the raw hex
 encoding (`xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`).
 
+_Added in gomplate [v3.4.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.4.0)_
 ### Usage
 
-```go
+```
 uuid.Parse uuid
 ```
-```go
+```
 uuid | uuid.Parse
 ```
 


### PR DESCRIPTION
Fixes #1839

Instead of generating two separate doc sites, this adds a label to each function to indicate the version of gomplate it was released in. That way I can still document unreleased functions, but it'll be more clear that they're not available in released builds yet.

(I didn't want to generate multiple doc sites because the docs overhaul I did in #1729 is only in `main`, and so I'd have had to backport that to the 3.11.x branch, which is likely more trouble than it's worth)