### PR TITLE
chore(api)!: Error instead of returning 0 on invalid inputs to conv.* functions

### DIFF
--- a/conv/conv_test.go
+++ b/conv/conv_test.go
@@ -125,88 +125,247 @@ func TestMustParseFloat(t *testing.T) {
 }
 
 func TestToInt64(t *testing.T) {
-	assert.Equal(t, int64(1), ToInt64(1))
-	assert.Equal(t, int64(1), ToInt64(int32(1)))
-	assert.Equal(t, int64(1), ToInt64(int64(1)))
-	assert.Equal(t, int64(1), ToInt64(float32(1)))
-	assert.Equal(t, int64(1), ToInt64(float64(1)))
-	assert.Equal(t, int64(42), ToInt64(42))
-	assert.Equal(t, int64(42), ToInt64("42.0"))
-	assert.Equal(t, int64(3), ToInt64("3.5"))
-	assert.Equal(t, int64(-1), ToInt64(uint64(math.MaxUint64)))
-	assert.Equal(t, int64(0xFF), ToInt64(uint8(math.MaxUint8)))
+	actual, err := ToInt64(1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
 
-	assert.Equal(t, int64(0), ToInt64(nil))
-	assert.Equal(t, int64(0), ToInt64(false))
-	assert.Equal(t, int64(1), ToInt64(true))
-	assert.Equal(t, int64(0), ToInt64(""))
-	assert.Equal(t, int64(0), ToInt64("foo"))
-	assert.Equal(t, int64(0xFFFF), ToInt64("0xFFFF"))
-	assert.Equal(t, int64(8), ToInt64("010"))
-	assert.Equal(t, int64(4096), ToInt64("4,096"))
-	assert.Equal(t, int64(-4096), ToInt64("-4,096.00"))
+	actual, err = ToInt64(int32(1))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = ToInt64(int64(1))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = ToInt64(float32(1))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = ToInt64(float64(1))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = ToInt64(42)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), actual)
+
+	actual, err = ToInt64("42.0")
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), actual)
+
+	actual, err = ToInt64("3.5")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), actual)
+
+	actual, err = ToInt64(uint64(math.MaxUint64))
+	require.NoError(t, err)
+	assert.Equal(t, int64(-1), actual)
+
+	actual, err = ToInt64(uint8(math.MaxUint8))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0xFF), actual)
+
+	actual, err = ToInt64(false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), actual)
+
+	actual, err = ToInt64(true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = ToInt64("0xFFFF")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0xFFFF), actual)
+
+	actual, err = ToInt64("010")
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), actual)
+
+	actual, err = ToInt64("4,096")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4096), actual)
+
+	actual, err = ToInt64("-4,096.00")
+	require.NoError(t, err)
+	assert.Equal(t, int64(-4096), actual)
+
+	t.Run("error cases", func(t *testing.T) {
+		_, err = ToInt64(nil)
+		require.Error(t, err)
+
+		_, err = ToInt64("")
+		require.Error(t, err)
+
+		_, err = ToInt64("foo")
+		require.Error(t, err)
+	})
 }
 
 func TestToInt(t *testing.T) {
-	assert.Equal(t, 1, ToInt(1))
-	assert.Equal(t, 1, ToInt(int32(1)))
-	assert.Equal(t, 1, ToInt(int64(1)))
-	assert.Equal(t, 1, ToInt(float32(1)))
-	assert.Equal(t, 1, ToInt(float64(1)))
-	assert.Equal(t, 42, ToInt(42))
-	assert.Equal(t, -1, ToInt(uint64(math.MaxUint64)))
-	assert.Equal(t, 0xFF, ToInt(uint8(math.MaxUint8)))
+	actual, err := ToInt(1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, actual)
 
-	assert.Equal(t, 0, ToInt(nil))
-	assert.Equal(t, 0, ToInt(false))
-	assert.Equal(t, 1, ToInt(true))
-	assert.Equal(t, 0, ToInt(""))
-	assert.Equal(t, 0, ToInt("foo"))
-	assert.Equal(t, 0xFFFF, ToInt("0xFFFF"))
-	assert.Equal(t, 8, ToInt("010"))
-	assert.Equal(t, 4096, ToInt("4,096"))
-	assert.Equal(t, -4096, ToInt("-4,096.00"))
+	actual, err = ToInt(int32(1))
+	require.NoError(t, err)
+	assert.Equal(t, 1, actual)
+
+	actual, err = ToInt(int64(1))
+	require.NoError(t, err)
+	assert.Equal(t, 1, actual)
+
+	actual, err = ToInt(float32(1))
+	require.NoError(t, err)
+	assert.Equal(t, 1, actual)
+
+	actual, err = ToInt(float64(1))
+	require.NoError(t, err)
+	assert.Equal(t, 1, actual)
+
+	actual, err = ToInt(42)
+	require.NoError(t, err)
+	assert.Equal(t, 42, actual)
+
+	actual, err = ToInt(uint64(math.MaxUint64))
+	require.NoError(t, err)
+	assert.Equal(t, -1, actual)
+
+	actual, err = ToInt(uint8(math.MaxUint8))
+	require.NoError(t, err)
+	assert.Equal(t, 0xFF, actual)
+
+	actual, err = ToInt(false)
+	require.NoError(t, err)
+	assert.Equal(t, 0, actual)
+
+	actual, err = ToInt(true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, actual)
+
+	actual, err = ToInt("0xFFFF")
+	require.NoError(t, err)
+	assert.Equal(t, 0xFFFF, actual)
+
+	actual, err = ToInt("010")
+	require.NoError(t, err)
+	assert.Equal(t, 8, actual)
+
+	actual, err = ToInt("4,096")
+	require.NoError(t, err)
+	assert.Equal(t, 4096, actual)
+
+	actual, err = ToInt("-4,096.00")
+	require.NoError(t, err)
+	assert.Equal(t, -4096, actual)
+
+	t.Run("error cases", func(t *testing.T) {
+		_, err = ToInt(nil)
+		require.Error(t, err)
+
+		_, err = ToInt("")
+		require.Error(t, err)
+
+		_, err = ToInt("foo")
+		require.Error(t, err)
+	})
 }
 
 func TestToInt64s(t *testing.T) {
-	assert.Equal(t, []int64{}, ToInt64s())
+	actual, err := ToInt64s()
+	require.NoError(t, err)
+	assert.Equal(t, []int64{}, actual)
 
-	assert.Equal(t, []int64{0}, ToInt64s(""))
-	assert.Equal(t, []int64{0}, ToInt64s("0"))
-	assert.Equal(t, []int64{42, 15}, ToInt64s("42", "15"))
-	assert.Equal(t, []int64{0, 0, 0, 1, 1, 2, 3, 5, 8, 13, -1000},
-		ToInt64s(nil, false, "", true, 1, 2.0, uint8(3), int64(5), float32(8), "13", "-1,000"))
+	actual, err = ToInt64s("0")
+	require.NoError(t, err)
+	assert.Equal(t, []int64{0}, actual)
+
+	actual, err = ToInt64s("42", "15")
+	require.NoError(t, err)
+	assert.Equal(t, []int64{42, 15}, actual)
+
+	actual, err = ToInt64s(false, true, 1, 2.0, uint8(3), int64(5), float32(8), "13", "-1,000")
+	require.NoError(t, err)
+	assert.Equal(t, []int64{0, 1, 1, 2, 3, 5, 8, 13, -1000}, actual)
+
+	t.Run("error cases", func(t *testing.T) {
+		_, err = ToInt64s("")
+		require.Error(t, err)
+
+		_, err = ToInt64s(nil, false, "", true, 1, 2.0, uint8(3), int64(5), float32(8), "13", "-1,000")
+		require.Error(t, err)
+	})
 }
 
 func TestToInts(t *testing.T) {
-	assert.Equal(t, []int{}, ToInts())
+	actual, err := ToInts()
+	require.NoError(t, err)
+	assert.Equal(t, []int{}, actual)
 
-	assert.Equal(t, []int{0}, ToInts(""))
-	assert.Equal(t, []int{0}, ToInts("0"))
-	assert.Equal(t, []int{42, 15}, ToInts("42", "15"))
-	assert.Equal(t, []int{0, 0, 0, 1, 1, 2, 3, 5, 8, 13, 42000},
-		ToInts(nil, false, "", true, 1, 2.0, uint8(3), int64(5), float32(8), "13", "42,000"))
+	actual, err = ToInts("0")
+	require.NoError(t, err)
+	assert.Equal(t, []int{0}, actual)
+
+	actual, err = ToInts("42", "15")
+	require.NoError(t, err)
+	assert.Equal(t, []int{42, 15}, actual)
+
+	actual, err = ToInts(false, true, 1, 2.0, uint8(3), int64(5), float32(8), "13", "42,000")
+	require.NoError(t, err)
+	assert.Equal(t, []int{0, 1, 1, 2, 3, 5, 8, 13, 42000}, actual)
+
+	t.Run("error cases", func(t *testing.T) {
+		_, err = ToInts("")
+		require.Error(t, err)
+
+		_, err = ToInts(nil, false, "", true, 1, 2.0, uint8(3), int64(5), float32(8), "13", "42,000")
+		require.Error(t, err)
+	})
 }
 
 func TestToFloat64(t *testing.T) {
-	z := []interface{}{0, 0.0, nil, false, float32(0), "", "0", "foo", int64(0), uint(0), "0x0", "00", "0,000"}
+	z := []interface{}{nil, "", "foo"}
 	for _, n := range z {
-		assert.Zero(t, ToFloat64(n))
+		_, err := ToFloat64(n)
+		require.Error(t, err)
 	}
-	assert.InEpsilon(t, 1.0, ToFloat64(true), 1e-12)
+
+	z = []interface{}{0, 0.0, false, float32(0), "0", int64(0), uint(0), "0x0", "00", "0,000"}
+	for _, n := range z {
+		actual, err := ToFloat64(n)
+		require.NoError(t, err)
+		assert.Zero(t, actual)
+	}
+
+	actual, err := ToFloat64(true)
+	require.NoError(t, err)
+	assert.InEpsilon(t, 1.0, actual, 1e-12)
+
 	z = []interface{}{42, 42.0, float32(42), "42", "42.0", uint8(42), "0x2A", "052"}
 	for _, n := range z {
-		assert.InEpsilon(t, 42.0, ToFloat64(n), 1e-12)
+		actual, err = ToFloat64(n)
+		require.NoError(t, err)
+		assert.InEpsilon(t, 42.0, actual, 1e-12)
 	}
+
 	z = []interface{}{1000.34, "1000.34", "1,000.34"}
 	for _, n := range z {
-		assert.InEpsilon(t, 1000.34, ToFloat64(n), 1e-12)
+		actual, err = ToFloat64(n)
+		require.NoError(t, err)
+		assert.InEpsilon(t, 1000.34, actual, 1e-12)
 	}
 }
 
 func TestToFloat64s(t *testing.T) {
-	assert.Equal(t, []float64{}, ToFloat64s())
-	assert.Equal(t, []float64{0, 1.0, 2.0, math.Pi, 4.0}, ToFloat64s(nil, true, "2", math.Pi, uint8(4)))
+	actual, err := ToFloat64s()
+	require.NoError(t, err)
+	assert.Equal(t, []float64{}, actual)
+
+	actual, err = ToFloat64s(true, "2", math.Pi, uint8(4))
+	require.NoError(t, err)
+	assert.Equal(t, []float64{1.0, 2.0, math.Pi, 4.0}, actual)
+
+	_, err = ToFloat64s(nil, true, "2", math.Pi, uint8(4))
+	require.Error(t, err)
 }
 
 type foo struct {

--- a/docs-src/content/functions/conv.yml
+++ b/docs-src/content/functions/conv.yml
@@ -301,8 +301,9 @@ funcs:
 
       This function attempts to convert most types of input (strings, numbers,
       and booleans), but behaviour when the input can not be converted is
-      undefined and subject to change. Unconvertable inputs may result in
-      errors, or `0` or `-1`.
+      undefined and subject to change.
+
+      Unconvertable inputs will result in errors.
 
       Floating-point numbers (with decimal points) are truncated.
     arguments:
@@ -326,6 +327,8 @@ funcs:
       on platform). This is similar to [`conv.ToInt64`](#conv-toint64) on 64-bit
       platforms, but is useful when input to another function must be provided
       as an `int`.
+
+      Unconvertable inputs will result in errors.
 
       On 32-bit systems, given a number that is too large to fit in an `int`,
       the result is `-1`. This is done to protect against
@@ -352,6 +355,8 @@ funcs:
     description: |
       Converts the inputs to an array of `int64`s.
 
+      Unconvertable inputs will result in errors.
+
       This delegates to [`conv.ToInt64`](#conv-toint64) for each input argument.
     arguments:
       - name: in...
@@ -365,6 +370,8 @@ funcs:
     released: v2.2.0
     description: |
       Converts the inputs to an array of `int`s.
+
+      Unconvertable inputs will result in errors.
 
       This delegates to [`conv.ToInt`](#conv-toint) for each input argument.
     arguments:
@@ -382,8 +389,9 @@ funcs:
 
       This function attempts to convert most types of input (strings, numbers,
       and booleans), but behaviour when the input can not be converted is
-      undefined and subject to change. Unconvertable inputs may result in
-      errors, or `0` or `-1`.
+      undefined and subject to change.
+      
+      Unconvertable inputs will result in errors.
     arguments:
       - name: in
         required: true
@@ -398,6 +406,8 @@ funcs:
     released: v2.2.0
     description: |
       Converts the inputs to an array of `float64`s.
+
+      Unconvertable inputs will result in errors.
 
       This delegates to [`conv.ToFloat64`](#conv-tofloat64) for each input argument.
     arguments:

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -453,8 +453,9 @@ Converts the input to an `int64` (64-bit signed integer).
 
 This function attempts to convert most types of input (strings, numbers,
 and booleans), but behaviour when the input can not be converted is
-undefined and subject to change. Unconvertable inputs may result in
-errors, or `0` or `-1`.
+undefined and subject to change.
+
+Unconvertable inputs will result in errors.
 
 Floating-point numbers (with decimal points) are truncated.
 
@@ -492,6 +493,8 @@ Converts the input to an `int` (signed integer, 32- or 64-bit depending
 on platform). This is similar to [`conv.ToInt64`](#conv-toint64) on 64-bit
 platforms, but is useful when input to another function must be provided
 as an `int`.
+
+Unconvertable inputs will result in errors.
 
 On 32-bit systems, given a number that is too large to fit in an `int`,
 the result is `-1`. This is done to protect against
@@ -532,6 +535,8 @@ $ gomplate -i '{{conv.ToInt true }}'
 
 Converts the inputs to an array of `int64`s.
 
+Unconvertable inputs will result in errors.
+
 This delegates to [`conv.ToInt64`](#conv-toint64) for each input argument.
 
 _Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
@@ -557,6 +562,8 @@ gomplate -i '{{ conv.ToInt64s true 0x42 "123,456.99" "1.2345e+3"}}'
 ## `conv.ToInts`
 
 Converts the inputs to an array of `int`s.
+
+Unconvertable inputs will result in errors.
 
 This delegates to [`conv.ToInt`](#conv-toint) for each input argument.
 
@@ -586,8 +593,9 @@ Converts the input to a `float64`.
 
 This function attempts to convert most types of input (strings, numbers,
 and booleans), but behaviour when the input can not be converted is
-undefined and subject to change. Unconvertable inputs may result in
-errors, or `0` or `-1`.
+undefined and subject to change.
+
+Unconvertable inputs will result in errors.
 
 _Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
@@ -614,6 +622,8 @@ $ gomplate -i '{{ conv.ToFloat64 "9,000.09"}}'
 ## `conv.ToFloat64s`
 
 Converts the inputs to an array of `float64`s.
+
+Unconvertable inputs will result in errors.
 
 This delegates to [`conv.ToFloat64`](#conv-tofloat64) for each input argument.
 

--- a/internal/funcs/coll.go
+++ b/internal/funcs/coll.go
@@ -153,12 +153,20 @@ func (CollFuncs) Flatten(args ...interface{}) ([]interface{}, error) {
 	if len(args) == 0 || len(args) > 2 {
 		return nil, fmt.Errorf("wrong number of args: wanted 1 or 2, got %d", len(args))
 	}
+
 	list := args[0]
+
+	var err error
 	depth := -1
 	if len(args) == 2 {
-		depth = conv.ToInt(args[0])
+		depth, err = conv.ToInt(list)
+		if err != nil {
+			return nil, fmt.Errorf("wrong depth type: must be int, got %T (%+v)", list, list)
+		}
+
 		list = args[1]
 	}
+
 	return coll.Flatten(list, depth)
 }
 

--- a/internal/funcs/conv.go
+++ b/internal/funcs/conv.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"context"
 	"net/url"
+	"strconv"
 	"text/template"
 
 	"github.com/hairyhenderson/gomplate/v4/conv"
@@ -52,23 +53,23 @@ func (ConvFuncs) Join(in interface{}, sep string) (string, error) {
 }
 
 // ParseInt -
-func (ConvFuncs) ParseInt(s interface{}, base, bitSize int) int64 {
-	return conv.MustParseInt(conv.ToString(s), base, bitSize)
+func (ConvFuncs) ParseInt(s interface{}, base, bitSize int) (int64, error) {
+	return strconv.ParseInt(conv.ToString(s), base, bitSize)
 }
 
 // ParseFloat -
-func (ConvFuncs) ParseFloat(s interface{}, bitSize int) float64 {
-	return conv.MustParseFloat(conv.ToString(s), bitSize)
+func (ConvFuncs) ParseFloat(s interface{}, bitSize int) (float64, error) {
+	return strconv.ParseFloat(conv.ToString(s), bitSize)
 }
 
 // ParseUint -
-func (ConvFuncs) ParseUint(s interface{}, base, bitSize int) uint64 {
-	return conv.MustParseUint(conv.ToString(s), base, bitSize)
+func (ConvFuncs) ParseUint(s interface{}, base, bitSize int) (uint64, error) {
+	return strconv.ParseUint(conv.ToString(s), base, bitSize)
 }
 
 // Atoi -
-func (ConvFuncs) Atoi(s interface{}) int {
-	return conv.MustAtoi(conv.ToString(s))
+func (ConvFuncs) Atoi(s interface{}) (int, error) {
+	return strconv.Atoi(conv.ToString(s))
 }
 
 // URL -
@@ -77,32 +78,32 @@ func (ConvFuncs) URL(s interface{}) (*url.URL, error) {
 }
 
 // ToInt64 -
-func (ConvFuncs) ToInt64(in interface{}) int64 {
+func (ConvFuncs) ToInt64(in interface{}) (int64, error) {
 	return conv.ToInt64(in)
 }
 
 // ToInt -
-func (ConvFuncs) ToInt(in interface{}) int {
+func (ConvFuncs) ToInt(in interface{}) (int, error) {
 	return conv.ToInt(in)
 }
 
 // ToInt64s -
-func (ConvFuncs) ToInt64s(in ...interface{}) []int64 {
+func (ConvFuncs) ToInt64s(in ...interface{}) ([]int64, error) {
 	return conv.ToInt64s(in...)
 }
 
 // ToInts -
-func (ConvFuncs) ToInts(in ...interface{}) []int {
+func (ConvFuncs) ToInts(in ...interface{}) ([]int, error) {
 	return conv.ToInts(in...)
 }
 
 // ToFloat64 -
-func (ConvFuncs) ToFloat64(in interface{}) float64 {
+func (ConvFuncs) ToFloat64(in interface{}) (float64, error) {
 	return conv.ToFloat64(in)
 }
 
 // ToFloat64s -
-func (ConvFuncs) ToFloat64s(in ...interface{}) []float64 {
+func (ConvFuncs) ToFloat64s(in ...interface{}) ([]float64, error) {
 	return conv.ToFloat64s(in...)
 }
 
@@ -121,5 +122,6 @@ func (ConvFuncs) Default(def, in interface{}) interface{} {
 	if truth, ok := template.IsTrue(in); truth && ok {
 		return in
 	}
+
 	return def
 }

--- a/internal/funcs/math_test.go
+++ b/internal/funcs/math_test.go
@@ -32,33 +32,78 @@ func TestAdd(t *testing.T) {
 	t.Parallel()
 
 	m := MathFuncs{}
-	assert.Equal(t, int64(12), m.Add(1, 1, 2, 3, 5))
-	assert.Equal(t, int64(2), m.Add(1, 1))
-	assert.Equal(t, int64(1), m.Add(1))
-	assert.Equal(t, int64(0), m.Add(-5, 5))
-	assert.InEpsilon(t, float64(5.1), m.Add(4.9, "0.2"), 1e-12)
+
+	actual, err := m.Add(1, 1, 2, 3, 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(12), actual)
+
+	actual, err = m.Add(1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), actual)
+
+	actual, err = m.Add(1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = m.Add(-5, 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), actual)
+
+	actual, err = m.Add(4.9, "0.2")
+	require.NoError(t, err)
+	assert.InEpsilon(t, float64(5.1), actual, 1e-12)
 }
 
 func TestMul(t *testing.T) {
 	t.Parallel()
 
 	m := MathFuncs{}
-	assert.Equal(t, int64(30), m.Mul(1, 1, 2, 3, 5))
-	assert.Equal(t, int64(1), m.Mul(1, 1))
-	assert.Equal(t, int64(1), m.Mul(1))
-	assert.Equal(t, int64(-25), m.Mul("-5", 5))
-	assert.Equal(t, int64(28), m.Mul(14, "2"))
-	assert.InEpsilon(t, float64(0.5), m.Mul("-1", -0.5), 1e-12)
+
+	actual, err := m.Mul(1, 1, 2, 3, 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(30), actual)
+
+	actual, err = m.Mul(1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = m.Mul(1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), actual)
+
+	actual, err = m.Mul("-5", 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(-25), actual)
+
+	actual, err = m.Mul(14, "2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(28), actual)
+
+	actual, err = m.Mul("-1", -0.5)
+	require.NoError(t, err)
+	assert.InEpsilon(t, float64(0.5), actual, 1e-12)
 }
 
 func TestSub(t *testing.T) {
 	t.Parallel()
 
 	m := MathFuncs{}
-	assert.Equal(t, int64(0), m.Sub(1, 1))
-	assert.Equal(t, int64(-10), m.Sub(-5, 5))
-	assert.Equal(t, int64(-41), m.Sub(true, "42"))
-	assert.InEpsilon(t, -5.3, m.Sub(10, 15.3), 1e-12)
+
+	actual, err := m.Sub(1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), actual)
+
+	actual, err = m.Sub(-5, 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(-10), actual)
+
+	actual, err = m.Sub(true, "42")
+	require.NoError(t, err)
+	assert.Equal(t, int64(-41), actual)
+
+	actual, err = m.Sub(10, 15.3)
+	require.NoError(t, err)
+	assert.InEpsilon(t, -5.3, actual, 1e-12)
 }
 
 func mustDiv(a, b interface{}) interface{} {
@@ -86,16 +131,28 @@ func TestRem(t *testing.T) {
 	t.Parallel()
 
 	m := MathFuncs{}
-	assert.Equal(t, int64(0), m.Rem(1, 1))
-	assert.Equal(t, int64(2), m.Rem(5, 3.0))
+
+	actual, err := m.Rem(1, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), actual)
+
+	actual, err = m.Rem(5, 3.0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), actual)
 }
 
 func TestPow(t *testing.T) {
 	t.Parallel()
 
 	m := MathFuncs{}
-	assert.Equal(t, int64(4), m.Pow(2, "2"))
-	assert.InEpsilon(t, 2.25, m.Pow(1.5, 2), 1e-12)
+
+	actual, err := m.Pow(2, "2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), actual)
+
+	actual, err = m.Pow(1.5, 2)
+	require.NoError(t, err)
+	assert.InEpsilon(t, 2.25, actual, 1e-12)
 }
 
 func mustSeq(t *testing.T, n ...interface{}) []int64 {
@@ -161,6 +218,7 @@ func TestIsIntFloatNum(t *testing.T) {
 		{nil, false, false},
 		{true, false, false},
 	}
+
 	m := MathFuncs{}
 	for _, tt := range tests {
 		tt := tt
@@ -178,6 +236,7 @@ func BenchmarkIsFloat(b *testing.B) {
 	data := []interface{}{
 		0, 1, -1, uint(42), uint8(255), uint16(42), uint32(42), uint64(42), int(42), int8(127), int16(42), int32(42), int64(42), float32(18.3), float64(18.3), 1.5, -18.6, "42", "052", "0xff", "-42", "-0", "3.14", "-3.14", "0.00", "NaN", "-Inf", "+Inf", "", "foo", nil, true,
 	}
+
 	m := MathFuncs{}
 	for _, n := range data {
 		n := n
@@ -197,9 +256,7 @@ func TestMax(t *testing.T) {
 		expected interface{}
 		n        []interface{}
 	}{
-		{int64(0), []interface{}{nil}},
 		{int64(0), []interface{}{0}},
-		{int64(0), []interface{}{"not a number"}},
 		{int64(1), []interface{}{1}},
 		{int64(-1), []interface{}{-1}},
 		{int64(1), []interface{}{-1, 0, 1}},
@@ -220,6 +277,19 @@ func TestMax(t *testing.T) {
 			assert.Equal(t, d.expected, actual)
 		})
 	}
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := m.Max("foo")
+		require.Error(t, err)
+
+		_, err = m.Max(nil)
+		require.Error(t, err)
+
+		_, err = m.Max("")
+		require.Error(t, err)
+	})
 }
 
 func TestMin(t *testing.T) {
@@ -230,9 +300,7 @@ func TestMin(t *testing.T) {
 		expected interface{}
 		n        []interface{}
 	}{
-		{int64(0), []interface{}{nil}},
 		{int64(0), []interface{}{0}},
-		{int64(0), []interface{}{"not a number"}},
 		{int64(1), []interface{}{1}},
 		{int64(-1), []interface{}{-1}},
 		{int64(-1), []interface{}{-1, 0, 1}},
@@ -250,9 +318,23 @@ func TestMin(t *testing.T) {
 			} else {
 				actual, _ = m.Min(d.n[0], d.n[1:]...)
 			}
+
 			assert.Equal(t, d.expected, actual)
 		})
 	}
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := m.Min("foo")
+		require.Error(t, err)
+
+		_, err = m.Min(nil)
+		require.Error(t, err)
+
+		_, err = m.Min("")
+		require.Error(t, err)
+	})
 }
 
 func TestContainsFloat(t *testing.T) {
@@ -297,8 +379,6 @@ func TestCeil(t *testing.T) {
 		n interface{}
 		a float64
 	}{
-		{"", 0.},
-		{nil, 0.},
 		{"Inf", gmath.Inf(1)},
 		{0, 0.},
 		{4.99, 5.},
@@ -310,9 +390,24 @@ func TestCeil(t *testing.T) {
 		t.Run(fmt.Sprintf("%v==%v", d.n, d.a), func(t *testing.T) {
 			t.Parallel()
 
-			assert.InDelta(t, d.a, m.Ceil(d.n), 1e-12)
+			actual, err := m.Ceil(d.n)
+			require.NoError(t, err)
+			assert.InDelta(t, d.a, actual, 1e-12)
 		})
 	}
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := m.Ceil("foo")
+		require.Error(t, err)
+
+		_, err = m.Ceil(nil)
+		require.Error(t, err)
+
+		_, err = m.Ceil("")
+		require.Error(t, err)
+	})
 }
 
 func TestFloor(t *testing.T) {
@@ -323,8 +418,6 @@ func TestFloor(t *testing.T) {
 		n interface{}
 		a float64
 	}{
-		{"", 0.},
-		{nil, 0.},
 		{"Inf", gmath.Inf(1)},
 		{0, 0.},
 		{4.99, 4.},
@@ -336,9 +429,24 @@ func TestFloor(t *testing.T) {
 		t.Run(fmt.Sprintf("%v==%v", d.n, d.a), func(t *testing.T) {
 			t.Parallel()
 
-			assert.InDelta(t, d.a, m.Floor(d.n), 1e-12)
+			actual, err := m.Floor(d.n)
+			require.NoError(t, err)
+			assert.InDelta(t, d.a, actual, 1e-12)
 		})
 	}
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := m.Floor("foo")
+		require.Error(t, err)
+
+		_, err = m.Floor(nil)
+		require.Error(t, err)
+
+		_, err = m.Floor("")
+		require.Error(t, err)
+	})
 }
 
 func TestRound(t *testing.T) {
@@ -349,8 +457,6 @@ func TestRound(t *testing.T) {
 		n interface{}
 		a float64
 	}{
-		{"", 0.},
-		{nil, 0.},
 		{"Inf", gmath.Inf(1)},
 		{0, 0.},
 		{4.99, 5},
@@ -366,9 +472,24 @@ func TestRound(t *testing.T) {
 		t.Run(fmt.Sprintf("%v==%v", d.n, d.a), func(t *testing.T) {
 			t.Parallel()
 
-			assert.InDelta(t, d.a, m.Round(d.n), 1e-12)
+			actual, err := m.Round(d.n)
+			require.NoError(t, err)
+			assert.InDelta(t, d.a, actual, 1e-12)
 		})
 	}
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := m.Round("foo")
+		require.Error(t, err)
+
+		_, err = m.Round(nil)
+		require.Error(t, err)
+
+		_, err = m.Round("")
+		require.Error(t, err)
+	})
 }
 
 func TestAbs(t *testing.T) {
@@ -379,8 +500,6 @@ func TestAbs(t *testing.T) {
 		n interface{}
 		a interface{}
 	}{
-		{"", 0.},
-		{nil, 0.},
 		{"-Inf", gmath.Inf(1)},
 		{0, int64(0)},
 		{0., 0.},
@@ -395,7 +514,22 @@ func TestAbs(t *testing.T) {
 		t.Run(fmt.Sprintf("%#v==%v", d.n, d.a), func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, d.a, m.Abs(d.n))
+			actual, err := m.Abs(d.n)
+			require.NoError(t, err)
+			assert.Equal(t, d.a, actual)
 		})
 	}
+
+	t.Run("error cases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := m.Abs("foo")
+		require.Error(t, err)
+
+		_, err = m.Abs(nil)
+		require.Error(t, err)
+
+		_, err = m.Abs("")
+		require.Error(t, err)
+	})
 }

--- a/internal/funcs/net.go
+++ b/internal/funcs/net.go
@@ -132,7 +132,12 @@ func (f *NetFuncs) CIDRHost(hostnum interface{}, prefix interface{}) (netip.Addr
 		return netip.Addr{}, err
 	}
 
-	ip, err := cidr.HostBig(network, big.NewInt(conv.ToInt64(hostnum)))
+	n, err := conv.ToInt64(hostnum)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("expected a number: %w", err)
+	}
+
+	ip, err := cidr.HostBig(network, big.NewInt(n))
 
 	return ip, err
 }
@@ -175,7 +180,11 @@ func (f *NetFuncs) CIDRSubnets(newbits interface{}, prefix interface{}) ([]netip
 		return nil, err
 	}
 
-	nBits := conv.ToInt(newbits)
+	nBits, err := conv.ToInt(newbits)
+	if err != nil {
+		return nil, fmt.Errorf("newbits must be a number: %w", err)
+	}
+
 	if nBits < 1 {
 		return nil, fmt.Errorf("must extend prefix by at least one bit")
 	}
@@ -208,7 +217,11 @@ func (f *NetFuncs) CIDRSubnetSizes(args ...interface{}) ([]netip.Prefix, error) 
 	if err != nil {
 		return nil, err
 	}
-	newbits := conv.ToInts(args[:len(args)-1]...)
+
+	newbits, err := conv.ToInts(args[:len(args)-1]...)
+	if err != nil {
+		return nil, fmt.Errorf("newbits must be numbers: %w", err)
+	}
 
 	startPrefixLen := network.Bits()
 	firstLength := newbits[0]

--- a/internal/funcs/random.go
+++ b/internal/funcs/random.go
@@ -26,25 +26,45 @@ type RandomFuncs struct {
 
 // ASCII -
 func (RandomFuncs) ASCII(count interface{}) (string, error) {
-	return random.StringBounds(conv.ToInt(count), ' ', '~')
+	n, err := conv.ToInt(count)
+	if err != nil {
+		return "", fmt.Errorf("count must be an integer: %w", err)
+	}
+
+	return random.StringBounds(n, ' ', '~')
 }
 
 // Alpha -
 func (RandomFuncs) Alpha(count interface{}) (string, error) {
-	return random.StringRE(conv.ToInt(count), "[[:alpha:]]")
+	n, err := conv.ToInt(count)
+	if err != nil {
+		return "", fmt.Errorf("count must be an integer: %w", err)
+	}
+
+	return random.StringRE(n, "[[:alpha:]]")
 }
 
 // AlphaNum -
 func (RandomFuncs) AlphaNum(count interface{}) (string, error) {
-	return random.StringRE(conv.ToInt(count), "[[:alnum:]]")
+	n, err := conv.ToInt(count)
+	if err != nil {
+		return "", fmt.Errorf("count must be an integer: %w", err)
+	}
+
+	return random.StringRE(n, "[[:alnum:]]")
 }
 
 // String -
-func (RandomFuncs) String(count interface{}, args ...interface{}) (s string, err error) {
-	c := conv.ToInt(count)
+func (RandomFuncs) String(count interface{}, args ...interface{}) (string, error) {
+	c, err := conv.ToInt(count)
+	if err != nil {
+		return "", fmt.Errorf("count must be an integer: %w", err)
+	}
+
 	if c == 0 {
 		return "", fmt.Errorf("count must be greater than 0")
 	}
+
 	m := ""
 	switch len(args) {
 	case 0:
@@ -59,8 +79,17 @@ func (RandomFuncs) String(count interface{}, args ...interface{}) (s string, err
 				return "", err
 			}
 		} else {
-			l = rune(conv.ToInt(args[0]))
-			u = rune(conv.ToInt(args[1]))
+			nl, err := conv.ToInt(args[0])
+			if err != nil {
+				return "", fmt.Errorf("lower must be an integer: %w", err)
+			}
+
+			nu, err := conv.ToInt(args[1])
+			if err != nil {
+				return "", fmt.Errorf("upper must be an integer: %w", err)
+			}
+
+			l, u = rune(nl), rune(nu)
 		}
 
 		return random.StringBounds(c, l, u)
@@ -114,14 +143,28 @@ func (RandomFuncs) Item(items interface{}) (interface{}, error) {
 func (RandomFuncs) Number(args ...interface{}) (int64, error) {
 	var min, max int64
 	min, max = 0, 100
+
+	var err error
+
 	switch len(args) {
 	case 0:
 	case 1:
-		max = conv.ToInt64(args[0])
+		max, err = conv.ToInt64(args[0])
+		if err != nil {
+			return 0, fmt.Errorf("max must be a number: %w", err)
+		}
 	case 2:
-		min = conv.ToInt64(args[0])
-		max = conv.ToInt64(args[1])
+		min, err = conv.ToInt64(args[0])
+		if err != nil {
+			return 0, fmt.Errorf("min must be a number: %w", err)
+		}
+
+		max, err = conv.ToInt64(args[1])
+		if err != nil {
+			return 0, fmt.Errorf("max must be a number: %w", err)
+		}
 	}
+
 	return random.Number(min, max)
 }
 
@@ -129,13 +172,27 @@ func (RandomFuncs) Number(args ...interface{}) (int64, error) {
 func (RandomFuncs) Float(args ...interface{}) (float64, error) {
 	var min, max float64
 	min, max = 0, 1.0
+
+	var err error
+
 	switch len(args) {
 	case 0:
 	case 1:
-		max = conv.ToFloat64(args[0])
+		max, err = conv.ToFloat64(args[0])
+		if err != nil {
+			return 0, fmt.Errorf("max must be a number: %w", err)
+		}
 	case 2:
-		min = conv.ToFloat64(args[0])
-		max = conv.ToFloat64(args[1])
+		min, err = conv.ToFloat64(args[0])
+		if err != nil {
+			return 0, fmt.Errorf("min must be a number: %w", err)
+		}
+
+		max, err = conv.ToFloat64(args[1])
+		if err != nil {
+			return 0, fmt.Errorf("max must be a number: %w", err)
+		}
 	}
+
 	return random.Float(min, max)
 }

--- a/internal/funcs/regexp.go
+++ b/internal/funcs/regexp.go
@@ -31,6 +31,7 @@ func (ReFuncs) FindAll(args ...interface{}) ([]string, error) {
 	re := ""
 	n := 0
 	input := ""
+
 	switch len(args) {
 	case 2:
 		n = -1
@@ -38,11 +39,18 @@ func (ReFuncs) FindAll(args ...interface{}) ([]string, error) {
 		input = conv.ToString(args[1])
 	case 3:
 		re = conv.ToString(args[0])
-		n = conv.ToInt(args[1])
+
+		var err error
+		n, err = conv.ToInt(args[1])
+		if err != nil {
+			return nil, fmt.Errorf("n must be an integer: %w", err)
+		}
+
 		input = conv.ToString(args[2])
 	default:
 		return nil, fmt.Errorf("wrong number of args: want 2 or 3, got %d", len(args))
 	}
+
 	return regexp.FindAll(re, n, input)
 }
 
@@ -75,16 +83,23 @@ func (ReFuncs) Split(args ...interface{}) ([]string, error) {
 	re := ""
 	n := -1
 	input := ""
+
 	switch len(args) {
 	case 2:
 		re = conv.ToString(args[0])
 		input = conv.ToString(args[1])
 	case 3:
 		re = conv.ToString(args[0])
-		n = conv.ToInt(args[1])
+		var err error
+		n, err = conv.ToInt(args[1])
+		if err != nil {
+			return nil, fmt.Errorf("n must be an integer: %w", err)
+		}
+
 		input = conv.ToString(args[2])
 	default:
 		return nil, fmt.Errorf("wrong number of args: want 2 or 3, got %d", len(args))
 	}
+
 	return regexp.Split(re, n, input)
 }

--- a/internal/funcs/strings.go
+++ b/internal/funcs/strings.go
@@ -115,23 +115,39 @@ func (f *StringFuncs) oldTrim(s, cutset string) string {
 func (StringFuncs) Abbrev(args ...interface{}) (string, error) {
 	str := ""
 	offset := 0
-	maxWidth := 0
-	if len(args) < 2 {
-		return "", fmt.Errorf("abbrev requires a 'maxWidth' and 'input' argument")
-	}
-	if len(args) == 2 {
-		maxWidth = conv.ToInt(args[0])
+	width := 0
+
+	var err error
+
+	switch len(args) {
+	case 2:
+		width, err = conv.ToInt(args[0])
+		if err != nil {
+			return "", fmt.Errorf("width must be an integer: %w", err)
+		}
+
 		str = conv.ToString(args[1])
-	}
-	if len(args) == 3 {
-		offset = conv.ToInt(args[0])
-		maxWidth = conv.ToInt(args[1])
+	case 3:
+		offset, err = conv.ToInt(args[0])
+		if err != nil {
+			return "", fmt.Errorf("offset must be an integer: %w", err)
+		}
+
+		width, err = conv.ToInt(args[1])
+		if err != nil {
+			return "", fmt.Errorf("width must be an integer: %w", err)
+		}
+
 		str = conv.ToString(args[2])
+	default:
+		return "", fmt.Errorf("abbrev requires a 'width' and 'input' argument")
 	}
-	if len(str) <= maxWidth {
+
+	if len(str) <= width {
 		return str, nil
 	}
-	return goutils.AbbreviateFull(str, offset, maxWidth)
+
+	return goutils.AbbreviateFull(str, offset, width)
 }
 
 // ReplaceAll -
@@ -342,13 +358,25 @@ func (StringFuncs) WordWrap(args ...interface{}) (string, error) {
 		case string:
 			opts.LBSeq = a
 		default:
-			opts.Width = uint(conv.ToInt(a))
+			n, err := conv.ToInt(args[0])
+			if err != nil {
+				return "", fmt.Errorf("expected width to be a number: %w", err)
+			}
+
+			opts.Width = uint(n)
 		}
 	}
+
 	if len(args) == 3 {
-		opts.Width = uint(conv.ToInt(args[0]))
+		n, err := conv.ToInt(args[0])
+		if err != nil {
+			return "", fmt.Errorf("expected width to be a number: %w", err)
+		}
+
+		opts.Width = uint(n)
 		opts.LBSeq = conv.ToString(args[1])
 	}
+
 	return gompstrings.WordWrap(in, opts), nil
 }
 

--- a/internal/funcs/time.go
+++ b/internal/funcs/time.go
@@ -104,33 +104,63 @@ func (TimeFuncs) Unix(in interface{}) (gotime.Time, error) {
 }
 
 // Nanosecond -
-func (TimeFuncs) Nanosecond(n interface{}) gotime.Duration {
-	return gotime.Nanosecond * gotime.Duration(conv.ToInt64(n))
+func (TimeFuncs) Nanosecond(n interface{}) (gotime.Duration, error) {
+	in, err := conv.ToInt64(n)
+	if err != nil {
+		return 0, fmt.Errorf("expected a number: %w", err)
+	}
+
+	return gotime.Nanosecond * gotime.Duration(in), nil
 }
 
 // Microsecond -
-func (TimeFuncs) Microsecond(n interface{}) gotime.Duration {
-	return gotime.Microsecond * gotime.Duration(conv.ToInt64(n))
+func (TimeFuncs) Microsecond(n interface{}) (gotime.Duration, error) {
+	in, err := conv.ToInt64(n)
+	if err != nil {
+		return 0, fmt.Errorf("expected a number: %w", err)
+	}
+
+	return gotime.Microsecond * gotime.Duration(in), nil
 }
 
 // Millisecond -
-func (TimeFuncs) Millisecond(n interface{}) gotime.Duration {
-	return gotime.Millisecond * gotime.Duration(conv.ToInt64(n))
+func (TimeFuncs) Millisecond(n interface{}) (gotime.Duration, error) {
+	in, err := conv.ToInt64(n)
+	if err != nil {
+		return 0, fmt.Errorf("expected a number: %w", err)
+	}
+
+	return gotime.Millisecond * gotime.Duration(in), nil
 }
 
 // Second -
-func (TimeFuncs) Second(n interface{}) gotime.Duration {
-	return gotime.Second * gotime.Duration(conv.ToInt64(n))
+func (TimeFuncs) Second(n interface{}) (gotime.Duration, error) {
+	in, err := conv.ToInt64(n)
+	if err != nil {
+		return 0, fmt.Errorf("expected a number: %w", err)
+	}
+
+	return gotime.Second * gotime.Duration(in), nil
 }
 
 // Minute -
-func (TimeFuncs) Minute(n interface{}) gotime.Duration {
-	return gotime.Minute * gotime.Duration(conv.ToInt64(n))
+func (TimeFuncs) Minute(n interface{}) (gotime.Duration, error) {
+	in, err := conv.ToInt64(n)
+	if err != nil {
+		return 0, fmt.Errorf("expected a number: %w", err)
+	}
+
+	return gotime.Minute * gotime.Duration(in), nil
 }
 
 // Hour -
-func (TimeFuncs) Hour(n interface{}) gotime.Duration {
-	return gotime.Hour * gotime.Duration(conv.ToInt64(n))
+func (TimeFuncs) Hour(n interface{}) (gotime.Duration, error) {
+	in, err := conv.ToInt64(n)
+	if err != nil {
+		return 0, fmt.Errorf("expected a number: %w", err)
+	}
+
+	return gotime.Hour * gotime.Duration(in), nil
 }
 
 // ParseDuration -

--- a/internal/tests/integration/math_test.go
+++ b/internal/tests/integration/math_test.go
@@ -13,8 +13,9 @@ func TestMath(t *testing.T) {
 	inOutTest(t, `{{ math.Pow 8 4 }} {{ pow 2 2 }}`, "4096 4")
 	inOutTest(t, `{{ math.Seq 0 }}, {{ seq 0 3 }}, {{ seq -5 -10 2 }}`,
 		`[1 0], [0 1 2 3], [-5 -7 -9]`)
-	inOutTest(t, `{{ math.Round 0.99 }}, {{ math.Round "foo" }}, {{math.Round 3.5}}`,
-		`1, 0, 4`)
+	inOutTest(t, `{{ math.Round 0.99 }}, {{math.Round 3.5}}`, `1, 4`)
 	inOutTest(t, `{{ math.Max -0 "+Inf" "NaN" }}, {{ math.Max 3.4 3.401 3.399 }}`,
 		`+Inf, 3.401`)
+
+	inOutContainsError(t, `{{ math.Round "foo" }}`, `could not convert \"foo\"`)
 }


### PR DESCRIPTION
This is a breaking change, but will result in more correct rendering.

Instead of quietly returning `0`, a number of functions in the `conv` namespace will now return an error if the input is invalid.

This includes:
- `conv.ToInt64`, `conv.ToInt`, `conv.ToInt64s`, `conv.ToInts`, `conv.ToFloat64`, `conv.ToFloat64s`, `conv.ParseInt`, `conv.ParseFloat`, `conv.ParseUint`, `conv.Atoi`

Because these functions are used by some other functions, this introduces stricter input validation for these functions:

- `coll.Flatten`
- `crypto.PBKDF2`, `crypto.Bcrypt`, `crypto.RSAGenerateKey`, `crypto.EncryptAES`, `crypto.DecryptAES`, `crypto.DecryptAESBytes`
- `math.Abs`, `math.Add`, `math.Mul`, `math.Sub`, `math.Div`, `math.Rem`, `math.Pow`, `math.Seq`, `math.Max`, `math.Min`, `math.Ceil`, `math.Floor`, `math.Round`
- `net.CIDRHost`, `net.CIDRSubnets`, `net.CIDRSubnetSizes`
- `random.ASCII`, `random.Alpha`, `random.AlphaNum`, `random.String`, `random.Number`, `random.Float`
- `regexp.FindAll`, `regexp.Split`
- `strings.Abbrev`, `strings.WordWrap`
- `time.Nanosecond`, `time.Microsecond`, `time.Millisecond`, `time.Second`, `time.Minute`, `time.Hour`