### PR TITLE
dep: remove broken inet.af/netaddr dependency and associated deprecated functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	golang.org/x/term v0.26.0
 	golang.org/x/text v0.20.0
 	gotest.tools/v3 v3.5.1
-	inet.af/netaddr v0.0.0-20230525184311-b8eac61e914a
 	k8s.io/client-go v0.31.2
 )
 

--- a/internal/funcs/net.go
+++ b/internal/funcs/net.go
@@ -9,10 +9,8 @@ import (
 
 	"github.com/hairyhenderson/gomplate/v4/conv"
 	"github.com/hairyhenderson/gomplate/v4/internal/cidr"
-	"github.com/hairyhenderson/gomplate/v4/internal/deprecated"
 	"github.com/hairyhenderson/gomplate/v4/net"
 	"go4.org/netipx"
-	"inet.af/netaddr"
 )
 
 // CreateNetFuncs -
@@ -58,30 +56,6 @@ func (f NetFuncs) LookupTXT(name interface{}) ([]string, error) {
 	return net.LookupTXT(conv.ToString(name))
 }
 
-// ParseIP -
-//
-// Deprecated: use [ParseAddr] instead
-func (f *NetFuncs) ParseIP(ip interface{}) (netaddr.IP, error) {
-	deprecated.WarnDeprecated(f.ctx, "net.ParseIP is deprecated - use net.ParseAddr instead")
-	return netaddr.ParseIP(conv.ToString(ip))
-}
-
-// ParseIPPrefix -
-//
-// Deprecated: use [ParsePrefix] instead
-func (f *NetFuncs) ParseIPPrefix(ipprefix interface{}) (netaddr.IPPrefix, error) {
-	deprecated.WarnDeprecated(f.ctx, "net.ParseIPPrefix is deprecated - use net.ParsePrefix instead")
-	return netaddr.ParseIPPrefix(conv.ToString(ipprefix))
-}
-
-// ParseIPRange -
-//
-// Deprecated: use [ParseRange] instead
-func (f *NetFuncs) ParseIPRange(iprange interface{}) (netaddr.IPRange, error) {
-	deprecated.WarnDeprecated(f.ctx, "net.ParseIPRange is deprecated - use net.ParseRange instead")
-	return netaddr.ParseIPRange(conv.ToString(iprange))
-}
-
 // ParseAddr -
 func (f NetFuncs) ParseAddr(ip interface{}) (netip.Addr, error) {
 	return netip.ParseAddr(conv.ToString(ip))
@@ -103,10 +77,6 @@ func (f *NetFuncs) parseNetipPrefix(prefix interface{}) (netip.Prefix, error) {
 	switch p := prefix.(type) {
 	case *stdnet.IPNet:
 		return f.ipPrefixFromIPNet(p), nil
-	case netaddr.IPPrefix:
-		deprecated.WarnDeprecated(f.ctx,
-			"support for netaddr.IPPrefix is deprecated - use net.ParsePrefix to produce a netip.Prefix instead")
-		return f.ipPrefixFromIPNet(p.Masked().IPNet()), nil
 	case netip.Prefix:
 		return p, nil
 	default:

--- a/internal/funcs/net_test.go
+++ b/internal/funcs/net_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hairyhenderson/gomplate/v4/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"inet.af/netaddr"
 )
 
 func TestCreateNetFuncs(t *testing.T) {
@@ -35,53 +34,6 @@ func TestNetLookupIP(t *testing.T) {
 
 	n := NetFuncs{}
 	assert.Equal(t, "127.0.0.1", must(n.LookupIP("localhost")))
-}
-
-func TestParseIP(t *testing.T) {
-	t.Parallel()
-
-	n := testNetNS()
-	_, err := n.ParseIP("not an IP")
-	require.Error(t, err)
-
-	ip, err := n.ParseIP("2001:470:20::2")
-	require.NoError(t, err)
-	assert.Equal(t, netaddr.IPFrom16([16]byte{
-		0x20, 0x01, 0x04, 0x70,
-		0, 0x20, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0x02,
-	}), ip)
-}
-
-func TestParseIPPrefix(t *testing.T) {
-	t.Parallel()
-
-	n := testNetNS()
-	_, err := n.ParseIPPrefix("not an IP")
-	require.Error(t, err)
-
-	_, err = n.ParseIPPrefix("1.1.1.1")
-	require.Error(t, err)
-
-	ipprefix, err := n.ParseIPPrefix("192.168.0.2/28")
-	require.NoError(t, err)
-	assert.Equal(t, "192.168.0.0/28", ipprefix.Masked().String())
-}
-
-func TestParseIPRange(t *testing.T) {
-	t.Parallel()
-
-	n := testNetNS()
-	_, err := n.ParseIPRange("not an IP")
-	require.Error(t, err)
-
-	_, err = n.ParseIPRange("1.1.1.1")
-	require.Error(t, err)
-
-	iprange, err := n.ParseIPRange("192.168.0.2-192.168.23.255")
-	require.NoError(t, err)
-	assert.Equal(t, "192.168.0.2-192.168.23.255", iprange.String())
 }
 
 func TestParseAddr(t *testing.T) {
@@ -154,8 +106,7 @@ func TestCIDRHost(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "fd00:fd12:3456:7890::22", ip.String())
 
-	// inet.af/netaddr.IPPrefix
-	ipPrefix, _ := n.ParseIPPrefix("10.12.127.0/20")
+	ipPrefix, _ := n.ParsePrefix("10.12.127.0/20")
 
 	ip, err = n.CIDRHost(16, ipPrefix)
 	require.NoError(t, err)
@@ -165,7 +116,7 @@ func TestCIDRHost(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "10.12.113.12", ip.String())
 
-	ipPrefix, _ = n.ParseIPPrefix("fd00:fd12:3456:7890:00a2::/72")
+	ipPrefix, _ = n.ParsePrefix("fd00:fd12:3456:7890:00a2::/72")
 	ip, err = n.CIDRHost(34, ipPrefix)
 	require.NoError(t, err)
 	assert.Equal(t, "fd00:fd12:3456:7890::22", ip.String())


### PR DESCRIPTION
Hey,

I am using `gomplate` as a library in another project, and noticed that builds started failing due to being unable to pull the module `inet.af/netaddr`.

It seems like the domain no longer resolves.  It could be related to the fact this is a .AF domain, and there have been some payment disputes between the country NIC and registrars recently[0], and the project's new README even warns about deprecating this domain name[1].

Since the IP, IPPrefix and IPRange (and other parts of `netaddr`) have been merged into the standard library `net/netip`, and the lack of references to these deprecated internal utility functions, I think it's safe to remove them from the code and tests.

[0] https://www.reuters.com/technology/brokeaf-goes-offline-afghan-web-domains-suspended-amid-payment-dispute-2024-02-16/
[1] https://github.com/go4org/netipx