### PR TITLE
docs(fix): fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ If you think you've found a sensitive security issue, please e-mail me before op
 
 ## Versioning, API and Deprecation
 
-I try to follow [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) as much as possible, and as such the version numbers attached to gomplate releases have _semantic meaning_. That is, patch-level releases (e.g. when going from 2.3.0 to 2.3.1) will only contain bug fixes and will not otherwise add or remove features, while minor-level releses (e.g. 2.3.0 to 2.4.0) will only contain new features and will not remove or make breaking changes to features, and major-level releases (e.g. 2.3.0 to 3.0.0) will contain breaking changes (either feature removals, renames, or significant behaviour changes).
+I try to follow [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html) as much as possible, and as such the version numbers attached to gomplate releases have _semantic meaning_. That is, patch-level releases (e.g. when going from 2.3.0 to 2.3.1) will only contain bug fixes and will not otherwise add or remove features, while minor-level releases (e.g. 2.3.0 to 2.4.0) will only contain new features and will not remove or make breaking changes to features, and major-level releases (e.g. 2.3.0 to 3.0.0) will contain breaking changes (either feature removals, renames, or significant behaviour changes).
 
 When making a change that'll require either a _minor_ or _major_ version bump upon release, the PR should be labeled with the `api/minor` or `api/major` labels.
 

--- a/config.go
+++ b/config.go
@@ -112,7 +112,7 @@ type rawConfig struct {
 
 // TODO: remove when we remove the deprecated array format for templates
 //
-// Deprecated: custom unmarshaling will be removed in the next version
+// Deprecated: custom unmarshalling will be removed in the next version
 func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	r := rawConfig{}
 	err := value.Decode(&r)
@@ -148,7 +148,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 
 // TODO: remove when we remove the deprecated array format for templates
 //
-// Deprecated: custom unmarshaling will be removed in the next version
+// Deprecated: custom unmarshalling will be removed in the next version
 func (c Config) MarshalYAML() (any, error) {
 	aux := rawConfig{
 		DataSources:           c.DataSources,

--- a/docs-src/content/functions/conv.yml
+++ b/docs-src/content/functions/conv.yml
@@ -302,7 +302,7 @@ funcs:
       This function attempts to convert most types of input (strings, numbers,
       and booleans).
 
-      Unconvertable inputs will result in errors.
+      Unconvertible inputs will result in errors.
 
       Floating-point numbers (with decimal points) are truncated.
     arguments:
@@ -327,7 +327,7 @@ funcs:
       platforms, but is useful when input to another function must be provided
       as an `int`.
 
-      Unconvertable inputs will result in errors.
+      Unconvertible inputs will result in errors.
 
       On 32-bit systems, given a number that is too large to fit in an `int`,
       the result is `-1`. This is done to protect against
@@ -354,7 +354,7 @@ funcs:
     description: |
       Converts the inputs to an array of `int64`s.
 
-      Unconvertable inputs will result in errors.
+      Unconvertible inputs will result in errors.
 
       This delegates to [`conv.ToInt64`](#convtoint64) for each input argument.
     arguments:
@@ -370,7 +370,7 @@ funcs:
     description: |
       Converts the inputs to an array of `int`s.
 
-      Unconvertable inputs will result in errors.
+      Unconvertible inputs will result in errors.
 
       This delegates to [`conv.ToInt`](#convtoint) for each input argument.
     arguments:
@@ -389,7 +389,7 @@ funcs:
       This function attempts to convert most types of input (strings, numbers,
       and booleans).
       
-      Unconvertable inputs will result in errors.
+      Unconvertible inputs will result in errors.
     arguments:
       - name: in
         required: true
@@ -405,7 +405,7 @@ funcs:
     description: |
       Converts the inputs to an array of `float64`s.
 
-      Unconvertable inputs will result in errors.
+      Unconvertible inputs will result in errors.
 
       This delegates to [`conv.ToFloat64`](#convtofloat64) for each input argument.
     arguments:

--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -151,7 +151,7 @@ funcs:
       Converts a JSON string into an object. Works for JSON Objects, but will
       also parse JSON Arrays. Will not parse other valid JSON types.
 
-      For more explict JSON Array support, see [`data.JSONArray`](#datajsonarray).
+      For more explicit JSON Array support, see [`data.JSONArray`](#datajsonarray).
 
       #### Encrypted JSON support (EJSON)
 
@@ -206,7 +206,7 @@ funcs:
       Converts a YAML string into an object. Works for YAML Objects but will
       also parse YAML Arrays. This can be used to access properties of YAML objects.
 
-      For more explict YAML Array support, see [`data.JSONArray`](#datayamlarray).
+      For more explicit YAML Array support, see [`data.JSONArray`](#datayamlarray).
     pipeline: true
     arguments:
       - name: in

--- a/docs-src/content/functions/filepath.yml
+++ b/docs-src/content/functions/filepath.yml
@@ -157,7 +157,7 @@ funcs:
     description: |
       Splits path immediately following the final path separator, separating it into a directory and file name component.
 
-      The function returns an array with two values, the first being the diretory, and the second the file.
+      The function returns an array with two values, the first being the directory, and the second the file.
 
       A wrapper for Go's [`filepath.Split`](https://pkg.go.dev/path/filepath/#Split) function.
     pipeline: true

--- a/docs-src/content/functions/math.yml
+++ b/docs-src/content/functions/math.yml
@@ -95,7 +95,7 @@ funcs:
     arguments:
       - name: num
         required: true
-        description: The input number. Will be converted to a `float64`, or `0` if not convertable
+        description: The input number. Will be converted to a `float64`, or `0` if not convertible
     examples:
       - |
         $ gomplate -i '{{ range (coll.Slice 5.1 42 "3.14" "0xFF" "NaN" "Inf" "-0") }}floor {{ printf "%#v" . }} = {{ math.Floor . }}{{"\n"}}{{ end }}'
@@ -236,7 +236,7 @@ funcs:
     arguments:
       - name: num
         required: true
-        description: The input number. Will be converted to a `float64`, or `0` if not convertable
+        description: The input number. Will be converted to a `float64`, or `0` if not convertible
     examples:
       - |
         $ gomplate -i '{{ range (coll.Slice -6.5 5.1 42.9 "3.5" 6.5) }}round {{ printf "%#v" . }} = {{ math.Round . }}{{"\n"}}{{ end }}'

--- a/docs-src/content/functions/semver.yml
+++ b/docs-src/content/functions/semver.yml
@@ -26,7 +26,7 @@ funcs:
         the pre release version is 1.1.1-beta.1
   - name: semver.CheckConstraint
     description: |
-      Test whether the input version matchs the constraint.
+      Test whether the input version matches the constraint.
 
       Ref: https://github.com/Masterminds/semver#checking-version-constraints
     pipeline: true

--- a/docs-src/content/functions/time.yml
+++ b/docs-src/content/functions/time.yml
@@ -153,7 +153,7 @@ funcs:
     released: v2.2.0
     description: |
       Same as [`time.Parse`](#timeparse), except that in the absence of a time zone
-      indicator, the timestamp wil be parsed in the local timezone.
+      indicator, the timestamp will be parsed in the local timezone.
     pipeline: true
     arguments:
       - name: layout

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -159,7 +159,7 @@ See [`--exec-pipe`](../usage/#--exec-pipe).
 
 Use the rendered output as the [`postExec`](#postexec) command's standard input.
 
-Must be used in conjuction with [`postExec`](#postexec), and will override
+Must be used in conjunction with [`postExec`](#postexec), and will override
 any [`outputFiles`](#outputfiles) settings.
 
 ## `experimental`

--- a/docs/content/datasources.md
+++ b/docs/content/datasources.md
@@ -136,7 +136,7 @@ bar
 
 ### The `.env` file format
 
-Many applications and frameworks support the use of a ".env" file for providing environment variables. It can also be considerd a simple key/value file format, and as such can be used as a datasource in gomplate.
+Many applications and frameworks support the use of a ".env" file for providing environment variables. It can also be considered a simple key/value file format, and as such can be used as a datasource in gomplate.
 
 To [override](#overriding-mime-types), use the unregistered `application/x-env` MIME type.
 

--- a/docs/content/functions/conv.md
+++ b/docs/content/functions/conv.md
@@ -454,7 +454,7 @@ Converts the input to an `int64` (64-bit signed integer).
 This function attempts to convert most types of input (strings, numbers,
 and booleans).
 
-Unconvertable inputs will result in errors.
+Unconvertible inputs will result in errors.
 
 Floating-point numbers (with decimal points) are truncated.
 
@@ -493,7 +493,7 @@ on platform). This is similar to [`conv.ToInt64`](#convtoint64) on 64-bit
 platforms, but is useful when input to another function must be provided
 as an `int`.
 
-Unconvertable inputs will result in errors.
+Unconvertible inputs will result in errors.
 
 On 32-bit systems, given a number that is too large to fit in an `int`,
 the result is `-1`. This is done to protect against
@@ -534,7 +534,7 @@ $ gomplate -i '{{conv.ToInt true }}'
 
 Converts the inputs to an array of `int64`s.
 
-Unconvertable inputs will result in errors.
+Unconvertible inputs will result in errors.
 
 This delegates to [`conv.ToInt64`](#convtoint64) for each input argument.
 
@@ -562,7 +562,7 @@ gomplate -i '{{ conv.ToInt64s true 0x42 "123,456.99" "1.2345e+3"}}'
 
 Converts the inputs to an array of `int`s.
 
-Unconvertable inputs will result in errors.
+Unconvertible inputs will result in errors.
 
 This delegates to [`conv.ToInt`](#convtoint) for each input argument.
 
@@ -593,7 +593,7 @@ Converts the input to a `float64`.
 This function attempts to convert most types of input (strings, numbers,
 and booleans).
 
-Unconvertable inputs will result in errors.
+Unconvertible inputs will result in errors.
 
 _Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage
@@ -621,7 +621,7 @@ $ gomplate -i '{{ conv.ToFloat64 "9,000.09"}}'
 
 Converts the inputs to an array of `float64`s.
 
-Unconvertable inputs will result in errors.
+Unconvertible inputs will result in errors.
 
 This delegates to [`conv.ToFloat64`](#convtofloat64) for each input argument.
 

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -210,7 +210,7 @@ $ gomplate -d person.json -f input.tmpl
 Converts a JSON string into an object. Works for JSON Objects, but will
 also parse JSON Arrays. Will not parse other valid JSON types.
 
-For more explict JSON Array support, see [`data.JSONArray`](#datajsonarray).
+For more explicit JSON Array support, see [`data.JSONArray`](#datajsonarray).
 
 #### Encrypted JSON support (EJSON)
 
@@ -291,7 +291,7 @@ Hello world
 Converts a YAML string into an object. Works for YAML Objects but will
 also parse YAML Arrays. This can be used to access properties of YAML objects.
 
-For more explict YAML Array support, see [`data.JSONArray`](#datayamlarray).
+For more explicit YAML Array support, see [`data.JSONArray`](#datayamlarray).
 
 _Added in gomplate [v2.0.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.0.0)_
 ### Usage

--- a/docs/content/functions/filepath.md
+++ b/docs/content/functions/filepath.md
@@ -277,7 +277,7 @@ b/c
 
 Splits path immediately following the final path separator, separating it into a directory and file name component.
 
-The function returns an array with two values, the first being the diretory, and the second the file.
+The function returns an array with two values, the first being the directory, and the second the file.
 
 A wrapper for Go's [`filepath.Split`](https://pkg.go.dev/path/filepath/#Split) function.
 

--- a/docs/content/functions/math.md
+++ b/docs/content/functions/math.md
@@ -158,7 +158,7 @@ math.Floor num
 
 | name | description |
 |------|-------------|
-| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
+| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertible |
 
 ### Examples
 
@@ -408,7 +408,7 @@ math.Round num
 
 | name | description |
 |------|-------------|
-| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertable |
+| `num` | _(required)_ The input number. Will be converted to a `float64`, or `0` if not convertible |
 
 ### Examples
 

--- a/docs/content/functions/semver.md
+++ b/docs/content/functions/semver.md
@@ -49,7 +49,7 @@ the pre release version is 1.1.1-beta.1
 ## `semver.CheckConstraint`_(unreleased)_
 **Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
 
-Test whether the input version matchs the constraint.
+Test whether the input version matches the constraint.
 
 Ref: https://github.com/Masterminds/semver#checking-version-constraints
 

--- a/docs/content/functions/time.md
+++ b/docs/content/functions/time.md
@@ -187,7 +187,7 @@ $ gomplate -i '{{ (time.Now).Format time.Kitchen }}
 ## `time.ParseLocal`
 
 Same as [`time.Parse`](#timeparse), except that in the absence of a time zone
-indicator, the timestamp wil be parsed in the local timezone.
+indicator, the timestamp will be parsed in the local timezone.
 
 _Added in gomplate [v2.2.0](https://github.com/hairyhenderson/gomplate/releases/tag/v2.2.0)_
 ### Usage

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -74,7 +74,7 @@ Hello,  bar!
 Hello,  baz!
 ```
 
-### Suppressing trailling newlines
+### Suppressing trailing newlines
 
 This code:
 

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -64,7 +64,7 @@ gomplate --input-dir=templates --output-dir=config --datasource config=config.ya
 
 ### `--output-map`
 
-Sometimes a 1-to-1 mapping betwen input filenames and output filenames is not desirable. For these cases, you can supply a template string as the argument to `--output-map`. The template string is interpreted as a regular gomplate template, and all datasources and external nested templates are available to the output map template.
+Sometimes a 1-to-1 mapping between input filenames and output filenames is not desirable. For these cases, you can supply a template string as the argument to `--output-map`. The template string is interpreted as a regular gomplate template, and all datasources and external nested templates are available to the output map template.
 
 A new [context][] is provided, with the input filename is available at `.in`, and the original context is available at `.ctx`. For convenience, any context keys not conflicting with `in` or `ctx` are also copied.
 

--- a/env/env.go
+++ b/env/env.go
@@ -9,7 +9,7 @@ import (
 // Getenv - retrieves the value of the environment variable named by the key.
 // If the variable is unset, but the same variable ending in `_FILE` is set, the
 // referenced file will be read into the value.
-// Otherwise the provided default (or an emptry string) is returned.
+// Otherwise the provided default (or an empty string) is returned.
 func Getenv(key string, def ...string) string {
 	fsys := datafs.WrapWdFS(osfs.NewFS())
 	return datafs.GetenvFsys(fsys, key, def...)
@@ -25,7 +25,7 @@ func ExpandEnv(s string) string {
 // If the variable is unset, but the same variable ending in `_FILE` is set, the
 // referenced file will be read into the value. If the key is not set, the
 // second return value will be false.
-// Otherwise the provided default (or an emptry string) is returned.
+// Otherwise the provided default (or an empty string) is returned.
 func LookupEnv(key string) (string, bool) {
 	fsys := datafs.WrapWdFS(osfs.NewFS())
 	return datafs.LookupEnvFsys(fsys, key)

--- a/internal/cidr/cidr.go
+++ b/internal/cidr/cidr.go
@@ -122,7 +122,7 @@ func PreviousSubnet(network netip.Prefix, prefixLen int) (netip.Prefix, bool) {
 
 // NextSubnet returns the next available subnet of the desired mask size
 // starting for the maximum IP of the offset subnet
-// If the IP exceeds the maxium IP then the second return value is true
+// If the IP exceeds the maximum IP then the second return value is true
 func NextSubnet(network netip.Prefix, prefixLen int) (netip.Prefix, bool) {
 	currentLast := netipx.PrefixLastIP(network)
 

--- a/internal/funcs/file_test.go
+++ b/internal/funcs/file_test.go
@@ -160,7 +160,7 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "truncate", string(out))
 
-	foopath = filepath.Join(newwd, "nonexistant", "subdir", "foo")
+	foopath = filepath.Join(newwd, "nonexistent", "subdir", "foo")
 	_, err = f.Write(foopath, "Hello subdirranean world!")
 	require.NoError(t, err)
 

--- a/internal/funcs/semver_test.go
+++ b/internal/funcs/semver_test.go
@@ -17,7 +17,7 @@ func TestSemverFuncs_MatchConstraint(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "mached constraint",
+			name:       "matched constraint",
 			constraint: ">=1.0.0",
 			in:         "v1.1.1",
 			want:       true,

--- a/internal/iohelpers/write_test.go
+++ b/internal/iohelpers/write_test.go
@@ -61,7 +61,7 @@ func TestWrite(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "truncate", string(out))
 
-	foopath = filepath.Join(newwd, "nonexistant", "subdir", "foo")
+	foopath = filepath.Join(newwd, "nonexistent", "subdir", "foo")
 	err = iohelpers.WriteFile(fsys, foopath, []byte("Hello subdirranean world!"))
 	require.NoError(t, err)
 

--- a/internal/urlhelpers/urlhelpers_test.go
+++ b/internal/urlhelpers/urlhelpers_test.go
@@ -29,7 +29,7 @@ func TestParseSourceURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, expected, u)
 
-	// behviour change in v4 - return relative if it's relative
+	// behaviour change in v4 - return relative if it's relative
 	expected = &url.URL{Path: "./foo/bar.json"}
 	u, err = ParseSourceURL("./foo/bar.json")
 	require.NoError(t, err)


### PR DESCRIPTION
Found via `codespell -L fom,fo,wil,nd,wit` and `typos --hidden --format brief`