### PR TITLE
chore(api)!: Return errors instead of panicking on regexp functions

### DIFF
--- a/internal/funcs/regexp.go
+++ b/internal/funcs/regexp.go
@@ -47,7 +47,7 @@ func (ReFuncs) FindAll(args ...interface{}) ([]string, error) {
 }
 
 // Match -
-func (ReFuncs) Match(re, input interface{}) bool {
+func (ReFuncs) Match(re, input interface{}) (bool, error) {
 	return regexp.Match(conv.ToString(re), conv.ToString(input))
 }
 
@@ -57,7 +57,7 @@ func (ReFuncs) QuoteMeta(in interface{}) string {
 }
 
 // Replace -
-func (ReFuncs) Replace(re, replacement, input interface{}) string {
+func (ReFuncs) Replace(re, replacement, input interface{}) (string, error) {
 	return regexp.Replace(conv.ToString(re),
 		conv.ToString(replacement),
 		conv.ToString(input))

--- a/internal/funcs/regexp_test.go
+++ b/internal/funcs/regexp_test.go
@@ -30,14 +30,20 @@ func TestReplace(t *testing.T) {
 	t.Parallel()
 
 	re := &ReFuncs{}
-	assert.Equal(t, "hello world", re.Replace("i", "ello", "hi world"))
+
+	actual, err := re.Replace("i", "ello", "hi world")
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", actual)
 }
 
 func TestMatch(t *testing.T) {
 	t.Parallel()
 
 	re := &ReFuncs{}
-	assert.True(t, re.Match(`i\ `, "hi world"))
+
+	actual, err := re.Match(`i\ `, "hi world")
+	require.NoError(t, err)
+	assert.True(t, actual)
 }
 
 func TestFind(t *testing.T) {

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -1,7 +1,10 @@
 // Package regexp contains functions for dealing with regular expressions
 package regexp
 
-import stdre "regexp"
+import (
+	"fmt"
+	stdre "regexp"
+)
 
 // Find -
 func Find(expression, input string) (string, error) {
@@ -22,9 +25,13 @@ func FindAll(expression string, n int, input string) ([]string, error) {
 }
 
 // Match -
-func Match(expression, input string) bool {
-	re := stdre.MustCompile(expression)
-	return re.MatchString(input)
+func Match(expression, input string) (bool, error) {
+	re, err := stdre.Compile(expression)
+	if err != nil {
+		return false, fmt.Errorf("error compiling expression: %w", err)
+	}
+
+	return re.MatchString(input), nil
 }
 
 // QuoteMeta -
@@ -33,16 +40,20 @@ func QuoteMeta(input string) string {
 }
 
 // Replace -
-func Replace(expression, replacement, input string) string {
-	re := stdre.MustCompile(expression)
-	return re.ReplaceAllString(input, replacement)
+func Replace(expression, replacement, input string) (string, error) {
+	re, err := stdre.Compile(expression)
+	if err != nil {
+		return "", fmt.Errorf("error compiling expression: %w", err)
+	}
+
+	return re.ReplaceAllString(input, replacement), nil
 }
 
 // ReplaceLiteral -
 func ReplaceLiteral(expression, replacement, input string) (string, error) {
 	re, err := stdre.Compile(expression)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error compiling expression: %w", err)
 	}
 	return re.ReplaceAllLiteralString(input, replacement), nil
 }
@@ -51,7 +62,8 @@ func ReplaceLiteral(expression, replacement, input string) (string, error) {
 func Split(expression string, n int, input string) ([]string, error) {
 	re, err := stdre.Compile(expression)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error compiling expression: %w", err)
 	}
+
 	return re.Split(input, n), nil
 }

--- a/regexp/regexp_test.go
+++ b/regexp/regexp_test.go
@@ -40,10 +40,21 @@ func TestFindAll(t *testing.T) {
 }
 
 func TestMatch(t *testing.T) {
-	assert.True(t, Match(`^[a-z]+\[[0-9]+\]$`, "adam[23]"))
-	assert.True(t, Match(`^[a-z]+\[[0-9]+\]$`, "eve[7]"))
-	assert.False(t, Match(`^[a-z]+\[[0-9]+\]$`, "Job[48]"))
-	assert.False(t, Match(`^[a-z]+\[[0-9]+\]$`, "snakey"))
+	actual, err := Match(`^[a-z]+\[[0-9]+\]$`, "adam[23]")
+	require.NoError(t, err)
+	assert.True(t, actual)
+
+	actual, err = Match(`^[a-z]+\[[0-9]+\]$`, "eve[7]")
+	require.NoError(t, err)
+	assert.True(t, actual)
+
+	actual, err = Match(`^[a-z]+\[[0-9]+\]$`, "Job[48]")
+	require.NoError(t, err)
+	assert.False(t, actual)
+
+	actual, err = Match(`^[a-z]+\[[0-9]+\]$`, "snakey")
+	require.NoError(t, err)
+	assert.False(t, actual)
 }
 
 func TestReplace(t *testing.T) {
@@ -60,7 +71,9 @@ func TestReplace(t *testing.T) {
 		{"Turing, Alan", "(?P<first>[a-zA-Z]+) (?P<last>[a-zA-Z]+)", "${last}, ${first}", "Alan Turing"},
 	}
 	for _, d := range testdata {
-		assert.Equal(t, d.expected, Replace(d.expression, d.replacement, d.input))
+		actual, err := Replace(d.expression, d.replacement, d.input)
+		require.NoError(t, err)
+		assert.Equal(t, d.expected, actual)
 	}
 }
 


### PR DESCRIPTION
Previously, when an invalid regular expression was given to `regex.Replace` or `regex.Match`, the functions would panic. Now, the functions return an error instead.