### PR TITLE
Add --exclude-processing option

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,15 +16,16 @@ import (
 // [github.com/hairyhenderson/gomplate/v4/internal/config.Config] is used
 // everywhere else, and will be exposed as API in a future version
 type Config struct {
-	Input       string
-	InputFiles  []string
-	InputDir    string
-	ExcludeGlob []string
-	OutputFiles []string
-	OutputDir   string
-	OutputMap   string
-	OutMode     string
-	Out         io.Writer
+	Input                 string
+	InputFiles            []string
+	InputDir              string
+	ExcludeGlob           []string
+	ExcludeProcessingGlob []string
+	OutputFiles           []string
+	OutputDir             string
+	OutputMap             string
+	OutMode               string
+	Out                   io.Writer
 
 	DataSources       []string
 	DataSourceHeaders []string
@@ -76,6 +77,10 @@ func (o *Config) String() string {
 		c += "\nexclude: " + strings.Join(o.ExcludeGlob, ", ")
 	}
 
+	if len(o.ExcludeProcessingGlob) > 0 {
+		c += "\nexcludeProcessing: " + strings.Join(o.ExcludeProcessingGlob, ", ")
+	}
+
 	c += "\noutput: "
 	switch {
 	case o.InputDir != "" && o.OutputDir != ".":
@@ -119,19 +124,20 @@ func (o *Config) String() string {
 
 func (o *Config) toNewConfig() (*config.Config, error) {
 	cfg := &config.Config{
-		Input:       o.Input,
-		InputFiles:  o.InputFiles,
-		InputDir:    o.InputDir,
-		ExcludeGlob: o.ExcludeGlob,
-		OutputFiles: o.OutputFiles,
-		OutputDir:   o.OutputDir,
-		OutputMap:   o.OutputMap,
-		OutMode:     o.OutMode,
-		LDelim:      o.LDelim,
-		RDelim:      o.RDelim,
-		Stdin:       os.Stdin,
-		Stdout:      &iohelpers.NopCloser{Writer: o.Out},
-		Stderr:      os.Stderr,
+		Input:                 o.Input,
+		InputFiles:            o.InputFiles,
+		InputDir:              o.InputDir,
+		ExcludeGlob:           o.ExcludeGlob,
+		ExcludeProcessingGlob: o.ExcludeProcessingGlob,
+		OutputFiles:           o.OutputFiles,
+		OutputDir:             o.OutputDir,
+		OutputMap:             o.OutputMap,
+		OutMode:               o.OutMode,
+		LDelim:                o.LDelim,
+		RDelim:                o.RDelim,
+		Stdin:                 os.Stdin,
+		Stdout:                &iohelpers.NopCloser{Writer: o.Out},
+		Stderr:                os.Stderr,
 	}
 	err := cfg.ParsePluginFlags(o.Plugins)
 	if err != nil {

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -139,6 +139,20 @@ excludes:
 This will skip all files with the extension `.txt`, except for files named
 `include-this.txt`, which will be processed.
 
+## `excludeProcessing`
+
+See [`--exclude-processing`](../usage/#exclude-processing).
+
+This is an array of exclude patterns, used in conjunction with [`inputDir`](#inputdir).
+The matching files will be copied to the output directory without template rendering. 
+
+```yaml
+excludeProcessing:
+  - '*.jpg'
+```
+
+This will copy all files with the extension `.jpg` to the output directory.
+
 ## `execPipe`
 
 See [`--exec-pipe`](../usage/#exec-pipe).

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -130,6 +130,20 @@ $ gomplate --include *.tmpl --exclude foo*.tmpl --input-dir in/ --output-dir out
 
 This will cause only files ending in `.tmpl` to be processed, except for files with names beginning with `foo`: `template.tmpl` will be included, but `foo-template.tmpl` will not.
 
+### `--exclude-processing`
+
+When using the [`--input-dir`](#input-dir-and-output-dir) argument, it can be useful to skip some files from processing and copy them directly to the output directory. Like the `--exclude` flag, it takes a [`.gitignore`][]-style pattern, and any files match the pattern will be copied.
+
+_Note:_ These patterns are _not_ treated as filesystem globs, and so a pattern like `/foo/bar.json` will match relative to the input directory, not the root of the filesystem as they may appear!
+
+Examples:
+
+```console
+$ gomplate --exclude-processing `*.png` --input-dir in/ --output-dir out/
+```
+
+This will skip all `*.png` files in the `in/` directory from being processed, and copy them to the `out/` directory.
+
 #### `.gomplateignore` files
 
 You can also use a file named `.gomplateignore` containing one exclude pattern on each line. This has the same syntax as a [`.gitignore`][] file.

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -114,6 +114,11 @@ func cobraConfig(cmd *cobra.Command, args []string) (cfg *config.Config, err err
 	if err != nil {
 		return nil, err
 	}
+	cfg.ExcludeProcessingGlob, err = getStringSlice(cmd, "exclude-processing")
+	if err != nil {
+		return nil, err
+	}
+
 	includesFlag, err := getStringSlice(cmd, "include")
 	if err != nil {
 		return nil, err

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -138,7 +138,7 @@ func InitFlags(command *cobra.Command) {
 	command.Flags().StringP("in", "i", "", "Template `string` to process (alternative to --file and --input-dir)")
 	command.Flags().String("input-dir", "", "`directory` which is examined recursively for templates (alternative to --file and --in)")
 
-	command.Flags().StringSlice("exclude", []string{}, "glob of files to ignore")
+	command.Flags().StringSlice("exclude", []string{}, "glob of files to not parse")
 	command.Flags().StringSlice("exclude-processing", []string{}, "glob of files to be copied without parsing")
 	command.Flags().StringSlice("include", []string{}, "glob of files to parse")
 

--- a/internal/cmd/main.go
+++ b/internal/cmd/main.go
@@ -138,7 +138,8 @@ func InitFlags(command *cobra.Command) {
 	command.Flags().StringP("in", "i", "", "Template `string` to process (alternative to --file and --input-dir)")
 	command.Flags().String("input-dir", "", "`directory` which is examined recursively for templates (alternative to --file and --in)")
 
-	command.Flags().StringSlice("exclude", []string{}, "glob of files to not parse")
+	command.Flags().StringSlice("exclude", []string{}, "glob of files to ignore")
+	command.Flags().StringSlice("exclude-processing", []string{}, "glob of files to be copied without parsing")
 	command.Flags().StringSlice("include", []string{}, "glob of files to parse")
 
 	command.Flags().StringSliceP("out", "o", []string{"-"}, "output `file` name. Omit to use standard output.")

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -49,10 +49,11 @@ type Config struct {
 	// internal use only, can't be injected in YAML
 	PostExecInput io.Reader `yaml:"-"`
 
-	Input       string   `yaml:"in,omitempty"`
-	InputDir    string   `yaml:"inputDir,omitempty"`
-	InputFiles  []string `yaml:"inputFiles,omitempty,flow"`
-	ExcludeGlob []string `yaml:"excludes,omitempty"`
+	Input                 string   `yaml:"in,omitempty"`
+	InputDir              string   `yaml:"inputDir,omitempty"`
+	InputFiles            []string `yaml:"inputFiles,omitempty,flow"`
+	ExcludeGlob           []string `yaml:"excludes,omitempty"`
+	ExcludeProcessingGlob []string `yaml:"excludeProcessing,omitempty"`
 
 	OutputDir   string   `yaml:"outputDir,omitempty"`
 	OutputMap   string   `yaml:"outputMap,omitempty"`
@@ -245,6 +246,9 @@ func (c *Config) MergeFrom(o *Config) *Config {
 	}
 	if !isZero(o.ExcludeGlob) {
 		c.ExcludeGlob = o.ExcludeGlob
+	}
+	if !isZero(o.ExcludeProcessingGlob) {
+		c.ExcludeProcessingGlob = o.ExcludeProcessingGlob
 	}
 	if !isZero(o.OutMode) {
 		c.OutMode = o.OutMode

--- a/internal/tests/integration/gomplateignore_test.go
+++ b/internal/tests/integration/gomplateignore_test.go
@@ -279,3 +279,34 @@ func TestGomplateignore_WithIncludes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, fromSlashes("rules/index.csv"), files)
 }
+
+func TestGomplateignore_WithExcludeProcessing(t *testing.T) {
+	files, err := executeOpts(t, `.gomplateignore
+*.log
+`, []string{
+		"--exclude-processing", "crash.bin",
+		"--exclude-processing", "log/*.zip",
+		"--exclude", "rules/*.txt",
+		"--exclude", "sprites/*.ini",
+	},
+		tfs.WithDir("logs",
+			tfs.WithFile("archive.zip", ""),
+			tfs.WithFile("engine.log", ""),
+			tfs.WithFile("skills.log", "")),
+		tfs.WithDir("rules",
+			tfs.WithFile("index.csv", ""),
+			tfs.WithFile("fire.txt", ""),
+			tfs.WithFile("earth.txt", "")),
+		tfs.WithDir("sprites",
+			tfs.WithFile("human.csv", ""),
+			tfs.WithFile("demon.xml", ""),
+			tfs.WithFile("alien.ini", "")),
+		tfs.WithFile("manifest.json", ""),
+		tfs.WithFile("crash.bin", ""),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, fromSlashes(
+		"crash.bin", "logs/archive.zip", "manifest.json", "rules/index.csv",
+		"sprites/demon.xml", "sprites/human.csv"), files)
+}

--- a/template.go
+++ b/template.go
@@ -358,7 +358,7 @@ func readInFile(ctx context.Context, cfg *config.Config, inFile string, mode os.
 
 		source = string(b)
 	}
-	return
+	return source, newmode, err
 }
 
 func getOutfileHandler(ctx context.Context, cfg *config.Config, outFile string, mode os.FileMode, modeOverride bool) (io.Writer, error) {

--- a/template.go
+++ b/template.go
@@ -266,6 +266,7 @@ func walkDir(ctx context.Context, cfg *config.Config, dir string, outFileNamer f
 	}
 
 	excludeProcessingMatches, err := matcher.Matches(".", &xignore.MatchesOptions{
+		// TODO: fix or replace xignore module so we can avoid attempting to read the .gomplateignore file for both exclude and excludeProcessing patterns
 		Ignorefile:    gomplateignore,
 		Nested:        true, // allow nested ignorefile
 		AfterPatterns: excludeProcessingGlob,

--- a/template.go
+++ b/template.go
@@ -324,24 +324,26 @@ func walkDir(ctx context.Context, cfg *config.Config, dir string, outFileNamer f
 }
 
 func readInFile(ctx context.Context, cfg *config.Config, inFile string, mode os.FileMode) (source string, newmode os.FileMode, err error) {
-	source = ""
 	newmode = mode
+	var b []byte
 
 	//nolint:nestif
 	if inFile == "-" {
-		b, err := io.ReadAll(cfg.Stdin)
+		b, err = io.ReadAll(cfg.Stdin)
 		if err != nil {
 			return source, newmode, fmt.Errorf("read from stdin: %w", err)
 		}
 
 		source = string(b)
 	} else {
-		fsys, err := datafs.FSysForPath(ctx, inFile)
+		var fsys fs.FS
+		var si fs.FileInfo
+		fsys, err = datafs.FSysForPath(ctx, inFile)
 		if err != nil {
 			return source, newmode, fmt.Errorf("fsysForPath: %w", err)
 		}
 
-		si, err := fs.Stat(fsys, inFile)
+		si, err = fs.Stat(fsys, inFile)
 		if err != nil {
 			return source, newmode, fmt.Errorf("stat %q: %w", inFile, err)
 		}
@@ -351,7 +353,7 @@ func readInFile(ctx context.Context, cfg *config.Config, inFile string, mode os.
 
 		// we read the file and store in memory immediately, to prevent leaking
 		// file descriptors.
-		b, err := fs.ReadFile(fsys, inFile)
+		b, err = fs.ReadFile(fsys, inFile)
 		if err != nil {
 			return source, newmode, fmt.Errorf("readAll %q: %w", inFile, err)
 		}

--- a/template_unix_test.go
+++ b/template_unix_test.go
@@ -23,7 +23,7 @@ func TestWalkDir_UNIX(t *testing.T) {
 
 	cfg := &config.Config{}
 
-	_, err := walkDir(ctx, cfg, "/indir", simpleNamer("/outdir"), nil, 0, false)
+	_, err := walkDir(ctx, cfg, "/indir", simpleNamer("/outdir"), nil, nil, 0, false)
 	assert.Error(t, err)
 
 	err = hackpadfs.MkdirAll(fsys, "/indir/one", 0o777)
@@ -37,7 +37,7 @@ func TestWalkDir_UNIX(t *testing.T) {
 	err = hackpadfs.WriteFullFile(fsys, "/indir/two/baz", []byte("baz"), 0o644)
 	require.NoError(t, err)
 
-	templates, err := walkDir(ctx, cfg, "/indir", simpleNamer("/outdir"), []string{"*/two"}, 0, false)
+	templates, err := walkDir(ctx, cfg, "/indir", simpleNamer("/outdir"), []string{"*/two"}, []string{}, 0, false)
 	require.NoError(t, err)
 
 	expected := []Template{

--- a/template_windows_test.go
+++ b/template_windows_test.go
@@ -32,7 +32,7 @@ func TestWalkDir_Windows(t *testing.T) {
 
 	cfg := &config.Config{}
 
-	_, err := walkDir(ctx, cfg, `C:\indir`, simpleNamer(`C:/outdir`), nil, 0, false)
+	_, err := walkDir(ctx, cfg, `C:\indir`, simpleNamer(`C:/outdir`), nil, nil, 0, false)
 	assert.Error(t, err)
 
 	err = hackpadfs.MkdirAll(fsys, `C:\indir\one`, 0o777)
@@ -50,7 +50,7 @@ func TestWalkDir_Windows(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "baz", fi.Name())
 
-	templates, err := walkDir(ctx, cfg, `C:\indir`, simpleNamer(`C:/outdir`), []string{`*\two`}, 0, false)
+	templates, err := walkDir(ctx, cfg, `C:\indir`, simpleNamer(`C:/outdir`), []string{`*\two`}, []string{}, 0, false)
 	require.NoError(t, err)
 
 	expected := []Template{


### PR DESCRIPTION
Fixes #1911 

This PR added a CLI option `--exclude-processing` and an equivelent config entry `excludeProcessing`, if it is set, the matching files will go with a different code path `copyFileToOutDir`.

To make the code reusable, the codes about file IO are offloaded from`fileToTemplate` into `readInFile`, `getOutfileHandler`, and are called by `copyFileToOutDir` as well. 

**How to test:**

Have a jpeg file in `in` directory.

**case 1: (test cli argument `--exclude-processing`)**

run:
`./gomplate --exclude-processing '*.jpg' --input-dir=in --output-dir=out`

the *.jpg exists in `out` directory  

**case 2: (test config file entry `excludeProcessing`)**

have a `.gomplate.yaml` file in the directory:
`
inputDir: in/
outputDir: out/
excludeProcessing:
  - '*.jpg'
 `

run:
`./gomplate --input-dir=in --output-dir=out`

the *.jpg exists in `out` directory  

