### PR TITLE
Update syntax.md

### DIFF
--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -51,7 +51,7 @@ Hello,  baz!
 
 This might not be desirable.
 
-You can use [Golang template syntax](https://golang.org/pkg/text/template/#hdr-Text_and_spaces) to fix this. Leading newlines (i.e. newlines that come before the action) can be suppressed by placing a minus sign in front of the first set of delimiters (`{{`). Putting the minus sign behind the trailing set of delimiters (`}}`) will suppress the newline _after_ the action. You can do both to suppress newlines entirely on that line.
+You can use [Golang template syntax](https://golang.org/pkg/text/template/#hdr-Text_and_spaces) to fix this. Leading newlines (i.e. newlines that come before the action) can be suppressed by placing a minus sign behind the first set of delimiters (`{{`). Putting the minus sign in front of the trailing set of delimiters (`}}`) will suppress the newline _after_ the action. You can do both to suppress newlines entirely on that line.
 
 Placing the minus sign within the context (i.e. inside of `{{.}}`) has no effect.
 


### PR DESCRIPTION
fix: wording was incorrect.

Details: Original text stated
```... newlines that come before the action) can be suppressed by placing a minus sign in front of the first set of delimiters (`{{`)...```

This appears to have been a typo. Following those directions would lead to (`-{{`). This would not behave as expected. What was originally intended was (`{{-`)