### PR TITLE
test: use `t.Setenv` to set env vars in tests

### DIFF
--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -133,64 +133,64 @@ func TestNewEc2Info(t *testing.T) {
 }
 
 func TestGetRegion(t *testing.T) {
-	oldReg, ok := os.LookupEnv("AWS_REGION")
-	if ok {
-		defer os.Setenv("AWS_REGION", oldReg)
-	}
-	oldDefReg, ok := os.LookupEnv("AWS_DEFAULT_REGION")
-	if ok {
-		defer os.Setenv("AWS_REGION", oldDefReg)
-	}
+	t.Run("with AWS_REGION set", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "kalamazoo")
+		os.Unsetenv("AWS_DEFAULT_REGION")
+		region, err := getRegion()
+		require.NoError(t, err)
+		assert.Empty(t, region)
+	})
 
-	os.Setenv("AWS_REGION", "kalamazoo")
-	os.Unsetenv("AWS_DEFAULT_REGION")
-	region, err := getRegion()
-	require.NoError(t, err)
-	assert.Empty(t, region)
+	t.Run("with AWS_DEFAULT_REGION set", func(t *testing.T) {
+		t.Setenv("AWS_DEFAULT_REGION", "kalamazoo")
+		os.Unsetenv("AWS_REGION")
+		region, err := getRegion()
+		require.NoError(t, err)
+		assert.Empty(t, region)
+	})
 
-	os.Setenv("AWS_DEFAULT_REGION", "kalamazoo")
-	os.Unsetenv("AWS_REGION")
-	region, err = getRegion()
-	require.NoError(t, err)
-	assert.Empty(t, region)
+	t.Run("with no AWS_REGION, AWS_DEFAULT_REGION set", func(t *testing.T) {
+		os.Unsetenv("AWS_REGION")
+		os.Unsetenv("AWS_DEFAULT_REGION")
+		metaClient := NewDummyEc2Meta()
+		region, err := getRegion(metaClient)
+		require.NoError(t, err)
+		assert.Equal(t, "unknown", region)
+	})
 
-	os.Unsetenv("AWS_DEFAULT_REGION")
-	metaClient := NewDummyEc2Meta()
-	region, err = getRegion(metaClient)
-	require.NoError(t, err)
-	assert.Equal(t, "unknown", region)
-
-	ec2meta := MockEC2Meta(nil, nil, "us-east-1")
-
-	region, err = getRegion(ec2meta)
-	require.NoError(t, err)
-	assert.Equal(t, "us-east-1", region)
+	t.Run("infer from EC2 metadata", func(t *testing.T) {
+		ec2meta := MockEC2Meta(nil, nil, "us-east-1")
+		region, err := getRegion(ec2meta)
+		require.NoError(t, err)
+		assert.Equal(t, "us-east-1", region)
+	})
 }
 
 func TestGetClientOptions(t *testing.T) {
-	oldVar, ok := os.LookupEnv("AWS_TIMEOUT")
-	if ok {
-		defer os.Setenv("AWS_TIMEOUT", oldVar)
-	}
-
 	co := GetClientOptions()
 	assert.Equal(t, ClientOptions{Timeout: 500 * time.Millisecond}, co)
 
-	os.Setenv("AWS_TIMEOUT", "42")
-	// reset the Once
-	coInit = sync.Once{}
-	co = GetClientOptions()
-	assert.Equal(t, ClientOptions{Timeout: 42 * time.Millisecond}, co)
+	t.Run("valid AWS_TIMEOUT, first call", func(t *testing.T) {
+		t.Setenv("AWS_TIMEOUT", "42")
+		// reset the Once
+		coInit = sync.Once{}
+		co = GetClientOptions()
+		assert.Equal(t, ClientOptions{Timeout: 42 * time.Millisecond}, co)
+	})
 
-	os.Setenv("AWS_TIMEOUT", "123")
-	// without resetting the Once, expect to be reused
-	co = GetClientOptions()
-	assert.Equal(t, ClientOptions{Timeout: 42 * time.Millisecond}, co)
+	t.Run("valid AWS_TIMEOUT, non-first call ", func(t *testing.T) {
+		t.Setenv("AWS_TIMEOUT", "123")
+		// without resetting the Once, expect to be reused
+		co = GetClientOptions()
+		assert.Equal(t, ClientOptions{Timeout: 42 * time.Millisecond}, co)
+	})
 
-	os.Setenv("AWS_TIMEOUT", "foo")
-	// reset the Once
-	coInit = sync.Once{}
-	assert.Panics(t, func() {
-		GetClientOptions()
+	t.Run("invalid AWS_TIMEOUT", func(t *testing.T) {
+		t.Setenv("AWS_TIMEOUT", "foo")
+		// reset the Once
+		coInit = sync.Once{}
+		assert.Panics(t, func() {
+			GetClientOptions()
+		})
 	})
 }

--- a/aws/ec2info_test.go
+++ b/aws/ec2info_test.go
@@ -133,9 +133,12 @@ func TestNewEc2Info(t *testing.T) {
 }
 
 func TestGetRegion(t *testing.T) {
+	// unset AWS region env vars for clean tests
+	os.Unsetenv("AWS_REGION")
+	os.Unsetenv("AWS_DEFAULT_REGION")
+
 	t.Run("with AWS_REGION set", func(t *testing.T) {
 		t.Setenv("AWS_REGION", "kalamazoo")
-		os.Unsetenv("AWS_DEFAULT_REGION")
 		region, err := getRegion()
 		require.NoError(t, err)
 		assert.Empty(t, region)
@@ -143,15 +146,12 @@ func TestGetRegion(t *testing.T) {
 
 	t.Run("with AWS_DEFAULT_REGION set", func(t *testing.T) {
 		t.Setenv("AWS_DEFAULT_REGION", "kalamazoo")
-		os.Unsetenv("AWS_REGION")
 		region, err := getRegion()
 		require.NoError(t, err)
 		assert.Empty(t, region)
 	})
 
 	t.Run("with no AWS_REGION, AWS_DEFAULT_REGION set", func(t *testing.T) {
-		os.Unsetenv("AWS_REGION")
-		os.Unsetenv("AWS_DEFAULT_REGION")
 		metaClient := NewDummyEc2Meta()
 		region, err := getRegion(metaClient)
 		require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestGetClientOptions(t *testing.T) {
 		assert.Equal(t, ClientOptions{Timeout: 42 * time.Millisecond}, co)
 	})
 
-	t.Run("valid AWS_TIMEOUT, non-first call ", func(t *testing.T) {
+	t.Run("valid AWS_TIMEOUT, non-first call", func(t *testing.T) {
 		t.Setenv("AWS_TIMEOUT", "123")
 		// without resetting the Once, expect to be reused
 		co = GetClientOptions()

--- a/context_test.go
+++ b/context_test.go
@@ -21,7 +21,7 @@ func TestEnvMapifiesEnvironment(t *testing.T) {
 func TestEnvGetsUpdatedEnvironment(t *testing.T) {
 	c := &tmplctx{}
 	assert.Empty(t, c.Env()["FOO"])
-	require.NoError(t, os.Setenv("FOO", "foo"))
+	t.Setenv("FOO", "foo")
 	assert.Equal(t, c.Env()["FOO"], "foo")
 }
 
@@ -42,8 +42,7 @@ func TestCreateContext(t *testing.T) {
 			".":   {URL: ub},
 		},
 	}
-	os.Setenv("foo", "foo: bar")
-	defer os.Unsetenv("foo")
+	t.Setenv("foo", "foo: bar")
 	c, err = createTmplContext(ctx, []string{"foo"}, d)
 	require.NoError(t, err)
 	assert.IsType(t, &tmplctx{}, c)
@@ -51,8 +50,7 @@ func TestCreateContext(t *testing.T) {
 	ds := ((*tctx)["foo"]).(map[string]interface{})
 	assert.Equal(t, "bar", ds["foo"])
 
-	os.Setenv("bar", "bar: baz")
-	defer os.Unsetenv("bar")
+	t.Setenv("bar", "bar: baz")
 	c, err = createTmplContext(ctx, []string{"."}, d)
 	require.NoError(t, err)
 	assert.IsType(t, map[string]interface{}{}, c)

--- a/data/datasource_env_test.go
+++ b/data/datasource_env_test.go
@@ -3,7 +3,6 @@ package data
 import (
 	"context"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,10 +18,8 @@ func TestReadEnv(t *testing.T) {
 	ctx := context.Background()
 
 	content := []byte(`hello world`)
-	os.Setenv("HELLO_WORLD", "hello world")
-	defer os.Unsetenv("HELLO_WORLD")
-	os.Setenv("HELLO_UNIVERSE", "hello universe")
-	defer os.Unsetenv("HELLO_UNIVERSE")
+	t.Setenv("HELLO_WORLD", "hello world")
+	t.Setenv("HELLO_UNIVERSE", "hello universe")
 
 	source := &Source{Alias: "foo", URL: mustParseURL("env:HELLO_WORLD")}
 

--- a/internal/cmd/logger_test.go
+++ b/internal/cmd/logger_test.go
@@ -14,13 +14,12 @@ import (
 
 func TestLogFormat(t *testing.T) {
 	os.Unsetenv("GOMPLATE_LOG_FORMAT")
-	defer os.Unsetenv("GOMPLATE_LOG_FORMAT")
 
 	assert.Equal(t, "json", logFormat(nil))
 	// os.Stdout isn't a terminal when this runs as a unit test...
 	assert.Equal(t, "json", logFormat(os.Stdout))
 
-	os.Setenv("GOMPLATE_LOG_FORMAT", "simple")
+	t.Setenv("GOMPLATE_LOG_FORMAT", "simple")
 	assert.Equal(t, "simple", logFormat(os.Stdout))
 	assert.Equal(t, "simple", logFormat(&bytes.Buffer{}))
 }

--- a/libkv/consul_test.go
+++ b/libkv/consul_test.go
@@ -14,25 +14,11 @@ import (
 )
 
 func TestConsulURL(t *testing.T) {
-	t.Run("consul scheme", func(t *testing.T) {
-		u, _ := url.Parse("consul+http://myconsul.server")
-		expected := &url.URL{Host: "myconsul.server", Scheme: "http"}
-		actual, err := consulURL(u)
-		require.NoError(t, err)
-		assert.Equal(t, expected, actual)
-	})
-
-	t.Run("consul scheme, CONSUL_HTTP_SSL unset", func(t *testing.T) {
-		os.Unsetenv("CONSUL_HTTP_SSL")
-		u, _ := url.Parse("consul://myconsul.server:2345")
-		expected := &url.URL{Host: "myconsul.server:2345", Scheme: "http"}
-		actual, err := consulURL(u)
-		require.NoError(t, err)
-		assert.Equal(t, expected, actual)
-	})
+	os.Unsetenv("CONSUL_HTTP_SSL")
 
 	t.Run("consul scheme, CONSUL_HTTP_SSL set to true", func(t *testing.T) {
 		t.Setenv("CONSUL_HTTP_SSL", "true")
+
 		u, _ := url.Parse("consul://")
 		expected := &url.URL{Host: "localhost:8500", Scheme: "https"}
 		actual, err := consulURL(u)
@@ -40,10 +26,27 @@ func TestConsulURL(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("consul+http scheme", func(t *testing.T) {
+		u, _ := url.Parse("consul+http://myconsul.server")
+		expected := &url.URL{Host: "myconsul.server", Scheme: "http"}
+		actual, err := consulURL(u)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run("consul+https scheme, CONSUL_HTTP_SSL set to false", func(t *testing.T) {
 		t.Setenv("CONSUL_HTTP_SSL", "false")
+
 		u, _ := url.Parse("consul+https://myconsul.server:1234")
 		expected := &url.URL{Host: "myconsul.server:1234", Scheme: "https"}
+		actual, err := consulURL(u)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("consul scheme, CONSUL_HTTP_SSL unset", func(t *testing.T) {
+		u, _ := url.Parse("consul://myconsul.server:2345")
+		expected := &url.URL{Host: "myconsul.server:2345", Scheme: "http"}
 		actual, err := consulURL(u)
 		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
@@ -78,7 +81,7 @@ func TestConsulURL(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("TLS enabled, HTTP_ADDR is set without host, URL has no host and ambiguous scheme", func(t *testing.T) {
+	t.Run("TLS enabled, HTTP_ADDR is set without scheme, URL has no host and ambiguous scheme", func(t *testing.T) {
 		t.Setenv("CONSUL_HTTP_ADDR", "localhost:8501")
 		t.Setenv("CONSUL_HTTP_SSL", "true")
 

--- a/render_test.go
+++ b/render_test.go
@@ -37,8 +37,7 @@ func TestRenderTemplate(t *testing.T) {
 	hu, _ := url.Parse("stdin:")
 	wu, _ := url.Parse("env:WORLD")
 
-	os.Setenv("WORLD", "world")
-	defer os.Unsetenv("WORLD")
+	t.Setenv("WORLD", "world")
 
 	tr = NewRenderer(Options{
 		Context: map[string]Datasource{

--- a/vault/auth_test.go
+++ b/vault/auth_test.go
@@ -1,7 +1,6 @@
 package vault
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +10,7 @@ import (
 func TestLogin(t *testing.T) {
 	server, v := MockServer(404, "Not Found")
 	defer server.Close()
-	os.Setenv("VAULT_TOKEN", "foo")
-	defer os.Unsetenv("VAULT_TOKEN")
+	t.Setenv("VAULT_TOKEN", "foo")
 	v.Login()
 	assert.Equal(t, "foo", v.client.Token())
 }
@@ -20,8 +18,7 @@ func TestLogin(t *testing.T) {
 func TestTokenLogin(t *testing.T) {
 	server, v := MockServer(404, "Not Found")
 	defer server.Close()
-	os.Setenv("VAULT_TOKEN", "foo")
-	defer os.Unsetenv("VAULT_TOKEN")
+	t.Setenv("VAULT_TOKEN", "foo")
 
 	token, err := v.TokenLogin()
 	require.NoError(t, err)

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -15,8 +15,7 @@ func TestNew(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://127.0.0.1:8200", v.client.Address())
 
-	os.Setenv("VAULT_ADDR", "http://example.com:1234")
-	defer os.Unsetenv("VAULT_ADDR")
+	t.Setenv("VAULT_ADDR", "http://example.com:1234")
 	v, err = New(nil)
 	require.NoError(t, err)
 	assert.Equal(t, "http://example.com:1234", v.client.Address())


### PR DESCRIPTION
Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```

This PR also splits large test cases into subtests. This is useful because VSCode is able to run subtest separately

![image](https://github.com/hairyhenderson/gomplate/assets/20135478/61cd4318-1e28-415a-b2e6-e4bc7abc0903)

