### PR TITLE
ci(build): Add macOS tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,26 @@ jobs:
       - run: make build GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }}
       - run: make test GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }}
       - run: make integration GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }}
-  windows-build:
-    runs-on: windows-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'windows-latest', 'macos-latest' ]
+        include:
+          - os: 'windows-latest'
+            # note: the tmp dir is set to C: so that it's not on the same drive as the
+            # repo, which is on D: - this will expose bugs with path handling!
+            TMP: 'C:\tmp'
+    runs-on: ${{ matrix.os }}
     env:
-      # note: the tmp dir is set to C: so that it's not on the same drive as the
-      # repo, which is on D: - this will expose bugs with path handling!
-      TMP: C:\tmp
+      TMP: ${{ matrix.TMP }}
     steps:
-      - run: pwd
+      - name: Set up macOS test dependencies
+        run: |
+          brew tap hashicorp/tap
+          brew install hashicorp/tap/consul
+          brew install hashicorp/tap/vault
+        if: matrix.os == 'macos-latest'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
Adds a matrix strategy to build & test on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build job workflow by unifying Windows and macOS builds into a single job with a matrix strategy.
  - Dynamically set environment variables based on the operating system.
  - Added setup steps for macOS test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->