### PR TITLE
deps(go): Bump to Go 1.25.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.8-labs
-FROM --platform=linux/amd64 golang:1.24-alpine AS build
+# syntax=docker/dockerfile:1.20-labs
+FROM --platform=linux/amd64 golang:1.25-alpine AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -2,7 +2,7 @@ FROM vault:1.13.3 AS vault
 
 FROM consul:1.15.4 AS consul
 
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 
 COPY --from=vault /bin/vault /bin/vault
 COPY --from=consul /bin/consul /bin/consul

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hairyhenderson/gomplate/v4
 
-go 1.24.5
+go 1.25.5
 
 require (
 	cuelang.org/go v0.13.2


### PR DESCRIPTION
Going to 1.25.5 as it contains a number of CVE fixes.