### PR TITLE
feat: Add ability to override 'type' query parameter name

### DIFF
--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -127,6 +127,13 @@ $ gomplate -d data=file:///tmp/data.txt?type=application/json -i '{{ (ds "data")
 bar
 ```
 
+If you need to provide a query parameter named `type` to the data source, set the `GOMPLATE_TYPE_PARAM` environment variable to another value:
+
+```console
+$ GOMPLATE_TYPE_PARAM=content-type gomplate -d data=https://example.com/mydata?content-type=application/json -i '{{ (ds "data").foo }}'
+bar
+```
+
 ### The `.env` file format
 
 Many applications and frameworks support the use of a ".env" file for providing environment variables. It can also be considerd a simple key/value file format, and as such can be used as a datasource in gomplate.

--- a/internal/tests/integration/integration_test.go
+++ b/internal/tests/integration/integration_test.go
@@ -95,6 +95,18 @@ func typeHandler(t, body string) func(http.ResponseWriter, *http.Request) {
 	}
 }
 
+func paramHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// just returns params as JSON
+		w.Header().Set("Content-Type", "application/json")
+
+		enc := json.NewEncoder(w)
+		if err := enc.Encode(r.URL.Query()); err != nil {
+			t.Fatalf("error encoding: %v", err)
+		}
+	}
+}
+
 // freeport - find a free TCP port for immediate use. No guarantees!
 func freeport(t *testing.T) (port int, addr string) {
 	l, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})


### PR DESCRIPTION
Fixes #1606 

This adds a new environment variable `GOMPLATE_TYPE_PARAM` which allows switching out the `type` parameter to another name for those rare cases when people need to send an HTTP server a parameter named `type`!