### PR TITLE
Do not fail on path resolution for default config

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -77,7 +77,10 @@ func readConfigFile(ctx context.Context, cmd *cobra.Command) (*gomplate.Config, 
 	// we only support loading configs from the local filesystem for now
 	fsys, err := datafs.FSysForPath(ctx, cfgFile)
 	if err != nil {
-		return nil, fmt.Errorf("fsys for path %v: %w", cfgFile, err)
+		if configRequired {
+			return nil, fmt.Errorf("fsys for path %v: %w", cfgFile, err)
+		}
+		return nil, nil
 	}
 
 	f, err := fsys.Open(cfgFile)


### PR DESCRIPTION
There is now an error after upgrading to the latest template with the config file support.
> Error: fsys for path .gomplate.yaml: resolve local path \".gomplate.yaml\": getwd: stat .: permission denied

It seems like the error happens during the local path resolution, which calls various os package methods, including getcwd.
If the config was not requested intentionally, I believe it is ok to skip these errors.

Context https://github.com/dexidp/dex/issues/3675