### PR TITLE
docs(links): Fix broken link

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,7 @@ jobs:
             --exclude="https://linux.die\.net.*" \
             --exclude="https://jqplay\.org.*" \
             --exclude="https://json\.org.*" \
-            --exclude="https://goessner\.net.*"
+            --exclude="https://goessner\.net.*" \
+            --exclude="http://opensource\.org.*"
 
           kill %1

--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -694,7 +694,7 @@ The correct capabilities must be allowed for the [authenticated](#vault-authenti
 
 ### Vault Environment variables
 
-In addition to the variables documented [above](#vault-authentication), a number of environment variables are interpreted by the Vault client, and are documented in the [official Vault documentation](https://developer.hashicorp.com/vault/docs/commands#environment-variables).
+In addition to the variables documented [above](#vault-authentication), a number of environment variables are interpreted by the Vault client, and are documented in the [official Vault documentation](https://developer.hashicorp.com/vault/docs/commands#configure-environment-variables).
 
 ### Examples
 


### PR DESCRIPTION
Muffet's [found a couple issues](https://github.com/hairyhenderson/gomplate/actions/runs/11759396946/job/32758826541): an upstream link has started rejecting GETs from robots, and the Vault docs have changed an anchor name...