### PR TITLE
chore(api)!: Unexport some Config methods

### DIFF
--- a/gomplate.go
+++ b/gomplate.go
@@ -20,9 +20,9 @@ func Run(ctx context.Context, cfg *Config) error {
 	Metrics = newMetrics()
 
 	// apply defaults before validation
-	cfg.ApplyDefaults()
+	cfg.applyDefaults()
 
-	err := cfg.Validate()
+	err := cfg.validate()
 	if err != nil {
 		return fmt.Errorf("failed to validate config: %w\n%+v", err, cfg)
 	}

--- a/template.go
+++ b/template.go
@@ -45,7 +45,7 @@ func copyFuncMap(funcMap template.FuncMap) template.FuncMap {
 
 // gatherTemplates - gather and prepare templates for rendering
 func gatherTemplates(ctx context.Context, cfg *Config, outFileNamer outputNamer) ([]Template, error) {
-	mode, modeOverride, err := cfg.GetMode()
+	mode, modeOverride, err := cfg.getMode()
 	if err != nil {
 		return nil, err
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -75,7 +75,7 @@ func TestGatherTemplates(t *testing.T) {
 		Stdin:  &bytes.Buffer{},
 		Stdout: &bytes.Buffer{},
 	}
-	cfg.ApplyDefaults()
+	cfg.applyDefaults()
 	templates, err := gatherTemplates(ctx, cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, templates, 1)
@@ -85,7 +85,7 @@ func TestGatherTemplates(t *testing.T) {
 		Input:  "foo",
 		Stdout: buf,
 	}
-	cfg.ApplyDefaults()
+	cfg.applyDefaults()
 	templates, err = gatherTemplates(ctx, cfg, nil)
 	require.NoError(t, err)
 	assert.Len(t, templates, 1)


### PR DESCRIPTION
When I merged #2094 I didn't mean to export all of `Config`'s methods - the ones only needed for parsing don't need to be exported.