### PR TITLE
docs: format user template in hello example

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -13,7 +13,7 @@ The template is read from standard in, and written to standard out.
 Use it like this:
 
 ```console
-$ echo "Hello, {{.Env.USER}}" | gomplate
+$ echo "Hello, {{ .Env.USER }}" | gomplate
 Hello, hairyhenderson
 ```
 


### PR DESCRIPTION
Correctly formats the example and makes it equal to the other one: https://github.com/hairyhenderson/gomplate/blob/d4d0df967d5ced07acde0c1e239da413b661f7bb/docs/content/_index.md#L24