### PR TITLE
Add missing-key flag to manage behavior in case of non-existing key

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -241,7 +241,7 @@ leftDelim: '%{'
 
 See [`--missing-key`](../usage/#--missing-key).
 
-Sets the behavior in case of non-existent keys
+Control the behavior during execution if a map is indexed with a key that is not present in the map
 
 ```yaml
 missingKey: error

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -237,6 +237,16 @@ Overrides the left template delimiter.
 leftDelim: '%{'
 ```
 
+## `missingKey`
+
+See [`--missing-key`](../usage/#--missing-key).
+
+Sets the behavior in case of non-existent keys
+
+```yaml
+missingKey: error
+```
+
 ## `outputDir`
 
 See [`--output-dir`](../usage/#input-dir-and-output-dir).

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -187,8 +187,9 @@ $ gomplate -c .=http://xkcd.com/info.0.json -i '<a href="{{ .img }}">{{ .title }
 Changes behavior if key not exist in the datasource.
 
 Available values:
-- `error` (default) - Exit with error if key not exist
-- `default`, `invalid` or `zero` - prints `<no value>` if key not exist
+- `error` (default): Execution stops immediately with an error.
+- `default` or `invalid`: Do nothing and continue execution. If printed, the result is the string `"<no value>"`.
+- `zero`: The operation returns the zero value for the element (which may be `nil`, in which case the string `"<no value>"` is printed).
 
 Examples:
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -184,7 +184,7 @@ $ gomplate -c .=http://xkcd.com/info.0.json -i '<a href="{{ .img }}">{{ .title }
 
 ### `--missing-key`
 
-Changes behavior if key not exist in the datasource.
+Control the behavior during execution if a map is indexed with a key that is not present in the map
 
 Available values:
 - `error` (default): Execution stops immediately with an error.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -184,7 +184,7 @@ $ gomplate -c .=http://xkcd.com/info.0.json -i '<a href="{{ .img }}">{{ .title }
 
 ### `--missing-key`
 
-Control the behavior during execution if a map is indexed with a key that is not present in the map
+Control the behavior during execution if a map is indexed with a key that is not present in the map.
 
 Available values:
 - `error` (default): Execution stops immediately with an error.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -182,6 +182,37 @@ $ gomplate -c .=http://xkcd.com/info.0.json -i '<a href="{{ .img }}">{{ .title }
 <a href="https://imgs.xkcd.com/comics/diploma_legal_notes.png">Diploma Legal Notes</a>
 ```
 
+### `--missing-key`
+
+Changes behavior if key not exist in the datasource.
+
+Available values:
+- `error` (default) - Exit with error if key not exist
+- `default`, `invalid` or `zero` - prints `<no value>` if key not exist
+
+Examples:
+
+```console
+$ gomplate --missing-key error -i 'Hi {{ .name }}'
+Hi 14:06:57 ERR  error="failed to render template <arg>: template: <arg>:1:6: executing \"<arg>\" at <.name>: map has no entry for key \"name\""
+```
+
+```console
+$ gomplate --missing-key default -i 'Hi {{ .name }}'
+Hi <no value>
+```
+
+```console
+$ gomplate --missing-key zero -i 'Hi {{ .name | default "Alex" }}'
+Hi Alex
+```
+
+```console
+$ gomplate --missing-key zero -i 'Hi {{ .name | required }}'
+Hi 14:12:04 ERR  error="failed to render template <arg>: template: <arg>:1:11: executing \"<arg>\" at <required>: error calling required: can not render template: a required value was not set"
+```
+
+
 ### Overriding the template delimiters
 
 Sometimes it's necessary to override the default template delimiters (`{{`/`}}`).

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -3,6 +3,7 @@ package gomplate
 import (
 	"bytes"
 	"context"
+	"github.com/hairyhenderson/gomplate/v4/funcs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -127,6 +128,38 @@ func TestHasTemplate(t *testing.T) {
 {{- $data.foo }}
 {{- end }}`
 	assert.Equal(t, "bar", testTemplate(t, g, tmpl))
+}
+
+func TestMissingKey(t *testing.T) {
+	g := NewRenderer(Options{
+		MissingKey: "zero",
+	})
+	tmpl := `{{ .name }}`
+	assert.Equal(t, "<no value>", testTemplate(t, g, tmpl))
+}
+
+func TestMissingKeyWithDefaultValue(t *testing.T) {
+	ns := funcs.CreateConvFuncs(context.TODO())
+	g := NewRenderer(Options{
+		MissingKey: "zero",
+		Funcs:      ns,
+	})
+	tmpl := `{{ .name | default "Alex" }}`
+	assert.Equal(t, "Alex", testTemplate(t, g, tmpl))
+}
+
+func TestMissingKeyRequired(t *testing.T) {
+	ns := funcs.CreateTestFuncs(context.TODO())
+	g := NewRenderer(Options{
+		MissingKey: "zero",
+		Funcs:      ns,
+	})
+	tmpl := `{{ .name | required }}`
+
+	var out bytes.Buffer
+	err := g.Render(context.Background(), "testtemplate", tmpl, &out)
+
+	assert.Error(t, err)
 }
 
 func TestCustomDelim(t *testing.T) {

--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -3,7 +3,6 @@ package gomplate
 import (
 	"bytes"
 	"context"
-	"github.com/hairyhenderson/gomplate/v4/funcs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -131,35 +130,23 @@ func TestHasTemplate(t *testing.T) {
 }
 
 func TestMissingKey(t *testing.T) {
-	g := NewRenderer(Options{
-		MissingKey: "zero",
-	})
-	tmpl := `{{ .name }}`
-	assert.Equal(t, "<no value>", testTemplate(t, g, tmpl))
-}
-
-func TestMissingKeyWithDefaultValue(t *testing.T) {
-	ns := funcs.CreateConvFuncs(context.TODO())
-	g := NewRenderer(Options{
-		MissingKey: "zero",
-		Funcs:      ns,
-	})
-	tmpl := `{{ .name | default "Alex" }}`
-	assert.Equal(t, "Alex", testTemplate(t, g, tmpl))
-}
-
-func TestMissingKeyRequired(t *testing.T) {
-	ns := funcs.CreateTestFuncs(context.TODO())
-	g := NewRenderer(Options{
-		MissingKey: "zero",
-		Funcs:      ns,
-	})
-	tmpl := `{{ .name | required }}`
-
-	var out bytes.Buffer
-	err := g.Render(context.Background(), "testtemplate", tmpl, &out)
-
-	assert.Error(t, err)
+	tests := map[string]struct {
+		MissingKey  string
+		ExpectedOut string
+	}{
+		"missing-key = zero":    {MissingKey: "zero", ExpectedOut: "<no value>"},
+		"missing-key = invalid": {MissingKey: "invalid", ExpectedOut: "<no value>"},
+		"missing-key = default": {MissingKey: "default", ExpectedOut: "<no value>"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			g := NewRenderer(Options{
+				MissingKey: tt.MissingKey,
+			})
+			tmpl := `{{ .name }}`
+			assert.Equal(t, tt.ExpectedOut, testTemplate(t, g, tmpl))
+		})
+	}
 }
 
 func TestCustomDelim(t *testing.T) {

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -160,6 +160,11 @@ func cobraConfig(cmd *cobra.Command, args []string) (cfg *config.Config, err err
 		return nil, err
 	}
 
+	cfg.MissingKey, err = getString(cmd, "missing-key")
+	if err != nil {
+		return nil, err
+	}
+
 	ds, err := getStringSlice(cmd, "datasource")
 	if err != nil {
 		return nil, err

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -156,7 +156,7 @@ func InitFlags(command *cobra.Command) {
 	command.Flags().String("left-delim", ldDefault, "override the default left-`delimiter` [$GOMPLATE_LEFT_DELIM]")
 	command.Flags().String("right-delim", rdDefault, "override the default right-`delimiter` [$GOMPLATE_RIGHT_DELIM]")
 
-	command.Flags().String("missing-key", "error", "Control behavior for non-existent keys. error (default) - return an error, zero - fallback to zero value")
+	command.Flags().String("missing-key", "error", "Control the behavior during execution if a map is indexed with a key that is not present in the map. error (default) - return an error, zero - fallback to zero value, default/invalid - print <no value>")
 
 	command.Flags().Bool("experimental", false, "enable experimental features [$GOMPLATE_EXPERIMENTAL]")
 

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -156,6 +156,8 @@ func InitFlags(command *cobra.Command) {
 	command.Flags().String("left-delim", ldDefault, "override the default left-`delimiter` [$GOMPLATE_LEFT_DELIM]")
 	command.Flags().String("right-delim", rdDefault, "override the default right-`delimiter` [$GOMPLATE_RIGHT_DELIM]")
 
+	command.Flags().String("missing-key", "error", "Control behavior for non-existent keys. error (default) - return an error, zero - fallback to zero value")
+
 	command.Flags().Bool("experimental", false, "enable experimental features [$GOMPLATE_EXPERIMENTAL]")
 
 	command.Flags().BoolP("verbose", "V", false, "output extra information about what gomplate is doing")

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -469,7 +469,7 @@ func (c Config) Validate() (err error) {
 	}
 
 	if err == nil {
-		missingKeyValues := []string{"error", "zero"}
+		missingKeyValues := []string{"", "error", "zero", "default"}
 		if !slices.Contains(missingKeyValues, c.MissingKey) {
 			err = fmt.Errorf("not allowed value for the 'missing-key' flag: %s. Allowed values: %s", c.MissingKey, strings.Join(missingKeyValues, ","))
 		}

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"net/url"
@@ -59,6 +60,8 @@ type Config struct {
 
 	LDelim string `yaml:"leftDelim,omitempty"`
 	RDelim string `yaml:"rightDelim,omitempty"`
+
+	MissingKey string `yaml:"missingKey,omitempty"`
 
 	PostExec []string `yaml:"postExec,omitempty,flow"`
 
@@ -465,6 +468,13 @@ func (c Config) Validate() (err error) {
 		}
 	}
 
+	if err == nil {
+		missingKeyValues := []string{"error", "zero"}
+		if !slices.Contains(missingKeyValues, c.MissingKey) {
+			err = fmt.Errorf("not allowed value for the 'missing-key' flag: %s. Allowed values: %s", c.MissingKey, strings.Join(missingKeyValues, ","))
+		}
+	}
+
 	return err
 }
 
@@ -532,6 +542,9 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.RDelim == "" {
 		c.RDelim = "}}"
+	}
+	if c.MissingKey == "" {
+		c.RDelim = "error"
 	}
 
 	if c.ExecPipe {

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -469,7 +469,7 @@ func (c Config) Validate() (err error) {
 	}
 
 	if err == nil {
-		missingKeyValues := []string{"", "error", "zero", "default"}
+		missingKeyValues := []string{"", "error", "zero", "default", "invalid"}
 		if !slices.Contains(missingKeyValues, c.MissingKey) {
 			err = fmt.Errorf("not allowed value for the 'missing-key' flag: %s. Allowed values: %s", c.MissingKey, strings.Join(missingKeyValues, ","))
 		}

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -544,7 +544,7 @@ func (c *Config) ApplyDefaults() {
 		c.RDelim = "}}"
 	}
 	if c.MissingKey == "" {
-		c.RDelim = "error"
+		c.MissingKey = "error"
 	}
 
 	if c.ExecPipe {

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"net/url"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/hairyhenderson/gomplate/v4/internal/datafs"
 	"github.com/hairyhenderson/gomplate/v4/internal/iohelpers"

--- a/internal/config/configfile_test.go
+++ b/internal/config/configfile_test.go
@@ -539,6 +539,7 @@ inputFiles: ['-']
 outputFiles: ['-']
 leftDelim: '{{'
 rightDelim: '}}'
+missingKey: error
 pluginTimeout: 5s
 `
 		assert.Equal(t, expected, c.String())

--- a/internal/tests/integration/config_test.go
+++ b/internal/tests/integration/config_test.go
@@ -281,7 +281,7 @@ func TestConfig_MissingKeyDefault(t *testing.T) {
 	writeConfig(t, tmpDir, `inputFiles: [in]
 missingKey: default
 `)
-	writeFile(t, tmpDir, "in", `{{ (ds "data").name }}`)
+	writeFile(t, tmpDir, "in", `{{ .name }}`)
 
 	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
 	assertSuccess(t, o, e, err, `<no value>`)
@@ -290,7 +290,7 @@ missingKey: default
 func TestConfig_MissingKeyNotDefined(t *testing.T) {
 	tmpDir := setupConfigTest(t)
 	writeConfig(t, tmpDir, `inputFiles: [in]`)
-	writeFile(t, tmpDir, "in", `{{ (ds "data").name }}`)
+	writeFile(t, tmpDir, "in", `{{ .name }}`)
 
 	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
 	assertFailed(t, o, e, err, `map has no entry for key \"name\"`)

--- a/internal/tests/integration/config_test.go
+++ b/internal/tests/integration/config_test.go
@@ -282,7 +282,6 @@ func TestConfig_MissingKeyDefault(t *testing.T) {
 missingKey: default
 `)
 	writeFile(t, tmpDir, "in", `{{ (ds "data").name }}`)
-	writeFile(t, tmpDir, "in.yaml", ``)
 
 	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
 	assertSuccess(t, o, e, err, `<no value>`)

--- a/internal/tests/integration/config_test.go
+++ b/internal/tests/integration/config_test.go
@@ -275,3 +275,24 @@ templates:
 	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
 	assertSuccess(t, o, e, err, "12345")
 }
+
+func TestConfig_MissingKeyDefault(t *testing.T) {
+	tmpDir := setupConfigTest(t)
+	writeConfig(t, tmpDir, `inputFiles: [in]
+missingKey: default
+`)
+	writeFile(t, tmpDir, "in", `{{ (ds "data").name }}`)
+	writeFile(t, tmpDir, "in.yaml", ``)
+
+	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
+	assertSuccess(t, o, e, err, `<no value>`)
+}
+
+func TestConfig_MissingKeyNotDefined(t *testing.T) {
+	tmpDir := setupConfigTest(t)
+	writeConfig(t, tmpDir, `inputFiles: [in]`)
+	writeFile(t, tmpDir, "in", `{{ (ds "data").name }}`)
+
+	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
+	assertFailed(t, o, e, err, `map has no entry for key \"name\"`)
+}

--- a/internal/tests/integration/integration_test.go
+++ b/internal/tests/integration/integration_test.go
@@ -25,11 +25,19 @@ import (
 const isWindows = runtime.GOOS == "windows"
 
 // a convenience...
-func inOutTest(t *testing.T, i, o string) {
+func inOutTest(t *testing.T, i, o string, args ...string) {
 	t.Helper()
 
-	stdout, stderr, err := cmd(t, "-i", i).run()
+	args = append(args, "-i", i)
+	stdout, stderr, err := cmd(t, args...).run()
 	assertSuccess(t, stdout, stderr, err, o)
+}
+func inOutContainsError(t *testing.T, i, e string, args ...string) {
+	t.Helper()
+
+	args = append(args, "-i", i)
+	stdout, stderr, err := cmd(t, args...).run()
+	assertFailed(t, stdout, stderr, err, e)
 }
 
 func inOutTestExperimental(t *testing.T, i, o string) {
@@ -54,6 +62,14 @@ func assertSuccess(t *testing.T, o, e string, err error, expected string) {
 	assert.Equal(t, "", e)
 	assert.Equal(t, expected, o)
 	require.NoError(t, err)
+}
+
+func assertFailed(t *testing.T, o, e string, err error, expected string) {
+	t.Helper()
+
+	assert.Contains(t, e, expected)
+	assert.Equal(t, "", o)
+	require.Error(t, err)
 }
 
 // mirrorHandler - reflects back the HTTP headers from the request

--- a/internal/tests/integration/integration_test.go
+++ b/internal/tests/integration/integration_test.go
@@ -32,6 +32,7 @@ func inOutTest(t *testing.T, i, o string, args ...string) {
 	stdout, stderr, err := cmd(t, args...).run()
 	assertSuccess(t, stdout, stderr, err, o)
 }
+
 func inOutContainsError(t *testing.T, i, e string, args ...string) {
 	t.Helper()
 

--- a/internal/tests/integration/missing_key_test.go
+++ b/internal/tests/integration/missing_key_test.go
@@ -1,0 +1,25 @@
+package integration
+
+import (
+	"testing"
+)
+
+func TestMissingKey_Default(t *testing.T) {
+	inOutTest(t, `{{ .name }}`, "<no value>", "--missing-key", "default")
+}
+
+func TestMissingKey_Zero(t *testing.T) {
+	inOutTest(t, `{{ .name }}`, "<no value>", "--missing-key", "zero")
+}
+
+func TestMissingKey_Fallback(t *testing.T) {
+	inOutTest(t, `{{ .name | default "Alex" }}`, "Alex", "--missing-key", "default")
+}
+
+func TestMissingKey_NotSpecified(t *testing.T) {
+	inOutContainsError(t, `{{ .name | default "Alex" }}`, `map has no entry for key \"name\"`)
+}
+
+func TestMissingKey_Error(t *testing.T) {
+	inOutContainsError(t, `{{ .name | default "Alex" }}`, `map has no entry for key \"name\"`, "--missing-key", "error")
+}

--- a/render.go
+++ b/render.go
@@ -166,6 +166,11 @@ func NewRenderer(opts Options) *Renderer {
 		opts.Funcs = template.FuncMap{}
 	}
 
+	missingKey := opts.MissingKey
+	if missingKey == "" {
+		missingKey = "error"
+	}
+
 	return &Renderer{
 		nested:      nested,
 		data:        d,
@@ -173,7 +178,7 @@ func NewRenderer(opts Options) *Renderer {
 		tctxAliases: tctxAliases,
 		lDelim:      opts.LDelim,
 		rDelim:      opts.RDelim,
-		missingKey:  opts.MissingKey,
+		missingKey:  missingKey,
 	}
 }
 

--- a/render.go
+++ b/render.go
@@ -42,7 +42,7 @@ type Options struct {
 	// templates to the specified string. Defaults to "{{"
 	RDelim string
 
-	// MissingKey sets the behavior in case of non-existing key
+	// MissingKey controls the behavior during execution if a map is indexed with a key that is not present in the map
 	MissingKey string
 
 	// Experimental - enable experimental features

--- a/render.go
+++ b/render.go
@@ -42,6 +42,9 @@ type Options struct {
 	// templates to the specified string. Defaults to "{{"
 	RDelim string
 
+	// MissingKey sets the behavior in case of non-existing key
+	MissingKey string
+
 	// Experimental - enable experimental features
 	Experimental bool
 }
@@ -78,6 +81,7 @@ func optionsFromConfig(cfg *config.Config) Options {
 		ExtraHeaders: cfg.ExtraHeaders,
 		LDelim:       cfg.LDelim,
 		RDelim:       cfg.RDelim,
+		MissingKey:   cfg.MissingKey,
 		Experimental: cfg.Experimental,
 	}
 
@@ -103,6 +107,7 @@ type Renderer struct {
 	funcs       template.FuncMap
 	lDelim      string
 	rDelim      string
+	missingKey  string
 	tctxAliases []string
 }
 
@@ -168,6 +173,7 @@ func NewRenderer(opts Options) *Renderer {
 		tctxAliases: tctxAliases,
 		lDelim:      opts.LDelim,
 		rDelim:      opts.RDelim,
+		missingKey:  opts.MissingKey,
 	}
 }
 
@@ -236,7 +242,7 @@ func (t *Renderer) renderTemplate(ctx context.Context, template Template, f temp
 
 	tstart := time.Now()
 	tmpl, err := parseTemplate(ctx, template.Name, template.Text,
-		f, tmplctx, t.nested, t.lDelim, t.rDelim)
+		f, tmplctx, t.nested, t.lDelim, t.rDelim, t.missingKey)
 	if err != nil {
 		return err
 	}

--- a/template.go
+++ b/template.go
@@ -52,7 +52,7 @@ func copyFuncMap(funcMap template.FuncMap) template.FuncMap {
 func parseTemplate(ctx context.Context, name, text string, funcs template.FuncMap, tmplctx interface{}, nested config.Templates, leftDelim, rightDelim string, missingKey string) (tmpl *template.Template, err error) {
 	tmpl = template.New(name)
 
-	missingKeyValues := []string{"error", "zero", "default"}
+	missingKeyValues := []string{"error", "zero", "default", "invalid"}
 	if !slices.Contains(missingKeyValues, missingKey) {
 		return nil, fmt.Errorf("not allowed value for the 'missing-key' flag: %s. Allowed values: %s", missingKey, strings.Join(missingKeyValues, ","))
 	}

--- a/template.go
+++ b/template.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -50,6 +51,12 @@ func copyFuncMap(funcMap template.FuncMap) template.FuncMap {
 // parseTemplate - parses text as a Go template with the given name and options
 func parseTemplate(ctx context.Context, name, text string, funcs template.FuncMap, tmplctx interface{}, nested config.Templates, leftDelim, rightDelim string, missingKey string) (tmpl *template.Template, err error) {
 	tmpl = template.New(name)
+
+	missingKeyValues := []string{"error", "zero", "default"}
+	if !slices.Contains(missingKeyValues, missingKey) {
+		return nil, fmt.Errorf("not allowed value for the 'missing-key' flag: %s. Allowed values: %s", missingKey, strings.Join(missingKeyValues, ","))
+	}
+
 	tmpl.Option("missingkey=" + missingKey)
 
 	funcMap := copyFuncMap(funcs)

--- a/template.go
+++ b/template.go
@@ -51,6 +51,9 @@ func copyFuncMap(funcMap template.FuncMap) template.FuncMap {
 // parseTemplate - parses text as a Go template with the given name and options
 func parseTemplate(ctx context.Context, name, text string, funcs template.FuncMap, tmplctx interface{}, nested config.Templates, leftDelim, rightDelim string, missingKey string) (tmpl *template.Template, err error) {
 	tmpl = template.New(name)
+	if missingKey == "" {
+		missingKey = "error"
+	}
 
 	missingKeyValues := []string{"error", "zero", "default", "invalid"}
 	if !slices.Contains(missingKeyValues, missingKey) {

--- a/template.go
+++ b/template.go
@@ -48,9 +48,9 @@ func copyFuncMap(funcMap template.FuncMap) template.FuncMap {
 }
 
 // parseTemplate - parses text as a Go template with the given name and options
-func parseTemplate(ctx context.Context, name, text string, funcs template.FuncMap, tmplctx interface{}, nested config.Templates, leftDelim, rightDelim string) (tmpl *template.Template, err error) {
+func parseTemplate(ctx context.Context, name, text string, funcs template.FuncMap, tmplctx interface{}, nested config.Templates, leftDelim, rightDelim string, missingKey string) (tmpl *template.Template, err error) {
 	tmpl = template.New(name)
-	tmpl.Option("missingkey=error")
+	tmpl.Option("missingkey=" + missingKey)
 
 	funcMap := copyFuncMap(funcs)
 


### PR DESCRIPTION
This pull request allow to control behavior in case of non-existent keys. It described in the issue #1948 