### PR TITLE
fix(lint): Address new lint warnings

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -202,7 +202,7 @@ func cobraConfig(cmd *cobra.Command, args []string) (cfg *gomplate.Config, err e
 	if err != nil {
 		return nil, err
 	}
-	err = ParseDataSourceFlags(cfg, ds, cx, ts, hdr)
+	err = parseDataSourceFlags(cfg, ds, cx, ts, hdr)
 	if err != nil {
 		return nil, err
 	}
@@ -320,10 +320,10 @@ func ParsePluginFlags(c *gomplate.Config, plugins []string) error {
 	return nil
 }
 
-// ParseDataSourceFlags - sets DataSources, Context, and Templates fields from
+// parseDataSourceFlags - sets DataSources, Context, and Templates fields from
 // the key=value format flags as provided at the command-line
 // Unreferenced headers will be set in c.ExtraHeaders
-func ParseDataSourceFlags(c *gomplate.Config, datasources, contexts, templates, headers []string) error {
+func parseDataSourceFlags(c *gomplate.Config, datasources, contexts, templates, headers []string) error {
 	err := parseResources(c, datasources, contexts, templates)
 	if err != nil {
 		return err

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -325,16 +325,16 @@ func mustURL(s string) *url.URL {
 func TestParseDataSourceFlags(t *testing.T) {
 	t.Parallel()
 	cfg := &gomplate.Config{}
-	err := ParseDataSourceFlags(cfg, nil, nil, nil, nil)
+	err := parseDataSourceFlags(cfg, nil, nil, nil, nil)
 	require.NoError(t, err)
 	assert.EqualValues(t, &gomplate.Config{}, cfg)
 
 	cfg = &gomplate.Config{}
-	err = ParseDataSourceFlags(cfg, []string{"foo/bar/baz.json"}, nil, nil, nil)
+	err = parseDataSourceFlags(cfg, []string{"foo/bar/baz.json"}, nil, nil, nil)
 	require.Error(t, err)
 
 	cfg = &gomplate.Config{}
-	err = ParseDataSourceFlags(cfg, []string{"baz=foo/bar/baz.json"}, nil, nil, nil)
+	err = parseDataSourceFlags(cfg, []string{"baz=foo/bar/baz.json"}, nil, nil, nil)
 	require.NoError(t, err)
 	expected := &gomplate.Config{
 		DataSources: map[string]gomplate.DataSource{
@@ -344,7 +344,7 @@ func TestParseDataSourceFlags(t *testing.T) {
 	assert.EqualValues(t, expected, cfg, "expected: %+v\nactual: %+v\n", expected, cfg)
 
 	cfg = &gomplate.Config{}
-	err = ParseDataSourceFlags(cfg,
+	err = parseDataSourceFlags(cfg,
 		[]string{"baz=foo/bar/baz.json"},
 		nil,
 		nil,
@@ -362,7 +362,7 @@ func TestParseDataSourceFlags(t *testing.T) {
 	}, cfg)
 
 	cfg = &gomplate.Config{}
-	err = ParseDataSourceFlags(cfg,
+	err = parseDataSourceFlags(cfg,
 		[]string{"baz=foo/bar/baz.json"},
 		[]string{"foo=http://example.com"},
 		nil,
@@ -390,7 +390,7 @@ func TestParseDataSourceFlags(t *testing.T) {
 	}, cfg)
 
 	cfg = &gomplate.Config{}
-	err = ParseDataSourceFlags(cfg,
+	err = parseDataSourceFlags(cfg,
 		nil,
 		nil,
 		[]string{"foo=http://example.com", "file.tmpl", "tmpldir/"},

--- a/internal/datafs/default.go
+++ b/internal/datafs/default.go
@@ -1,0 +1,27 @@
+package datafs
+
+import (
+	"sync"
+
+	"github.com/hairyhenderson/go-fsimpl"
+	"github.com/hairyhenderson/go-fsimpl/autofs"
+)
+
+// DefaultProvider is the default filesystem provider used by gomplate
+var DefaultProvider = sync.OnceValue(
+	func() fsimpl.FSProvider {
+		fsp := fsimpl.NewMux()
+
+		// start with all go-fsimpl filesystems
+		fsp.Add(autofs.FS)
+
+		// override go-fsimpl's filefs with wdfs to handle working directories
+		fsp.Add(wdFSProvider)
+
+		// gomplate-only filesystems
+		fsp.Add(EnvFS)
+		fsp.Add(StdinFS)
+		fsp.Add(mergeFSProvider)
+
+		return fsp
+	})()

--- a/internal/datafs/envfs.go
+++ b/internal/datafs/envfs.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hairyhenderson/go-fsimpl"
 )
 
-// NewEnvFS returns a filesystem (an fs.FS) that can be used to read data from
+// newEnvFS returns a filesystem (an fs.FS) that can be used to read data from
 // environment variables.
-func NewEnvFS(_ *url.URL) (fs.FS, error) {
+func newEnvFS(_ *url.URL) (fs.FS, error) {
 	return &envFS{locfs: os.DirFS("/")}, nil
 }
 
@@ -24,7 +24,7 @@ type envFS struct {
 }
 
 //nolint:gochecknoglobals
-var EnvFS = fsimpl.FSProviderFunc(NewEnvFS, "env")
+var EnvFS = fsimpl.FSProviderFunc(newEnvFS, "env")
 
 var _ fs.FS = (*envFS)(nil)
 

--- a/internal/datafs/envfs_test.go
+++ b/internal/datafs/envfs_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestEnvFS_Open(t *testing.T) {
-	fsys, err := NewEnvFS(nil)
+	fsys, err := newEnvFS(nil)
 	require.NoError(t, err)
 	assert.IsType(t, &envFS{}, fsys)
 
@@ -78,7 +78,7 @@ func TestEnvFS(t *testing.T) {
 	lfsys := fstest.MapFS{}
 	lfsys["foo/bar/baz.txt"] = &fstest.MapFile{Data: []byte("\nhello file\n")}
 
-	fsys, err := NewEnvFS(u)
+	fsys, err := newEnvFS(u)
 	require.NoError(t, err)
 	assert.IsType(t, &envFS{}, fsys)
 

--- a/internal/datafs/fsurl.go
+++ b/internal/datafs/fsurl.go
@@ -27,9 +27,9 @@ func SplitFSMuxURL(in *url.URL) (*url.URL, string) {
 		// it has a path, the URL must begin with a slash.
 		if u.Opaque != "" {
 			return &url.URL{Scheme: u.Scheme}, u.Opaque
-		} else {
-			return &url.URL{Scheme: u.Scheme, Path: "/"}, strings.TrimLeft(u.Path, "/")
 		}
+
+		return &url.URL{Scheme: u.Scheme, Path: "/"}, strings.TrimLeft(u.Path, "/")
 	}
 
 	// trim leading and trailing slashes - they are not part of a valid path

--- a/internal/datafs/mergefs.go
+++ b/internal/datafs/mergefs.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hairyhenderson/gomplate/v4/internal/urlhelpers"
 )
 
-// NewMergeFS returns a new filesystem that merges the contents of multiple
+// newMergeFS returns a new filesystem that merges the contents of multiple
 // paths. Only a URL like "merge:" or "merge:///" makes sense here - the
 // piped-separated lists of sub-sources to merge must be given to Open.
 //
@@ -31,7 +31,7 @@ import (
 //
 // An FSProvider will also be needed, which can be provided with a context
 // using ContextWithFSProvider. Provide that context with fsimpl.WithContextFS.
-func NewMergeFS(u *url.URL) (fs.FS, error) {
+func newMergeFS(u *url.URL) (fs.FS, error) {
 	if u.Scheme != "merge" {
 		return nil, fmt.Errorf("unsupported scheme %q", u.Scheme)
 	}
@@ -49,7 +49,7 @@ type mergeFS struct {
 }
 
 //nolint:gochecknoglobals
-var MergeFS = fsimpl.FSProviderFunc(NewMergeFS, "merge")
+var mergeFSProvider = fsimpl.FSProviderFunc(newMergeFS, "merge")
 
 var (
 	_ fs.FS                    = (*mergeFS)(nil)

--- a/internal/datafs/mergefs_test.go
+++ b/internal/datafs/mergefs_test.go
@@ -65,12 +65,12 @@ func setupMergeFsys(ctx context.Context, t *testing.T) fs.FS {
 	})
 
 	mux := fsimpl.NewMux()
-	mux.Add(MergeFS)
+	mux.Add(mergeFSProvider)
 	mux.Add(WrappedFSProvider(fsys, "file", ""))
 
 	ctx = ContextWithFSProvider(ctx, mux)
 
-	fsys, err := NewMergeFS(mustParseURL("merge:///"))
+	fsys, err := newMergeFS(mustParseURL("merge:///"))
 	require.NoError(t, err)
 
 	fsys = WithDataSourceRegistryFS(reg, fsys)
@@ -293,7 +293,7 @@ func TestMergeFS_ReadsSubFilesOnce(t *testing.T) {
 		}))
 
 	mux := fsimpl.NewMux()
-	mux.Add(MergeFS)
+	mux.Add(mergeFSProvider)
 	mux.Add(WrappedFSProvider(fsys, "file", ""))
 
 	ctx := ContextWithFSProvider(context.Background(), mux)
@@ -302,7 +302,7 @@ func TestMergeFS_ReadsSubFilesOnce(t *testing.T) {
 	reg.Register("jsonfile", config.DataSource{URL: mustParseURL("tmp/jsonfile.json")})
 	reg.Register("yamlfile", config.DataSource{URL: mustParseURL("tmp/yamlfile.yaml")})
 
-	fsys, err := NewMergeFS(mustParseURL("merge:///"))
+	fsys, err := newMergeFS(mustParseURL("merge:///"))
 	require.NoError(t, err)
 
 	fsys = WithDataSourceRegistryFS(reg, fsys)

--- a/internal/datafs/stdinfs.go
+++ b/internal/datafs/stdinfs.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hairyhenderson/go-fsimpl"
 )
 
-// NewStdinFS returns a filesystem (an fs.FS) that can be used to read data from
+// newStdinFS returns a filesystem (an fs.FS) that can be used to read data from
 // standard input (os.Stdin).
-func NewStdinFS(_ *url.URL) (fs.FS, error) {
+func newStdinFS(_ *url.URL) (fs.FS, error) {
 	return &stdinFS{ctx: context.Background()}, nil
 }
 
@@ -23,7 +23,7 @@ type stdinFS struct {
 }
 
 //nolint:gochecknoglobals
-var StdinFS = fsimpl.FSProviderFunc(NewStdinFS, "stdin")
+var StdinFS = fsimpl.FSProviderFunc(newStdinFS, "stdin")
 
 var (
 	_ fs.FS         = (*stdinFS)(nil)

--- a/internal/datafs/stdinfs_test.go
+++ b/internal/datafs/stdinfs_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestStdinFS_Open(t *testing.T) {
-	fsys, err := NewStdinFS(nil)
+	fsys, err := newStdinFS(nil)
 	require.NoError(t, err)
 	assert.IsType(t, &stdinFS{}, fsys)
 
@@ -56,7 +56,7 @@ func TestStdinFS(t *testing.T) {
 
 	ctx := ContextWithStdin(context.Background(), bytes.NewReader(content))
 
-	fsys, err := NewStdinFS(u)
+	fsys, err := newStdinFS(u)
 	require.NoError(t, err)
 	assert.IsType(t, &stdinFS{}, fsys)
 
@@ -128,7 +128,7 @@ func TestStdinFS(t *testing.T) {
 	t.Run("open errors", func(t *testing.T) {
 		ctx := ContextWithStdin(context.Background(), &errorReader{err: fs.ErrPermission})
 
-		fsys, err := NewStdinFS(u)
+		fsys, err := newStdinFS(u)
 		require.NoError(t, err)
 		assert.IsType(t, &stdinFS{}, fsys)
 
@@ -141,7 +141,7 @@ func TestStdinFS(t *testing.T) {
 	t.Run("readFile errors", func(t *testing.T) {
 		ctx := ContextWithStdin(context.Background(), &errorReader{err: fs.ErrPermission})
 
-		fsys, err := NewStdinFS(u)
+		fsys, err := newStdinFS(u)
 		require.NoError(t, err)
 		assert.IsType(t, &stdinFS{}, fsys)
 

--- a/internal/datafs/wdfs.go
+++ b/internal/datafs/wdfs.go
@@ -193,7 +193,7 @@ func isSupportedPath(name string) bool {
 	}
 }
 
-// WdFS is a filesystem provider that creates local filesystems which support
+// wdFSProvider is a filesystem provider that creates local filesystems which support
 // absolute paths beginning with '/', and interpret relative paths as relative
 // to the current working directory (as reported by [os.Getwd]).
 //
@@ -203,7 +203,7 @@ func isSupportedPath(name string) bool {
 // - Root Local - e.g. \\. or \\?
 // - non-drive Local Devices - e.g. \\.\COM1, \\.\pipe\foo
 // - NT Paths - e.g. \??\C:\foo\bar or \??\UNC\foo\bar
-var WdFS = fsimpl.FSProviderFunc(
+var wdFSProvider = fsimpl.FSProviderFunc(
 	func(u *url.URL) (fs.FS, error) {
 		if !isSupportedPath(u.Path) {
 			return nil, fmt.Errorf("unsupported path %q: %w", u.Path, fs.ErrInvalid)

--- a/render.go
+++ b/render.go
@@ -9,12 +9,10 @@ import (
 	"path"
 	"slices"
 	"strings"
-	"sync"
 	"text/template"
 	"time"
 
 	"github.com/hairyhenderson/go-fsimpl"
-	"github.com/hairyhenderson/go-fsimpl/autofs"
 	"github.com/hairyhenderson/gomplate/v4/internal/datafs"
 	"github.com/hairyhenderson/gomplate/v4/internal/funcs"
 )
@@ -372,20 +370,4 @@ func parseNestedTemplate(_ context.Context, fsys fs.FS, alias, fname string, tmp
 }
 
 // DefaultFSProvider is the default filesystem provider used by gomplate
-var DefaultFSProvider = sync.OnceValue(
-	func() fsimpl.FSProvider {
-		fsp := fsimpl.NewMux()
-
-		// start with all go-fsimpl filesystems
-		fsp.Add(autofs.FS)
-
-		// override go-fsimpl's filefs with wdfs to handle working directories
-		fsp.Add(datafs.WdFS)
-
-		// gomplate-only filesystem
-		fsp.Add(datafs.EnvFS)
-		fsp.Add(datafs.StdinFS)
-		fsp.Add(datafs.MergeFS)
-
-		return fsp
-	})()
+var DefaultFSProvider = datafs.DefaultProvider


### PR DESCRIPTION
Handling some new linter warnings, and also unexporting some things in `internal/` that didn't need to be exported.