### PR TITLE
ci(test): Add 32-bit & ARM CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/hairyhenderson/gomplate-ci-build
+    strategy:
+      fail-fast: false
+      matrix:
+        goarch: [ '386', 'amd64', 'arm', 'arm64' ]
+        include:
+          - goarch: 'arm'
+            goarm: '7'
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
       - run: |
           git config --global user.email "bogus@example.com"
           git config --global user.name "Someone"
@@ -19,14 +28,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: make build
-      - name: Save binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: gomplate
-          path: bin/gomplate
-      - run: make test
-      - run: make integration
+      - run: make build GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }}
+      - run: make test GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }}
+      - run: make integration GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }}
   windows-build:
     runs-on: windows-latest
     env:
@@ -45,10 +49,5 @@ jobs:
           git config --global user.email "bogus@example.com"
           git config --global user.name "Someone"
       - run: make build
-      - name: Save binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: gomplate.exe
-          path: bin/gomplate.exe
       - run: make test
       - run: make integration

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,11 @@ $(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS)): $(PREFIX)/bin/$(PKG_NAME)_$(
 
 build: $(PREFIX)/bin/$(PKG_NAME)_$(GOOS)-$(GOARCH)$(TARGETVARIANT)$(call extension,$(GOOS)) $(PREFIX)/bin/$(PKG_NAME)$(call extension,$(GOOS))
 
-ifeq ($(OS),Windows_NT)
+# test with race detector on supported platforms
+# windows/amd64 is supported in theory, but in practice it requires a C compiler
+race_platforms := 'linux/amd64' 'darwin/amd64' 'darwin/arm64'
+ifeq (,$(findstring '$(GOOS)/$(GOARCH)',$(race_platforms)))
+export CGO_ENABLED=0
 test:
 	$(GO) test -coverprofile=c.out ./...
 else


### PR DESCRIPTION
#2121 only popped up because the Alpine build runs tests on all platforms. I should at least run tests on 32-bit platforms in CI to make sure I don't hit errors like this again.

Also adding emulated tests (with QEMU) for ARM64 and ARMv7. They take a bit longer (because of the crypto differences), but it'll probably be worth it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new build setup for 32-bit Linux platforms.
  - Added a dedicated Dockerfile (`Dockerfile.test32bit`) for 32-bit build environments.

- **Refactor**
  - Updated the existing Dockerfile to use a multi-stage build process and set environment variables for cross-platform compatibility.
  - Enhanced testing commands in the `Makefile` with race detection for supported platforms.

- **Chores**
  - Simplified the linting workflow by removing unnecessary arguments for a cleaner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->