### PR TITLE
Fix the wdFS behaviour due to Go 1.21.4's changes to IsAbs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,18 +42,20 @@ jobs:
   windows-build:
     runs-on: windows-latest
     env:
-      TMP: D:\a\tmp
+      # note: the tmp dir is set to C: so that it's not on the same drive as the
+      # repo, which is on D: - this will expose bugs with path handling!
+      TMP: C:\tmp
     steps:
       - run: pwd
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.21'
-      - run: |
-          git config --global user.email "bogus@example.com"
-          git config --global user.name "Someone"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.4'
+      - run: |
+          git config --global user.email "bogus@example.com"
+          git config --global user.name "Someone"
       - run: make build
       - name: Save binary
         uses: actions/upload-artifact@v3

--- a/data/datasource_git.go
+++ b/data/datasource_git.go
@@ -241,7 +241,7 @@ func (g gitsource) clone(ctx context.Context, repoURL *url.URL, depth int) (bill
 		return g.clone(ctx, u, depth)
 	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("git clone for %v failed: %w", repoURL, err)
+		return nil, nil, fmt.Errorf("git clone %s: %w", u, err)
 	}
 	return fs, repo, nil
 }

--- a/internal/tests/integration/datasources_git_test.go
+++ b/internal/tests/integration/datasources_git_test.go
@@ -33,8 +33,8 @@ func setupDatasourcesGitTest(t *testing.T) *fs.Dir {
 
 	repoPath := tmpDir.Join("repo")
 
-	icmd.RunCommand("git", "init", repoPath).
-		Assert(t, icmd.Expected{Out: "Initialized empty Git repository"})
+	icmd.RunCmd(icmd.Command("git", "init", repoPath), icmd.Dir(repoPath)).
+		Assert(t, icmd.Expected{Out: "Initialized empty Git repository in "})
 	icmd.RunCmd(icmd.Command("git", "add", "config.json"), icmd.Dir(repoPath)).Assert(t, icmd.Expected{})
 	icmd.RunCmd(icmd.Command("git", "add", "jsonfile"), icmd.Dir(repoPath)).Assert(t, icmd.Expected{})
 	icmd.RunCmd(icmd.Command("git", "add", "subdir"), icmd.Dir(repoPath)).Assert(t, icmd.Expected{})

--- a/template.go
+++ b/template.go
@@ -90,7 +90,12 @@ func parseNestedTemplates(ctx context.Context, nested config.Templates, tmpl *te
 		}
 
 		// TODO: maybe need to do something with root here?
-		if _, reldir := datafs.ResolveLocalPath(u.Path); reldir != "" && reldir != "." {
+		_, reldir, err := datafs.ResolveLocalPath(u.Path)
+		if err != nil {
+			return fmt.Errorf("resolveLocalPath: %w", err)
+		}
+
+		if reldir != "" && reldir != "." {
 			fsys, err = fs.Sub(fsys, reldir)
 			if err != nil {
 				return fmt.Errorf("sub filesystem for %q unavailable: %w", &u, err)
@@ -220,7 +225,10 @@ func walkDir(ctx context.Context, cfg *config.Config, dir string, outFileNamer f
 
 	// we need dir to be relative to the root of fsys
 	// TODO: maybe need to do something with root here?
-	_, reldir := datafs.ResolveLocalPath(dir)
+	_, reldir, err := datafs.ResolveLocalPath(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolveLocalPath: %w", err)
+	}
 
 	subfsys, err := fs.Sub(fsys, reldir)
 	if err != nil {


### PR DESCRIPTION
Handling of relatively obscure forms of Windows file paths was broken by the security fixes in Go 1.21.4. This PR fixes the logic to be more in-line with how Windows itself categorizes and parses paths.

There's probably an opportunity for more refactoring, but this'll do for now.

This also updates the CI to expose bugs when dealing with non-current volumes on Windows.