### PR TITLE
chore(go)!: Require proper context propagation where missing

### DIFF
--- a/gomplate_test.go
+++ b/gomplate_test.go
@@ -55,7 +55,11 @@ func TestBoolTemplates(t *testing.T) {
 func TestEc2MetaTemplates(t *testing.T) {
 	createGomplate := func(data map[string]string, region string) *renderer {
 		ec2meta := aws.MockEC2Meta(data, nil, region)
-		return newRenderer(RenderOptions{Funcs: template.FuncMap{"ec2meta": ec2meta.Meta}})
+		return newRenderer(RenderOptions{
+			Funcs: template.FuncMap{"ec2meta": func(key string, def ...string) (string, error) {
+				return ec2meta.Meta(t.Context(), key, def...)
+			}},
+		})
 	}
 
 	g := createGomplate(nil, "")
@@ -72,9 +76,13 @@ func TestEc2MetaTemplates_WithJSON(t *testing.T) {
 
 	g := newRenderer(RenderOptions{
 		Funcs: template.FuncMap{
-			"ec2meta":    ec2meta.Meta,
-			"ec2dynamic": ec2meta.Dynamic,
-			"json":       parsers.JSON,
+			"ec2meta": func(key string, def ...string) (string, error) {
+				return ec2meta.Meta(t.Context(), key, def...)
+			},
+			"ec2dynamic": func(key string, def ...string) (string, error) {
+				return ec2meta.Dynamic(t.Context(), key, def...)
+			},
+			"json": parsers.JSON,
 		},
 	})
 

--- a/internal/aws/ec2meta_test.go
+++ b/internal/aws/ec2meta_test.go
@@ -17,47 +17,47 @@ func must(r any, err error) any {
 func TestMeta_MissingKey(t *testing.T) {
 	ec2meta := MockEC2Meta(nil, nil, "")
 
-	assert.Empty(t, must(ec2meta.Meta("foo")))
-	assert.Equal(t, "default", must(ec2meta.Meta("foo", "default")))
+	assert.Empty(t, must(ec2meta.Meta(t.Context(), "foo")))
+	assert.Equal(t, "default", must(ec2meta.Meta(t.Context(), "foo", "default")))
 }
 
 func TestMeta_ValidKey(t *testing.T) {
 	ec2meta := MockEC2Meta(map[string]string{"instance-id": "i-1234"}, nil, "")
 
-	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id")))
-	assert.Equal(t, "i-1234", must(ec2meta.Meta("instance-id", "unused default")))
+	assert.Equal(t, "i-1234", must(ec2meta.Meta(t.Context(), "instance-id")))
+	assert.Equal(t, "i-1234", must(ec2meta.Meta(t.Context(), "instance-id", "unused default")))
 }
 
 func TestDynamic_MissingKey(t *testing.T) {
 	ec2meta := MockEC2Meta(nil, nil, "")
 
-	assert.Empty(t, must(ec2meta.Dynamic("foo")))
-	assert.Equal(t, "default", must(ec2meta.Dynamic("foo", "default")))
+	assert.Empty(t, must(ec2meta.Dynamic(t.Context(), "foo")))
+	assert.Equal(t, "default", must(ec2meta.Dynamic(t.Context(), "foo", "default")))
 }
 
 func TestDynamic_ValidKey(t *testing.T) {
 	ec2meta := MockEC2Meta(nil, map[string]string{"instance-id": "i-1234"}, "")
 
-	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id")))
-	assert.Equal(t, "i-1234", must(ec2meta.Dynamic("instance-id", "unused default")))
+	assert.Equal(t, "i-1234", must(ec2meta.Dynamic(t.Context(), "instance-id")))
+	assert.Equal(t, "i-1234", must(ec2meta.Dynamic(t.Context(), "instance-id", "unused default")))
 }
 
 func TestRegion_NoRegion(t *testing.T) {
 	ec2meta := MockEC2Meta(nil, nil, "")
 
-	assert.Equal(t, "unknown", must(ec2meta.Region()))
+	assert.Equal(t, "unknown", must(ec2meta.Region(t.Context())))
 }
 
 func TestRegion_NoRegionWithDefault(t *testing.T) {
 	ec2meta := MockEC2Meta(nil, nil, "")
 
-	assert.Equal(t, "foo", must(ec2meta.Region("foo")))
+	assert.Equal(t, "foo", must(ec2meta.Region(t.Context(), "foo")))
 }
 
 func TestRegion_KnownRegion(t *testing.T) {
 	ec2meta := MockEC2Meta(nil, nil, "us-east-1")
 
-	assert.Equal(t, "us-east-1", must(ec2meta.Region()))
+	assert.Equal(t, "us-east-1", must(ec2meta.Region(t.Context())))
 }
 
 func TestUnreachable(t *testing.T) {
@@ -68,8 +68,8 @@ func TestUnreachable(t *testing.T) {
 }
 
 func TestRetrieveMetadata_NonEC2(t *testing.T) {
-	ec2meta := NewEc2Meta(ClientOptions{})
+	ec2meta := NewEc2Meta()
 	ec2meta.nonAWS = true
 
-	assert.Equal(t, "foo", must(ec2meta.retrieveMetadata("", "foo")))
+	assert.Equal(t, "foo", must(ec2meta.retrieveMetadata(t.Context(), "", "foo")))
 }

--- a/internal/aws/kms.go
+++ b/internal/aws/kms.go
@@ -20,8 +20,8 @@ type KMS struct {
 }
 
 // NewKMS - Create new AWS KMS client using an SDKSession
-func NewKMS(_ ClientOptions) *KMS {
-	client := kms.NewFromConfig(SDKConfig())
+func NewKMS(ctx context.Context) *KMS {
+	client := kms.NewFromConfig(SDKConfig(ctx))
 	return &KMS{
 		Client: client,
 	}
@@ -29,12 +29,12 @@ func NewKMS(_ ClientOptions) *KMS {
 
 // Encrypt plaintext using the specified key.
 // Returns a base64 encoded ciphertext
-func (k *KMS) Encrypt(keyID, plaintext string) (string, error) {
+func (k *KMS) Encrypt(ctx context.Context, keyID, plaintext string) (string, error) {
 	input := &kms.EncryptInput{
 		KeyId:     &keyID,
 		Plaintext: []byte(plaintext),
 	}
-	output, err := k.Client.Encrypt(context.Background(), input)
+	output, err := k.Client.Encrypt(ctx, input)
 	if err != nil {
 		return "", err
 	}
@@ -46,7 +46,7 @@ func (k *KMS) Encrypt(keyID, plaintext string) (string, error) {
 }
 
 // Decrypt a base64 encoded ciphertext
-func (k *KMS) Decrypt(ciphertext string) (string, error) {
+func (k *KMS) Decrypt(ctx context.Context, ciphertext string) (string, error) {
 	ciphertextBlob, err := b64.Decode(ciphertext)
 	if err != nil {
 		return "", err
@@ -54,7 +54,7 @@ func (k *KMS) Decrypt(ciphertext string) (string, error) {
 	input := &kms.DecryptInput{
 		CiphertextBlob: ciphertextBlob,
 	}
-	output, err := k.Client.Decrypt(context.Background(), input)
+	output, err := k.Client.Decrypt(ctx, input)
 	if err != nil {
 		return "", err
 	}

--- a/internal/aws/kms_test.go
+++ b/internal/aws/kms_test.go
@@ -35,7 +35,7 @@ func TestEncrypt(t *testing.T) {
 	kmsClient := &KMS{Client: c}
 
 	// Success
-	resp, err := kmsClient.Encrypt("dummykey", "plaintextvalue")
+	resp, err := kmsClient.Encrypt(t.Context(), "dummykey", "plaintextvalue")
 	require.NoError(t, err)
 	expectedResp, _ := b64.Encode([]byte("PLAINTEXTVALUE"))
 	assert.Equal(t, expectedResp, resp)
@@ -48,7 +48,7 @@ func TestDecrypt(t *testing.T) {
 	encodedCiphertextBlob, _ := b64.Encode([]byte("CIPHERVALUE"))
 
 	// Success
-	resp, err := kmsClient.Decrypt(encodedCiphertextBlob)
+	resp, err := kmsClient.Decrypt(t.Context(), encodedCiphertextBlob)
 	require.NoError(t, err)
 	assert.Equal(t, "ciphervalue", resp)
 }

--- a/internal/aws/session.go
+++ b/internal/aws/session.go
@@ -25,9 +25,9 @@ type ClientOptions struct {
 	Timeout time.Duration
 }
 
-// GetClientOptions - Centralised reading of AWS_TIMEOUT
+// getClientOptions - Centralised reading of AWS_TIMEOUT
 // ... but cannot use in vault/auth.go as different strconv.Atoi error handling
-func GetClientOptions() ClientOptions {
+func getClientOptions() ClientOptions {
 	coInit.Do(func() {
 		timeout := env.Getenv("AWS_TIMEOUT")
 		if timeout == "" {
@@ -45,9 +45,9 @@ func GetClientOptions() ClientOptions {
 }
 
 // SDKConfig -
-func SDKConfig(region ...string) aws.Config {
+func SDKConfig(ctx context.Context, region ...string) aws.Config {
 	sdkConfigInit.Do(func() {
-		options := GetClientOptions()
+		options := getClientOptions()
 		timeout := options.Timeout
 		if timeout == 0 {
 			timeout = 500 * time.Millisecond
@@ -65,7 +65,7 @@ func SDKConfig(region ...string) aws.Config {
 			opts = append(opts, config.WithRegion(region[0]))
 		}
 
-		cfg, err := config.LoadDefaultConfig(context.Background(), opts...)
+		cfg, err := config.LoadDefaultConfig(ctx, opts...)
 		if err != nil {
 			panic(fmt.Errorf("failed to load config: %w", err))
 		}

--- a/internal/aws/sts.go
+++ b/internal/aws/sts.go
@@ -8,7 +8,7 @@ import (
 
 // STS -
 type STS struct {
-	identifier func() CallerIdentitifier
+	identifier func(context.Context) CallerIdentitifier
 	cache      map[string]any
 }
 
@@ -20,11 +20,11 @@ type CallerIdentitifier interface {
 }
 
 // NewSTS -
-func NewSTS(_ ClientOptions) *STS {
+func NewSTS() *STS {
 	return &STS{
-		identifier: func() CallerIdentitifier {
+		identifier: func(ctx context.Context) CallerIdentitifier {
 			if identifierClient == nil {
-				identifierClient = sts.NewFromConfig(SDKConfig())
+				identifierClient = sts.NewFromConfig(SDKConfig(ctx))
 			}
 			return identifierClient
 		},
@@ -32,15 +32,15 @@ func NewSTS(_ ClientOptions) *STS {
 	}
 }
 
-func (s *STS) getCallerID() (*sts.GetCallerIdentityOutput, error) {
-	i := s.identifier()
+func (s *STS) getCallerID(ctx context.Context) (*sts.GetCallerIdentityOutput, error) {
+	i := s.identifier(ctx)
 	if val, ok := s.cache["GetCallerIdentity"]; ok {
 		if c, ok := val.(*sts.GetCallerIdentityOutput); ok {
 			return c, nil
 		}
 	}
 	in := &sts.GetCallerIdentityInput{}
-	out, err := i.GetCallerIdentity(context.Background(), in)
+	out, err := i.GetCallerIdentity(ctx, in)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +49,8 @@ func (s *STS) getCallerID() (*sts.GetCallerIdentityOutput, error) {
 }
 
 // UserID -
-func (s *STS) UserID() (string, error) {
-	cid, err := s.getCallerID()
+func (s *STS) UserID(ctx context.Context) (string, error) {
+	cid, err := s.getCallerID(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -58,8 +58,8 @@ func (s *STS) UserID() (string, error) {
 }
 
 // Account -
-func (s *STS) Account() (string, error) {
-	cid, err := s.getCallerID()
+func (s *STS) Account(ctx context.Context) (string, error) {
+	cid, err := s.getCallerID(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -67,8 +67,8 @@ func (s *STS) Account() (string, error) {
 }
 
 // Arn -
-func (s *STS) Arn() (string, error) {
-	cid, err := s.getCallerID()
+func (s *STS) Arn(ctx context.Context) (string, error) {
+	cid, err := s.getCallerID(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/aws/testutils.go
+++ b/internal/aws/testutils.go
@@ -16,7 +16,7 @@ func MockEC2Meta(data map[string]string, dynamicData map[string]string, region s
 	return &Ec2Meta{
 		metadataCache:    map[string]string{},
 		dynamicdataCache: map[string]string{},
-		ec2MetadataProvider: func() (EC2Metadata, error) {
+		ec2MetadataProvider: func(_ context.Context) (EC2Metadata, error) {
 			return &DummEC2MetadataProvider{
 				data:        data,
 				dynamicData: dynamicData,
@@ -30,7 +30,7 @@ func MockEC2Meta(data map[string]string, dynamicData map[string]string, region s
 func NewDummyEc2Info(metaClient *Ec2Meta) *Ec2Info {
 	i := &Ec2Info{
 		metaClient: metaClient,
-		describer:  func() (InstanceDescriber, error) { return DummyInstanceDescriber{}, nil },
+		describer:  func(_ context.Context) (InstanceDescriber, error) { return DummyInstanceDescriber{}, nil },
 		cache:      map[string]any{},
 	}
 	return i

--- a/internal/funcs/aws.go
+++ b/internal/funcs/aws.go
@@ -13,8 +13,7 @@ func CreateAWSFuncs(ctx context.Context) map[string]any {
 	f := map[string]any{}
 
 	ns := &Funcs{
-		ctx:     ctx,
-		awsopts: aws.GetClientOptions(),
+		ctx: ctx,
 	}
 
 	f["aws"] = func() any { return ns }
@@ -40,49 +39,48 @@ type Funcs struct {
 	infoInit sync.Once
 	kmsInit  sync.Once
 	stsInit  sync.Once
-	awsopts  aws.ClientOptions
 }
 
 // EC2Region -
 func (a *Funcs) EC2Region(def ...string) (string, error) {
 	a.metaInit.Do(a.initMeta)
-	return a.meta.Region(def...)
+	return a.meta.Region(a.ctx, def...)
 }
 
 // EC2Meta -
 func (a *Funcs) EC2Meta(key string, def ...string) (string, error) {
 	a.metaInit.Do(a.initMeta)
-	return a.meta.Meta(key, def...)
+	return a.meta.Meta(a.ctx, key, def...)
 }
 
 // EC2Dynamic -
 func (a *Funcs) EC2Dynamic(key string, def ...string) (string, error) {
 	a.metaInit.Do(a.initMeta)
-	return a.meta.Dynamic(key, def...)
+	return a.meta.Dynamic(a.ctx, key, def...)
 }
 
 // EC2Tag -
 func (a *Funcs) EC2Tag(tag string, def ...string) (string, error) {
 	a.infoInit.Do(a.initInfo)
-	return a.info.Tag(tag, def...)
+	return a.info.Tag(a.ctx, tag, def...)
 }
 
 // EC2Tag -
 func (a *Funcs) EC2Tags() (map[string]string, error) {
 	a.infoInit.Do(a.initInfo)
-	return a.info.Tags()
+	return a.info.Tags(a.ctx)
 }
 
 // KMSEncrypt -
 func (a *Funcs) KMSEncrypt(keyID, plaintext any) (string, error) {
 	a.kmsInit.Do(a.initKMS)
-	return a.kms.Encrypt(conv.ToString(keyID), conv.ToString(plaintext))
+	return a.kms.Encrypt(a.ctx, conv.ToString(keyID), conv.ToString(plaintext))
 }
 
 // KMSDecrypt -
 func (a *Funcs) KMSDecrypt(ciphertext any) (string, error) {
 	a.kmsInit.Do(a.initKMS)
-	return a.kms.Decrypt(conv.ToString(ciphertext))
+	return a.kms.Decrypt(a.ctx, conv.ToString(ciphertext))
 }
 
 // UserID - Gets the unique identifier of the calling entity. The exact value
@@ -92,42 +90,42 @@ func (a *Funcs) KMSDecrypt(ciphertext any) (string, error) {
 // found on the Policy Variables reference page in the IAM User Guide.
 func (a *Funcs) UserID() (string, error) {
 	a.stsInit.Do(a.initSTS)
-	return a.sts.UserID()
+	return a.sts.UserID(a.ctx)
 }
 
 // Account - Gets the AWS account ID number of the account that owns or
 // contains the calling entity.
 func (a *Funcs) Account() (string, error) {
 	a.stsInit.Do(a.initSTS)
-	return a.sts.Account()
+	return a.sts.Account(a.ctx)
 }
 
 // ARN - Gets the AWS ARN associated with the calling entity
 func (a *Funcs) ARN() (string, error) {
 	a.stsInit.Do(a.initSTS)
-	return a.sts.Arn()
+	return a.sts.Arn(a.ctx)
 }
 
 func (a *Funcs) initMeta() {
 	if a.meta == nil {
-		a.meta = aws.NewEc2Meta(a.awsopts)
+		a.meta = aws.NewEc2Meta()
 	}
 }
 
 func (a *Funcs) initInfo() {
 	if a.info == nil {
-		a.info = aws.NewEc2Info(a.awsopts)
+		a.info = aws.NewEc2Info()
 	}
 }
 
 func (a *Funcs) initKMS() {
 	if a.kms == nil {
-		a.kms = aws.NewKMS(a.awsopts)
+		a.kms = aws.NewKMS(a.ctx)
 	}
 }
 
 func (a *Funcs) initSTS() {
 	if a.sts == nil {
-		a.sts = aws.NewSTS(a.awsopts)
+		a.sts = aws.NewSTS()
 	}
 }

--- a/internal/funcs/aws_test.go
+++ b/internal/funcs/aws_test.go
@@ -31,7 +31,7 @@ func TestAWSFuncs(t *testing.T) {
 
 	m := aws.NewDummyEc2Meta()
 	i := aws.NewDummyEc2Info(m)
-	af := &Funcs{meta: m, info: i}
+	af := &Funcs{ctx: t.Context(), meta: m, info: i}
 	assert.Equal(t, "unknown", must(af.EC2Region()))
 	assert.Empty(t, must(af.EC2Meta("foo")))
 	assert.Empty(t, must(af.EC2Tag("foo")))

--- a/internal/funcs/net.go
+++ b/internal/funcs/net.go
@@ -28,32 +28,37 @@ type NetFuncs struct {
 
 // LookupIP -
 func (f NetFuncs) LookupIP(name any) (string, error) {
-	return net.LookupIP(conv.ToString(name))
+	return net.LookupIP(f.ctx, conv.ToString(name))
 }
 
 // LookupIPs -
 func (f NetFuncs) LookupIPs(name any) ([]string, error) {
-	return net.LookupIPs(conv.ToString(name))
+	return net.LookupIPs(f.ctx, conv.ToString(name))
 }
 
 // LookupCNAME -
 func (f NetFuncs) LookupCNAME(name any) (string, error) {
-	return net.LookupCNAME(conv.ToString(name))
+	return stdnet.DefaultResolver.LookupCNAME(f.ctx, conv.ToString(name))
 }
 
 // LookupSRV -
 func (f NetFuncs) LookupSRV(name any) (*stdnet.SRV, error) {
-	return net.LookupSRV(conv.ToString(name))
+	_, addrs, err := stdnet.DefaultResolver.LookupSRV(f.ctx, "", "", conv.ToString(name))
+	if err != nil {
+		return nil, err
+	}
+	return addrs[0], nil
 }
 
 // LookupSRVs -
 func (f NetFuncs) LookupSRVs(name any) ([]*stdnet.SRV, error) {
-	return net.LookupSRVs(conv.ToString(name))
+	_, addrs, err := stdnet.DefaultResolver.LookupSRV(f.ctx, "", "", conv.ToString(name))
+	return addrs, err
 }
 
 // LookupTXT -
 func (f NetFuncs) LookupTXT(name any) ([]string, error) {
-	return net.LookupTXT(conv.ToString(name))
+	return stdnet.DefaultResolver.LookupTXT(f.ctx, conv.ToString(name))
 }
 
 // ParseAddr -

--- a/internal/version/gen/vgen.go
+++ b/internal/version/gen/vgen.go
@@ -13,12 +13,13 @@ import (
 )
 
 func main() {
-	descVer, err := describedVersion(context.Background())
+	ctx := context.Background()
+	descVer, err := describedVersion(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	latest, err := latestTag()
+	latest, err := latestTag(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -78,9 +79,9 @@ func version(descVer, latest *semver.Version) *semver.Version {
 	return &ver
 }
 
-func latestTag() (*semver.Version, error) {
+func latestTag(ctx context.Context) (*semver.Version, error) {
 	// get the latest tag
-	tags, err := runCmd(context.Background(), "git tag --list v*")
+	tags, err := runCmd(ctx, "git tag --list v*")
 	if err != nil {
 		return nil, fmt.Errorf("git tag failed: %w", err)
 	}

--- a/net/net.go
+++ b/net/net.go
@@ -8,8 +8,8 @@ import (
 )
 
 // LookupIP -
-func LookupIP(name string) (string, error) {
-	i, err := LookupIPs(name)
+func LookupIP(ctx context.Context, name string) (string, error) {
+	i, err := LookupIPs(ctx, name)
 	if err != nil {
 		return "", err
 	}
@@ -20,9 +20,9 @@ func LookupIP(name string) (string, error) {
 }
 
 // LookupIPs -
-func LookupIPs(name string) ([]string, error) {
+func LookupIPs(ctx context.Context, name string) ([]string, error) {
 	resolver := &net.Resolver{}
-	srcIPs, err := resolver.LookupIPAddr(context.Background(), name)
+	srcIPs, err := resolver.LookupIPAddr(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -42,18 +42,24 @@ func LookupIPs(name string) ([]string, error) {
 }
 
 // LookupCNAME -
+//
+// Deprecated: use [net.Resolver.LookupCNAME] instead
 func LookupCNAME(name string) (string, error) {
 	resolver := &net.Resolver{}
 	return resolver.LookupCNAME(context.Background(), name)
 }
 
 // LookupTXT -
+//
+// Deprecated: use [net.Resolver.LookupTXT] instead
 func LookupTXT(name string) ([]string, error) {
 	resolver := &net.Resolver{}
 	return resolver.LookupTXT(context.Background(), name)
 }
 
 // LookupSRV -
+//
+// Deprecated: use [net.Resolver#LookupSRV] instead
 func LookupSRV(name string) (*net.SRV, error) {
 	srvs, err := LookupSRVs(name)
 	if err != nil {
@@ -63,6 +69,8 @@ func LookupSRV(name string) (*net.SRV, error) {
 }
 
 // LookupSRVs -
+//
+// Deprecated: use [net.Resolver#LookupSRV] instead
 func LookupSRVs(name string) ([]*net.SRV, error) {
 	resolver := &net.Resolver{}
 	_, addrs, err := resolver.LookupSRV(context.Background(), "", "", name)

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -15,18 +15,18 @@ func must(r any, err error) any {
 }
 
 func TestLookupIP(t *testing.T) {
-	assert.Equal(t, "127.0.0.1", must(LookupIP("localhost")))
-	assert.Equal(t, "198.41.0.4", must(LookupIP("a.root-servers.net")))
+	assert.Equal(t, "127.0.0.1", must(LookupIP(t.Context(), "localhost")))
+	assert.Equal(t, "198.41.0.4", must(LookupIP(t.Context(), "a.root-servers.net")))
 }
 
 func TestLookupIPs(t *testing.T) {
-	assert.Equal(t, []string{"127.0.0.1"}, must(LookupIPs("localhost")))
-	assert.ElementsMatch(t, []string{"1.1.1.1", "1.0.0.1"}, must(LookupIPs("one.one.one.one")))
+	assert.Equal(t, []string{"127.0.0.1"}, must(LookupIPs(t.Context(), "localhost")))
+	assert.ElementsMatch(t, []string{"1.1.1.1", "1.0.0.1"}, must(LookupIPs(t.Context(), "one.one.one.one")))
 }
 
 func BenchmarkLookupIPs(b *testing.B) {
 	for b.Loop() {
-		must(LookupIPs("localhost"))
+		must(LookupIPs(b.Context(), "localhost"))
 	}
 }
 


### PR DESCRIPTION
Updates a number of function signatures to add a `context.Context` where necessary, so we can stop using `context.Background()` as much as possible.

Also deprecates a few functions.

chore(go): Deprecate net.LookupSRVs, net.LookupSRV, net.LookupTXT, and net.LookupCNAME