### PR TITLE
fix: Simplify condition to just use filepath.IsAbs

### DIFF
--- a/internal/datafs/wdfs.go
+++ b/internal/datafs/wdfs.go
@@ -68,8 +68,7 @@ func resolveLocalPath(wvol, name string) (root, resolved string, err error) {
 	// name (e.g. "/foo/bar"). UNC paths (beginning with "//") are ignored.
 	if name[0] == '/' && (len(name) == 1 || (name[1] != '/' && name[1] != '?')) {
 		name = filepath.Join(wvol, name)
-		// TODO: maybe this can be reduced to just '!filepath.IsAbs(name)'?
-	} else if name[0] != '/' && !filepath.IsAbs(name) {
+	} else if !filepath.IsAbs(name) {
 		wd, _ := os.Getwd()
 		name = filepath.Join(wd, name)
 	}


### PR DESCRIPTION
Clearing out a TODO - file path.IsAbs checks that name starts with `/` on UNIX-like OSes, and on Windows the `/` check is integral as well. The logic is _slightly_ different, but I think this is simpler and should still work.