### PR TITLE
Fix example for Strings.Trim

### DIFF
--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -665,7 +665,7 @@ input | strings.Trim cutset
 ### Examples
 
 ```console
-$ gomplate -i '{{ "_-foo-_" | strings.Trim "_-" }}
+$ gomplate -i '{{ "_-foo-_" | strings.Trim "_-" }}'
 foo
 ```
 


### PR DESCRIPTION
Minor doc update: The current example is missing a trailing `'`.