### PR TITLE
ci(fix): fix broken release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -125,15 +125,14 @@ jobs:
       - name: Upload release assets
         run: |
           cd bin
-          assets=(checksums-${TAG_NAME}_sha256.txt checksums-${TAG_NAME}_sha512.txt)
+
+          assets="checksums-${TAG_NAME}_sha256.txt checksums-${TAG_NAME}_sha512.txt"
           for f in gomplate_*; do
-            assets=($assets ${f})
+            assets="$assets ${f}"
           done
 
-          for f in ${assets[@]}; do
-            echo "uploading $f"
-            gh release upload ${TAG_NAME} $f
-          done
+          echo "uploading assets: $assets"
+          gh release upload ${TAG_NAME} $assets --clobber
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Publish GitHub Release

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairyhenderson/gomplate/v4
 
-go 1.22.4
+go 1.22.5
 
 require (
 	cuelang.org/go v0.9.2


### PR DESCRIPTION
the v4.1.0 release [failed](https://github.com/hairyhenderson/gomplate/actions/runs/9819804876/job/27113740454), so I used this to redo the release.

the main issue was permissions - there was a tag protection rule applied incorrectly