### PR TITLE
Build(deps): replace inet.af/netaddr by github.com/inetaf/netaddr

### DIFF
--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -7,7 +7,7 @@ preamble: |
 
   [RFC 4632]: http://tools.ietf.org/html/rfc4632
   [RFC 4291]: http://tools.ietf.org/html/rfc4291
-  [`inet.af/netaddr`]: https://pkg.go.dev/inet.af/netaddr
+  [`github.com/inetaf/netaddr`]: https://pkg.go.dev/github.com/inetaf/netaddr
   [`net`]: https://pkg.go.dev/net
 funcs:
   - name: net.LookupIP
@@ -157,10 +157,10 @@ funcs:
     deprecated: Use [`net.ParseAddr`](#net-parseaddr) instead.
     description: |
       Parse the given string as an IP address (a `netaddr.IP` from the
-      [`inet.af/netaddr`](https://pkg.go.dev/inet.af/netaddr) package).
+      [`github.com/inetaf/netaddr`](https://pkg.go.dev/github.com/inetaf/netaddr) package).
 
       Any of `netaddr.IP`'s methods may be called on the resulting value. See
-      [the docs](https://pkg.go.dev/inet.af/netaddr) for details.
+      [the docs](https://pkg.go.dev/github.com/inetaf/netaddr) for details.
     pipeline: true
     arguments:
       - name: ip
@@ -203,13 +203,13 @@ funcs:
     description: |
       Parse the given string as an IP address prefix (CIDR) representing an IP
       network (a `netaddr.IPPrefix` from the
-      [`inet.af/netaddr`][] package).
+      [`github.com/inetaf/netaddr`][] package).
 
       The string can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
       the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
 
       Any of `netaddr.IPPrefix`'s methods may be called on the resulting value.
-      See [the docs][`inet.af/netaddr`] for details.
+      See [the docs][`github.com/inetaf/netaddr`] for details.
     pipeline: true
     arguments:
       - name: ipprefix
@@ -260,12 +260,12 @@ funcs:
     deprecated: Use [`net.ParseRange`](#net-parserange) instead.
     description: |
       Parse the given string as an inclusive range of IP addresses from the same
-      address family (a `netaddr.IPRange` from the [`inet.af/netaddr`][] package).
+      address family (a `netaddr.IPRange` from the [`github.com/inetaf/netaddr`][] package).
 
       The string must contain a hyphen (`-`).
 
       Any of `netaddr.IPRange`'s methods may be called on the resulting value.
-      See [the docs][`inet.af/netaddr`] for details.
+      See [the docs][`github.com/inetaf/netaddr`] for details.
     pipeline: true
     arguments:
       - name: iprange

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -12,7 +12,7 @@ calculations.
 
 [RFC 4632]: http://tools.ietf.org/html/rfc4632
 [RFC 4291]: http://tools.ietf.org/html/rfc4291
-[`inet.af/netaddr`]: https://pkg.go.dev/inet.af/netaddr
+[`github.com/inetaf/netaddr`]: https://pkg.go.dev/github.com/inetaf/netaddr
 [`net`]: https://pkg.go.dev/net
 
 ## `net.LookupIP`
@@ -257,10 +257,10 @@ $ gomplate -i '{{ $ip := net.ParseAddr (net.LookupIP "example.com") -}}
 **Deprecation Notice:** Use [`net.ParseAddr`](#net-parseaddr) instead.
 
 Parse the given string as an IP address (a `netaddr.IP` from the
-[`inet.af/netaddr`](https://pkg.go.dev/inet.af/netaddr) package).
+[`github.com/inetaf/netaddr`](https://pkg.go.dev/github.com/inetaf/netaddr) package).
 
 Any of `netaddr.IP`'s methods may be called on the resulting value. See
-[the docs](https://pkg.go.dev/inet.af/netaddr) for details.
+[the docs](https://pkg.go.dev/github.com/inetaf/netaddr) for details.
 
 _Added in gomplate [v3.10.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0)_
 ### Usage
@@ -331,13 +331,13 @@ true
 
 Parse the given string as an IP address prefix (CIDR) representing an IP
 network (a `netaddr.IPPrefix` from the
-[`inet.af/netaddr`][] package).
+[`github.com/inetaf/netaddr`][] package).
 
 The string can be in the form `"192.168.1.0/24"` or `"2001::db8::/32"`,
 the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
 
 Any of `netaddr.IPPrefix`'s methods may be called on the resulting value.
-See [the docs][`inet.af/netaddr`] for details.
+See [the docs][`github.com/inetaf/netaddr`] for details.
 
 _Added in gomplate [v3.10.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0)_
 ### Usage
@@ -418,12 +418,12 @@ $ gomplate -i '{{ $range := net.ParseRange "1.2.3.0-1.2.3.233" -}}
 **Deprecation Notice:** Use [`net.ParseRange`](#net-parserange) instead.
 
 Parse the given string as an inclusive range of IP addresses from the same
-address family (a `netaddr.IPRange` from the [`inet.af/netaddr`][] package).
+address family (a `netaddr.IPRange` from the [`github.com/inetaf/netaddr`][] package).
 
 The string must contain a hyphen (`-`).
 
 Any of `netaddr.IPRange`'s methods may be called on the resulting value.
-See [the docs][`inet.af/netaddr`] for details.
+See [the docs][`github.com/inetaf/netaddr`] for details.
 
 _Added in gomplate [v3.10.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.10.0)_
 ### Usage

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	golang.org/x/term v0.19.0
 	golang.org/x/text v0.14.0
 	gotest.tools/v3 v3.5.1
-	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a
+	github.com/inetaf/netaddr v0.0.0-20230525184311-b8eac61e914a
 	k8s.io/client-go v0.29.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -771,7 +771,5 @@ gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a h1:1XCVEdxrvL6c0TGOhecLuB7U9zYNdxZEjvOqJreKZiM=
-inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a/go.mod h1:e83i32mAQOW1LAqEIweALsuK2Uw4mhQadA5r7b0Wobo=
 k8s.io/client-go v0.29.3 h1:R/zaZbEAxqComZ9FHeQwOh3Y1ZUs7FaHKZdQtIc2WZg=
 k8s.io/client-go v0.29.3/go.mod h1:tkDisCvgPfiRpxGnOORfkljmS+UrW+WtXAy2fTvXJB0=

--- a/internal/funcs/net.go
+++ b/internal/funcs/net.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hairyhenderson/gomplate/v4/internal/cidr"
 	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
 	"github.com/hairyhenderson/gomplate/v4/net"
+	"github.com/inetaf/netaddr"
 	"go4.org/netipx"
-	"inet.af/netaddr"
 )
 
 // CreateNetFuncs -

--- a/internal/funcs/net_test.go
+++ b/internal/funcs/net_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 
 	"github.com/hairyhenderson/gomplate/v4/internal/config"
+	"github.com/inetaf/netaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"inet.af/netaddr"
 )
 
 func TestCreateNetFuncs(t *testing.T) {
@@ -154,7 +154,7 @@ func TestCIDRHost(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "fd00:fd12:3456:7890::22", ip.String())
 
-	// inet.af/netaddr.IPPrefix
+	// github.com/inetaf/netaddr.IPPrefix
 	ipPrefix, _ := n.ParseIPPrefix("10.12.127.0/20")
 
 	ip, err = n.CIDRHost(16, ipPrefix)


### PR DESCRIPTION
inet.af domain was seized and is not functional anymore. Unfortunately, github.com/inetaf/netaddr is not a dropin replacement as its path has not been updated:

        module declares its path as: inet.af/netaddr
                but was required as: github.com/inetaf/netaddr

I don't know the best way to handle this. A `replace` would not help dependencies. Alternatively, support for `inet.af/netaddr` could be dropped as it is already broken due to the domain problem.

cc @bradfitz for insights (maybe push a last update to update the path?)