### PR TITLE
ci(docs): Require up-to-date function docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Docs Checks
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check-func-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install gomplate
+        run: |
+          docker create --name gomplate hairyhenderson/gomplate
+          docker cp gomplate:/gomplate .
+          sudo mv gomplate /usr/local/bin
+      - name: Make sure function docs are up-to-date
+        run: |
+          make --always-make gen-func-docs
+          git diff --exit-code
+          if [ $? -ne 0 ]; then
+            echo "Function docs are out of date. Please run 'make gen-func-docs' locally and commit the changes."
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,9 @@ gen-docs: docs/themes/hugo-theme-relearn
 docs/content/functions/%.md: docs-src/content/functions/%.yml docs-src/content/functions/func_doc.md.tmpl
 	gomplate -d data=$< -f docs-src/content/functions/func_doc.md.tmpl -o $@
 
+# run the above target for all files found in docs-src/content/functions/*.yml
+gen-func-docs: $(shell find docs-src/content/functions -name "*.yml" | sed -e 's#docs-src#docs#' -e 's#\.yml#\.md#')
+
 # this target doesn't usually get used - it's mostly here as a reminder to myself
 # hint: make sure CLOUDCONVERT_API_KEY is set ;)
 gomplate.png: gomplate.svg
@@ -224,6 +227,6 @@ lint:
 ci-lint:
 	@golangci-lint run --verbose --max-same-issues=0 --max-issues-per-linter=0 --out-format=github-actions
 
-.PHONY: gen-changelog clean test build-x build-release build test-integration-docker gen-docs lint clean-images clean-containers docker-images test-remote-windows integration testbins-windows
+.PHONY: gen-changelog clean test build-x build-release build test-integration-docker gen-docs lint clean-images clean-containers docker-images test-remote-windows integration testbins-windows gen-func-docs
 .DELETE_ON_ERROR:
 .SECONDARY:

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -536,6 +536,43 @@ Go
 COBOL
 ```
 
+## `data.CUE`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+
+**Alias:** `cue`
+
+Converts a [CUE](https://cuelang.org/) document into an object. Any type
+of CUE document is supported. This can be used to access properties of CUE
+documents.
+
+Note that the `import` statement is not yet supported, and will result in
+an error (except for importing builtin packages).
+
+### Usage
+
+```
+data.CUE input
+```
+```
+input | data.CUE
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `input` | _(required)_ the CUE document to parse |
+
+### Examples
+
+```console
+$ gomplate -i '{{ $t := `data: {
+    hello: "world"
+  }` -}}
+  Hello {{ (cue $t).data.hello }}'
+Hello world
+```
+
 ## `data.ToJSON`
 
 **Alias:** `toJSON`
@@ -725,4 +762,47 @@ $ gomplate -f input.tmpl
 first,second
 1,2
 3,4
+```
+
+## `data.ToCUE`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+
+**Alias:** `toCUE`
+
+Converts an object to a [CUE](https://cuelang.org/) document in canonical
+format. The input object can be of any type.
+
+This is roughly equivalent to using the `cue export --out=cue <file>`
+command to convert from other formats to CUE.
+
+### Usage
+
+```
+data.ToCUE input
+```
+```
+input | data.ToCUE
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `input` | _(required)_ the object to marshal as a CUE document |
+
+### Examples
+
+```console
+$ gomplate -i '{{ `{"foo":"bar"}` | data.JSON | data.ToCUE }}'
+{
+	foo: "bar"
+}
+```
+```console
+$ gomplate -i '{{ toCUE "hello world" }}'
+"hello world"
+```
+```console
+$ gomplate -i '{{ coll.Slice 1 "two" true | data.ToCUE }}'
+[1, "two", true]
 ```


### PR DESCRIPTION
Some docs updates have been missed (see https://github.com/hairyhenderson/gomplate/pull/2070 and also the updates made in #1781 were missed). This attempts to render docs in CI and fail if they're not up-to-date.