### PR TITLE
docs: Sync fix from #2107 to source

### DIFF
--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -419,7 +419,7 @@ funcs:
         description: the input
     examples:
       - |
-        $ gomplate -i '{{ "_-foo-_" | strings.Trim "_-" }}
+        $ gomplate -i '{{ "_-foo-_" | strings.Trim "_-" }}'
         foo
   - name: strings.TrimPrefix
     released: v2.5.0


### PR DESCRIPTION
Missed in #2107 - the fix needs to be in the source the docs were generated from too!