### PR TITLE
docs(chore): Uncomment 'released' tags for functions in v4.0.0

### DIFF
--- a/docs-src/content/functions/aws.yml
+++ b/docs-src/content/functions/aws.yml
@@ -117,7 +117,7 @@ funcs:
         Name=bar
         svc:name=foobar
   - name: aws.KMSEncrypt
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Encrypt an input string with the AWS Key Management Service (KMS).
 

--- a/docs-src/content/functions/coll.yml
+++ b/docs-src/content/functions/coll.yml
@@ -61,7 +61,7 @@ funcs:
         Hello, Lisa
         Hello, Maggie
   - name: coll.GoSlice
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       This exposes the `slice` function from Go's [`text/template`](https://golang.org/pkg/text/template/#hdr-Functions)
       package. Note that using `slice` will use the `coll.Slice` function instead,
@@ -119,7 +119,7 @@ funcs:
         {{ if (has $o "foo") }}{{ $o.foo }}{{ else }}THERE IS NO FOO{{ end }}'
         THERE IS NO FOO
   - name: coll.Index
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Returns the result of indexing the given map, slice, or array by the given
       key or index. This is similar to the built-in `index` function, but the
@@ -172,7 +172,7 @@ funcs:
         [Alice's Adventures in Wonderland Gulliver's Travels]
   - name: coll.JQ
     alias: jq
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Filters an input object or list using the [jq](https://stedolan.github.io/jq/) language, as implemented by [gojq](https://github.com/itchyny/gojq).
 
@@ -462,7 +462,7 @@ funcs:
         {{ coll.Omit $keys $data }}'
         map[bar:2]
   - name: coll.Set
-    # released: v4.0.0
+    released: v4.0.0
     alias: set
     description: |
       Sets the given key to the given value in the given map.
@@ -488,7 +488,7 @@ funcs:
         $ gomplate -i '{{ dict "foo" 1 | coll.Set "bar" 2 }}'
         map[bar:2 foo:1]
   - name: coll.Unset
-    # released: v4.0.0
+    released: v4.0.0
     alias: unset
     description: |
       Deletes the element with the specified key in the given map. If there is no such element, the map is returned unchanged.

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -160,7 +160,7 @@ funcs:
         -----END PUBLIC KEY-----
   - name: crypto.Ed25519GenerateKey
     experimental: true
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Generate a new Ed25519 Private Key and output in
       PEM-encoded PKCS#8 ASN.1 DER form.
@@ -171,7 +171,7 @@ funcs:
         ...
   - name: crypto.Ed25519GenerateKeyFromSeed
     experimental: true
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Generate a new Ed25519 Private Key from a random seed and output in
       PEM-encoded PKCS#8 ASN.1 DER form.
@@ -190,7 +190,7 @@ funcs:
         ...
   - name: crypto.Ed25519DerivePublicKey
     experimental: true
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Derive a public key from an Ed25519 private key and output in PKIX
       ASN.1 DER form.

--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -133,7 +133,7 @@ funcs:
           "v=spf1 -all"
         ]
   - name: net.ParseAddr
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Parse the given string as an IP address (a
       [`netip.Addr`](https://pkg.go.dev/net/netip#Addr)).
@@ -174,7 +174,7 @@ funcs:
           {{ $ip.Prefix 12 }}'
         93.176.0.0/12
   - name: net.ParsePrefix
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Parse the given string as an IP address prefix (CIDR) representing an IP
       network (a [`netip.Prefix`](https://pkg.go.dev/net/netip#Prefix)).
@@ -228,7 +228,7 @@ funcs:
         93.176.0.0-93.191.255.255
   - name: net.ParseRange
     experimental: true
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Parse the given string as an inclusive range of IP addresses from the same
       address family (a [`netipx.IPRange`](https://pkg.go.dev/go4.org/netipx#IPRange)

--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -146,7 +146,7 @@ funcs:
         $ gomplate -i '{{ (coll.Slice "foo" "bar" "baz") | strings.Sort }}'
         [bar baz foo]
   - name: strings.SkipLines
-    # released: v4.0.0
+    released: v4.0.0
     description: |
       Skips the given number of lines (each ending in a `\n`), returning the
       remainder.

--- a/docs/content/functions/aws.md
+++ b/docs/content/functions/aws.md
@@ -176,8 +176,7 @@ Name=bar
 svc:name=foobar
 ```
 
-## `aws.KMSEncrypt`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `aws.KMSEncrypt`
 
 Encrypt an input string with the AWS Key Management Service (KMS).
 
@@ -200,6 +199,7 @@ for more details.
 
 See also [`aws.KMSDecrypt`](#aws-kmsdecrypt).
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```

--- a/docs/content/functions/coll.md
+++ b/docs/content/functions/coll.md
@@ -90,8 +90,7 @@ Hello, Lisa
 Hello, Maggie
 ```
 
-## `coll.GoSlice`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `coll.GoSlice`
 
 This exposes the `slice` function from Go's [`text/template`](https://golang.org/pkg/text/template/#hdr-Functions)
 package. Note that using `slice` will use the `coll.Slice` function instead,
@@ -110,6 +109,7 @@ is x[1:2:3]. The first argument must be a string, slice, or array.
 See the [Go language spec](https://go.dev/ref/spec#Slice_expressions) for
 more details.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -169,8 +169,7 @@ $ gomplate -i '{{ $o := data.JSON (getenv "DATA") -}}
 THERE IS NO FOO
 ```
 
-## `coll.Index`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `coll.Index`
 
 Returns the result of indexing the given map, slice, or array by the given
 key or index. This is similar to the built-in `index` function, but the
@@ -180,6 +179,7 @@ non-existent map key.
 
 Multiple indexes may be given, for nested indexing.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -248,8 +248,7 @@ $ gomplate -i '{{ .books | jsonpath `$..works[?( @.edition_count > 400 )].title`
 [Alice's Adventures in Wonderland Gulliver's Travels]
 ```
 
-## `coll.JQ`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `coll.JQ`
 
 **Alias:** `jq`
 
@@ -266,6 +265,7 @@ See also:
 - [jq manual](https://stedolan.github.io/jq/manual/)
 - [gojq differences to jq](https://github.com/itchyny/gojq#difference-to-jq)
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -707,8 +707,7 @@ $ gomplate -i '{{ $data := dict "foo" 1 "bar" 2 "baz" 3 }}
 map[bar:2]
 ```
 
-## `coll.Set`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `coll.Set`
 
 **Alias:** `set`
 
@@ -716,6 +715,7 @@ Sets the given key to the given value in the given map.
 
 The map is modified in place, and the modified map is returned.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -745,8 +745,7 @@ $ gomplate -i '{{ dict "foo" 1 | coll.Set "bar" 2 }}'
 map[bar:2 foo:1]
 ```
 
-## `coll.Unset`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `coll.Unset`
 
 **Alias:** `unset`
 
@@ -754,6 +753,7 @@ Deletes the element with the specified key in the given map. If there is no such
 
 The map is modified in place, and the modified map is returned.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -245,8 +245,7 @@ aztsmrD79OXXnhUlURI=
 -----END PUBLIC KEY-----
 ```
 
-## `crypto.Ed25519GenerateKey`_(unreleased)_ _(experimental)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `crypto.Ed25519GenerateKey` _(experimental)_
 **Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
 
 [experimental]: ../config/#experimental
@@ -254,6 +253,7 @@ aztsmrD79OXXnhUlURI=
 Generate a new Ed25519 Private Key and output in
 PEM-encoded PKCS#8 ASN.1 DER form.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -269,8 +269,7 @@ $ gomplate -i '{{ crypto.Ed25519GenerateKey }}'
 ...
 ```
 
-## `crypto.Ed25519GenerateKeyFromSeed`_(unreleased)_ _(experimental)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `crypto.Ed25519GenerateKeyFromSeed` _(experimental)_
 **Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
 
 [experimental]: ../config/#experimental
@@ -278,6 +277,7 @@ $ gomplate -i '{{ crypto.Ed25519GenerateKey }}'
 Generate a new Ed25519 Private Key from a random seed and output in
 PEM-encoded PKCS#8 ASN.1 DER form.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -302,8 +302,7 @@ $ gomplate -i '{{ crypto.Ed25519GenerateKeyFromSeed "base64" "MDAwMDAwMDAwMDAwMD
 ...
 ```
 
-## `crypto.Ed25519DerivePublicKey`_(unreleased)_ _(experimental)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `crypto.Ed25519DerivePublicKey` _(experimental)_
 **Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
 
 [experimental]: ../config/#experimental
@@ -311,6 +310,7 @@ $ gomplate -i '{{ crypto.Ed25519GenerateKeyFromSeed "base64" "MDAwMDAwMDAwMDAwMD
 Derive a public key from an Ed25519 private key and output in PKIX
 ASN.1 DER form.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -219,8 +219,7 @@ $ gomplate -i '{{net.LookupTXT "example.com" | data.ToJSONPretty "  " }}'
 ]
 ```
 
-## `net.ParseAddr`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `net.ParseAddr`
 
 Parse the given string as an IP address (a
 [`netip.Addr`](https://pkg.go.dev/net/netip#Addr)).
@@ -228,6 +227,7 @@ Parse the given string as an IP address (a
 Any of `netip.Addr`'s methods may be called on the resulting value. See
 [the docs](https://pkg.go.dev/net/netip#Addr) for details.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -288,8 +288,7 @@ $ gomplate -i '{{ $ip := net.ParseIP (net.LookupIP "example.com") -}}
 93.176.0.0/12
 ```
 
-## `net.ParsePrefix`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `net.ParsePrefix`
 
 Parse the given string as an IP address prefix (CIDR) representing an IP
 network (a [`netip.Prefix`](https://pkg.go.dev/net/netip#Prefix)).
@@ -300,6 +299,7 @@ the CIDR notations defined in [RFC 4632][] and [RFC 4291][].
 Any of `netip.Prefix`'s methods may be called on the resulting value. See
 [the docs](https://pkg.go.dev/net/netip#Prefix) for details.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```
@@ -369,8 +369,7 @@ $ gomplate -i '{{ $net := net.ParseIPPrefix "93.184.0.0/12" -}}
 93.176.0.0-93.191.255.255
 ```
 
-## `net.ParseRange`_(unreleased)_ _(experimental)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `net.ParseRange` _(experimental)_
 **Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
 
 [experimental]: ../config/#experimental
@@ -389,6 +388,7 @@ Note that this function is experimental for now, because it uses a
 brought into the standard library in the future, which may require
 breaking changes to this function.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -215,8 +215,7 @@ $ gomplate -i '{{ (coll.Slice "foo" "bar" "baz") | strings.Sort }}'
 [bar baz foo]
 ```
 
-## `strings.SkipLines`_(unreleased)_
-**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+## `strings.SkipLines`
 
 Skips the given number of lines (each ending in a `\n`), returning the
 remainder.
@@ -224,6 +223,7 @@ remainder.
 If `skip` is greater than the number of lines in `in`, an empty string is
 returned.
 
+_Added in gomplate [v4.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v4.0.0)_
 ### Usage
 
 ```


### PR DESCRIPTION
Forgot to do this before the v4 release 🤦‍♂️ - this removes the `unreleased` text from the rendered docs.