### PR TITLE
Warn when deprecated k=v array form is used for templates

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -455,18 +455,6 @@ templates:
     url: https://example.com/api/v1/someremotetemplate
     header:
       Authorization: ["Basic aGF4MHI6c3dvcmRmaXNoCg=="]
-  dir: foo/bar/
-```
-
-_(Deprecated)_ Can also be an array of template references. Can be just a path,
-or an alias and a path:
-
-```yaml
-templates:
-  - t=foo/bar/helloworld.tmpl
-  - templatedir/
-  - dir=foo/bar/
-  - mytemplate.t
 ```
 
 [command-line arguments]: ../usage

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
 	"github.com/hairyhenderson/gomplate/v4/internal/urlhelpers"
 	"github.com/hairyhenderson/yaml"
 )
@@ -16,7 +18,7 @@ import (
 // Note that templates use the DataSource type, since they have the exact same
 // shape.
 // TODO: get rid of this and just use map[string]DataSource once the legacy
-// [k=]v array format is no longer supported
+// [k=]v array format is no longer supported (v4.1.0?)
 type Templates map[string]DataSource
 
 // UnmarshalYAML - satisfy the yaml.Umarshaler interface
@@ -39,6 +41,8 @@ func (t *Templates) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (t *Templates) unmarshalYAMLArray(value *yaml.Node) error {
+	deprecated.WarnDeprecated(context.Background(),
+		"config: the YAML array form for 'templates' is deprecated and will be removed in the next version. Use the map form instead.")
 	a := []string{}
 	err := value.Decode(&a)
 	if err != nil {

--- a/internal/tests/integration/config_test.go
+++ b/internal/tests/integration/config_test.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	tfs "gotest.tools/v3/fs"
 )
 
@@ -102,7 +103,7 @@ datasources:
 	assertSuccess(t, o, e, err, "")
 
 	b, err := os.ReadFile(tmpDir.Join("outdir", "file"))
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hello world", string(b))
 }
 
@@ -128,7 +129,7 @@ outputFiles: [out]
 	assertSuccess(t, o, e, err, "")
 
 	b, err := os.ReadFile(tmpDir.Join("out"))
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "hello world", string(b))
 }
 
@@ -170,7 +171,7 @@ datasources:
 
 	o, e, err := cmd(t).withDir(tmpDir.Path()).
 		withEnv("GOMPLATE_LEFT_DELIM", "<<").run()
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", e)
 	assert.Equal(t, "hello world", o)
 }
@@ -194,7 +195,7 @@ datasources:
 	o, e, err := cmd(t, "--left-delim={{").
 		withDir(tmpDir.Path()).
 		withEnv("GOMPLATE_LEFT_DELIM", "<<").run()
-	assert.NilError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "", e)
 	assert.Equal(t, "hello world", o)
 }
@@ -232,7 +233,7 @@ suppressEmpty: true
 
 	_, _, err := cmd(t).withDir(tmpDir.Path()).
 		withEnv("GOMPLATE_SUPPRESS_EMPTY", "false").run()
-	assert.NilError(t, err)
+	require.NoError(t, err)
 
 	_, err = os.Stat(tmpDir.Join("missing"))
 	assert.ErrorIs(t, err, fs.ErrNotExist)
@@ -273,7 +274,9 @@ templates:
 	writeFile(t, tmpDir, "t1.tmpl", `{{ .testValue }}`)
 
 	o, e, err := cmd(t).withDir(tmpDir.Path()).run()
-	assertSuccess(t, o, e, err, "12345")
+	assert.Contains(t, e, "Deprecated: config: the YAML array form for 'templates' is deprecated")
+	assert.Equal(t, "12345", o)
+	require.NoError(t, err)
 }
 
 func TestConfig_MissingKeyDefault(t *testing.T) {


### PR DESCRIPTION
A precursor to #1976, which will be re-done in v4.1.0 or so.