### PR TITLE
feat(config): Allow avoiding reading default config file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,5 +52,7 @@ jobs:
             --exclude="https://docs\.aws.*" \
             --exclude="https://linux.die\.net.*" \
             --exclude="https://jqplay\.org.*" \
+            --exclude="https://json\.org.*" \
+            --exclude="https://goessner\.net.*"
 
           kill %1

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -21,7 +21,7 @@ Hello, hairyhenderson
 
 ### `--config`
 
-Specify the path to a [gomplate config file](../config). The default is `.gomplate.yaml`. Can also be set with the `GOMPLATE_CONFIG` environment variable.
+Specify the path to a [gomplate config file](../config). The default is `.gomplate.yaml`. Can also be set with the `GOMPLATE_CONFIG` environment variable. Setting `--config` or `GOMPLATE_CONFIG` to an empty string (`--config=""` or `export GOMPLATE_CONFIG=""`) will disable the use of a config file, skipping the default `.gomplate.yaml` file.
 
 For example:
 

--- a/env/env.go
+++ b/env/env.go
@@ -20,3 +20,13 @@ func ExpandEnv(s string) string {
 	fsys := datafs.WrapWdFS(osfs.NewFS())
 	return datafs.ExpandEnvFsys(fsys, s)
 }
+
+// LookupEnv - retrieves the value of the environment variable named by the key.
+// If the variable is unset, but the same variable ending in `_FILE` is set, the
+// referenced file will be read into the value. If the key is not set, the
+// second return value will be false.
+// Otherwise the provided default (or an emptry string) is returned.
+func LookupEnv(key string) (string, bool) {
+	fsys := datafs.WrapWdFS(osfs.NewFS())
+	return datafs.LookupEnvFsys(fsys, key)
+}

--- a/internal/datafs/getenv.go
+++ b/internal/datafs/getenv.go
@@ -15,7 +15,7 @@ func ExpandEnvFsys(fsys fs.FS, s string) string {
 
 // GetenvFsys - a convenience function intended for internal use only!
 func GetenvFsys(fsys fs.FS, key string, def ...string) string {
-	val := getenvFile(fsys, key)
+	val, _ := getenvFile(fsys, key)
 	if val == "" && len(def) > 0 {
 		return def[0]
 	}
@@ -23,22 +23,28 @@ func GetenvFsys(fsys fs.FS, key string, def ...string) string {
 	return val
 }
 
-func getenvFile(fsys fs.FS, key string) string {
-	val := os.Getenv(key)
+// LookupEnvFsys - a convenience function intended for internal use only!
+func LookupEnvFsys(fsys fs.FS, key string) (string, bool) {
+	return getenvFile(fsys, key)
+}
+
+func getenvFile(fsys fs.FS, key string) (string, bool) {
+	val, found := os.LookupEnv(key)
 	if val != "" {
-		return val
+		return val, true
 	}
 
 	p := os.Getenv(key + "_FILE")
 	if p != "" {
 		val, err := readFile(fsys, p)
 		if err != nil {
-			return ""
+			return "", false
 		}
-		return strings.TrimSpace(val)
+
+		return strings.TrimSpace(val), true
 	}
 
-	return ""
+	return "", found
 }
 
 func readFile(fsys fs.FS, p string) (string, error) {

--- a/internal/tests/integration/config_test.go
+++ b/internal/tests/integration/config_test.go
@@ -153,6 +153,20 @@ func TestConfig_EnvConfigFile(t *testing.T) {
 	assertSuccess(t, o, e, err, "yet another alternate config")
 }
 
+func TestConfig_SkipConfigFile(t *testing.T) {
+	tmpDir := setupConfigTest(t)
+
+	// first set a poisoned default config to prove that it's not being read
+	writeFile(t, tmpDir, ".gomplate.yaml", `badyaml`)
+
+	o, e, err := cmd(t, "--config", "", "--in", "foo").withDir(tmpDir.Path()).run()
+	assertSuccess(t, o, e, err, "foo")
+
+	o, e, err = cmd(t, "--in", "foo").withDir(tmpDir.Path()).
+		withEnv("GOMPLATE_CONFIG", "").run()
+	assertSuccess(t, o, e, err, "foo")
+}
+
 func TestConfig_ConfigOverridesEnvDelim(t *testing.T) {
 	if isWindows {
 		t.Skip()

--- a/internal/tests/integration/datasources_consul_test.go
+++ b/internal/tests/integration/datasources_consul_test.go
@@ -42,7 +42,8 @@ func setupDatasourcesConsulTest(t *testing.T) (string, *vaultClient) {
 					"serf_lan": `+strconv.Itoa(serfLanPort)+`,
 					"serf_wan": -1,
 					"dns": -1,
-					"grpc": -1
+					"grpc": -1,
+					"grpc_tls": -1
 				},
 				"connect": { "enabled": false }
 			}`,


### PR DESCRIPTION
In https://github.com/hairyhenderson/gomplate/pull/2202 the root issue was that the user was running in an unreadable working directory, and so gomplate errored with a message like:

```
Error: fsys for path .gomplate.yaml: resolve local path ".gomplate.yaml": getwd: stat .: permission denied
```

Rather than ignore errors when the default config file can't be read (which will hide real failures and perform the wrong behaviour potentially), this PR adds the ability to set `--config` or `$GOMPLATE_CONFIG` to an empty string, which will cause the config file parsing code to be skipped entirely.