### PR TITLE
docs(fix): Quotation in external templates example

### DIFF
--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -325,7 +325,7 @@ Hello {{ . }}!
 ```
 
 ```
-$ gomplate -t hello=hello.t -i '{{ template "hello" "World" }} {{ template "hello" .Env.USER }}"
+$ gomplate -t hello=hello.t -i '{{ template "hello" "World" }} {{ template "hello" .Env.USER }}'
 Hello World! Hello hairyhenderson!
 ```
 


### PR DESCRIPTION
Minor thing I found reading through the example on external templates