### PR TITLE
feat(env): New functions env.Env and env.HasEnv

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,10 +2,9 @@ package gomplate
 
 import (
 	"context"
-	"os"
-	"strings"
 
 	"github.com/hairyhenderson/gomplate/v5/internal/datafs"
+	"github.com/hairyhenderson/gomplate/v5/internal/funcs"
 	"github.com/hairyhenderson/gomplate/v5/internal/parsers"
 )
 
@@ -14,12 +13,7 @@ type tmplctx map[string]any
 
 // Env - Map environment variables for use in a template
 func (c *tmplctx) Env() map[string]string {
-	env := make(map[string]string)
-	for _, i := range os.Environ() {
-		sep := strings.Index(i, "=")
-		env[i[0:sep]] = i[sep+1:]
-	}
-	return env
+	return funcs.EnvFuncs{}.Env()
 }
 
 // createTmplContext reads the datasources for the given aliases

--- a/docs-src/content/functions/env.yml
+++ b/docs-src/content/functions/env.yml
@@ -39,6 +39,49 @@ funcs:
         $ export SECRET_FILE=/tmp/mysecret
         $ gomplate -i 'Your secret is {{getenv "SECRET"}}'
         Your secret is safe
+  - name: env.Env
+    released: v5.1.0
+    description: |
+      Returns a map of all environment variables. This is equivalent to [`.Env`](/syntax/#env),
+      but accessible via the `env` namespace.
+
+      Unlike [`env.Getenv`](#envgetenv), this does not read `_FILE` variants, and will
+      fail when accessing a missing key.
+
+      This is useful when you want strict environment variable access without the
+      `_FILE` fallback behavior.
+    pipeline: false
+    examples:
+      - |
+        $ gomplate -i 'Hello, {{env.Env.USER}}'
+        Hello, hairyhenderson
+      - |
+        $ gomplate -i '{{ env.Env.HOME }}'
+        /home/hairyhenderson
+  - name: env.HasEnv
+    released: v5.1.0
+    description: |
+      Returns `true` if the environment variable is set, `false` otherwise.
+      This wraps the [`os.LookupEnv`](https://pkg.go.dev/os/#LookupEnv) function.
+
+      Note that a variable set to an empty string is still considered "set".
+    pipeline: true
+    arguments:
+      - name: var
+        required: true
+        description: the environment variable name
+    examples:
+      - |
+        $ gomplate -i '{{if env.HasEnv "FOO"}}FOO is set{{else}}FOO is not set{{end}}'
+        FOO is not set
+        $ FOO=bar gomplate -i '{{if env.HasEnv "FOO"}}FOO is set{{else}}FOO is not set{{end}}'
+        FOO is set
+      - |
+        $ EMPTY= gomplate -i '{{if env.HasEnv "EMPTY"}}EMPTY is set{{end}}'
+        EMPTY is set
+      - |
+        $ gomplate -i '{{ "USER" | env.HasEnv }}'
+        true
   - name: env.ExpandEnv
     released: v2.5.0
     description: |

--- a/docs-src/content/functions/regexp.yml
+++ b/docs-src/content/functions/regexp.yml
@@ -73,7 +73,7 @@ funcs:
         description: The input to test
     examples:
       - |
-        $ gomplate -i '{{ if (.Env.USER | regexp.Match `^h`) }}username ({{.Env.USER}}) starts with h!{{end}}'
+        $ gomplate -i '{{ $u := env.Env.USER }}{{if ($u | regexp.Match `^h`) }}username ({{ $u }}) starts with h!{{end}}'
         username (hairyhenderson) starts with h!
   - name: regexp.QuoteMeta
     released: v3.7.0

--- a/docs-src/content/functions/strings.yml
+++ b/docs-src/content/functions/strings.yml
@@ -40,7 +40,7 @@ funcs:
       - |
         _`input.tmpl`:_
         ```
-        {{ if (.Env.FOO | strings.Contains "f") }}yes{{else}}no{{end}}
+        {{ if (env.Getenv "FOO" | strings.Contains "f") }}yes{{else}}no{{end}}
         ```
 
         ```console
@@ -63,9 +63,9 @@ funcs:
         description: the input to search
     examples:
       - |
-        $ URL=http://example.com gomplate -i '{{if .Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
+        $ URL=http://example.com gomplate -i '{{if env.Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
         bar
-        $ URL=https://example.com gomplate -i '{{if .Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
+        $ URL=https://example.com gomplate -i '{{if env.Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
         foo
   - name: strings.HasSuffix
     released: v1.9.0
@@ -83,7 +83,7 @@ funcs:
       - |
         _`input.tmpl`:_
         ```
-        {{.Env.URL}}{{if not (.Env.URL | strings.HasSuffix ":80")}}:80{{end}}
+        {{env.Env.URL}}{{if not (env.Env.URL | strings.HasSuffix ":80")}}:80{{end}}
         ```
 
         ```console

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -22,7 +22,7 @@ Here are some hands-on examples of how `gomplate` works:
 
 ```console
 $ # at its most basic, gomplate can be used with environment variables...
-$ echo 'Hello, {{ .Env.USER }}' | gomplate
+$ echo 'Hello, {{ env.Getenv "USER" }}' | gomplate
 Hello, hairyhenderson
 
 $ # but that's kind of boring. gomplate has tons of functions to do useful stuff, too

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -183,7 +183,7 @@ argument, there are no shell-imposed length limits.
 
 A simple example:
 ```yaml
-in: hello to {{ .Env.USER }}
+in: hello to {{ env.Env.USER }}
 ```
 
 A multi-line example (see https://yaml-multiline.info/ for more about multi-line

--- a/docs/content/functions/env.md
+++ b/docs/content/functions/env.md
@@ -55,6 +55,76 @@ $ gomplate -i 'Your secret is {{getenv "SECRET"}}'
 Your secret is safe
 ```
 
+## `env.Env`
+
+Returns a map of all environment variables. This is equivalent to [`.Env`](/syntax/#env),
+but accessible via the `env` namespace.
+
+Unlike [`env.Getenv`](#envgetenv), this does not read `_FILE` variants, and will
+fail when accessing a missing key.
+
+This is useful when you want strict environment variable access without the
+`_FILE` fallback behavior.
+
+_Added in gomplate [v5.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v5.1.0)_
+### Usage
+
+```
+env.Env
+```
+
+
+### Examples
+
+```console
+$ gomplate -i 'Hello, {{env.Env.USER}}'
+Hello, hairyhenderson
+```
+```console
+$ gomplate -i '{{ env.Env.HOME }}'
+/home/hairyhenderson
+```
+
+## `env.HasEnv`
+
+Returns `true` if the environment variable is set, `false` otherwise.
+This wraps the [`os.LookupEnv`](https://pkg.go.dev/os/#LookupEnv) function.
+
+Note that a variable set to an empty string is still considered "set".
+
+_Added in gomplate [v5.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v5.1.0)_
+### Usage
+
+```
+env.HasEnv var
+```
+```
+var | env.HasEnv
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `var` | _(required)_ the environment variable name |
+
+### Examples
+
+```console
+$ gomplate -i '{{if env.HasEnv "FOO"}}FOO is set{{else}}FOO is not set{{end}}'
+FOO is not set
+$ FOO=bar gomplate -i '{{if env.HasEnv "FOO"}}FOO is set{{else}}FOO is not set{{end}}'
+FOO is set
+```
+```console
+$ EMPTY= gomplate -i '{{if env.HasEnv "EMPTY"}}EMPTY is set{{end}}'
+EMPTY is set
+```
+```console
+$ gomplate -i '{{ "USER" | env.HasEnv }}'
+true
+```
+
 ## `env.ExpandEnv`
 
 Exposes the [os.ExpandEnv](https://pkg.go.dev/os/#ExpandEnv) function.

--- a/docs/content/functions/regexp.md
+++ b/docs/content/functions/regexp.md
@@ -112,7 +112,7 @@ input | regexp.Match expression
 ### Examples
 
 ```console
-$ gomplate -i '{{ if (.Env.USER | regexp.Match `^h`) }}username ({{.Env.USER}}) starts with h!{{end}}'
+$ gomplate -i '{{ $u := env.Env.USER }}{{if ($u | regexp.Match `^h`) }}username ({{ $u }}) starts with h!{{end}}'
 username (hairyhenderson) starts with h!
 ```
 

--- a/docs/content/functions/strings.md
+++ b/docs/content/functions/strings.md
@@ -64,7 +64,7 @@ input | strings.Contains substr
 
 _`input.tmpl`:_
 ```
-{{ if (.Env.FOO | strings.Contains "f") }}yes{{else}}no{{end}}
+{{ if (env.Getenv "FOO" | strings.Contains "f") }}yes{{else}}no{{end}}
 ```
 
 ```console
@@ -98,9 +98,9 @@ input | strings.HasPrefix prefix
 ### Examples
 
 ```console
-$ URL=http://example.com gomplate -i '{{if .Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
+$ URL=http://example.com gomplate -i '{{if env.Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
 bar
-$ URL=https://example.com gomplate -i '{{if .Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
+$ URL=https://example.com gomplate -i '{{if env.Env.URL | strings.HasPrefix "https"}}foo{{else}}bar{{end}}'
 foo
 ```
 
@@ -129,7 +129,7 @@ input | strings.HasSuffix suffix
 
 _`input.tmpl`:_
 ```
-{{.Env.URL}}{{if not (.Env.URL | strings.HasSuffix ":80")}}:80{{end}}
+{{env.Env.URL}}{{if not (env.Env.URL | strings.HasSuffix ":80")}}:80{{end}}
 ```
 
 ```console

--- a/docs/content/syntax.md
+++ b/docs/content/syntax.md
@@ -266,7 +266,8 @@ The context is foo
 Templates rendered by gomplate always have a _default_ context. You can populate
 the default context from data sources with the [`--context`/`c`](../usage/#--context-c)
 flag. The special context item [`.Env`](#env) is available for referencing the
-system's environment variables.
+system's environment variables _(unless overridden with `--context .=...` - see
+[`env.Env`](../functions/env/#envenv) for an alternative)._
 
 _Note:_ The initial context (`.`) is always available as the variable `$`,
 so the initial context is always available, even when shadowed with `range`
@@ -330,6 +331,8 @@ Hello World! Hello hairyhenderson!
 ```
 
 ## `.Env`
+
+_**Note:** Consider using [`env.Env`](../functions/env/#envenv) instead, which will continue to work even if the context is overridden (e.g. with `--context .=...`)._
 
 You can easily access environment variables with `.Env`, but there's a catch:
 if you try to reference an environment variable that doesn't exist, parsing

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -5,15 +5,15 @@ menu: main
 ---
 
 The simplest usage of `gomplate` is to just replace environment
-variables. All environment variables are available by referencing [`.Env`](../syntax/#env)
-(or [`getenv`](../functions/env/#envgetenv)) in the template.
+variables. All environment variables are available by referencing [`env.Env`](../functions/env/#envenv)
+(or [`env.Getenv`](../functions/env/#envgetenv)) in the template.
 
 The template is read from standard in, and written to standard out.
 
 Use it like this:
 
 ```console
-$ echo "Hello, {{ .Env.USER }}" | gomplate
+$ echo "Hello, {{ env.Env.USER }}" | gomplate
 Hello, hairyhenderson
 ```
 

--- a/internal/funcs/env.go
+++ b/internal/funcs/env.go
@@ -2,6 +2,8 @@ package funcs
 
 import (
 	"context"
+	"os"
+	"strings"
 
 	"github.com/hairyhenderson/gomplate/v5/conv"
 	"github.com/hairyhenderson/gomplate/v5/env"
@@ -22,6 +24,20 @@ type EnvFuncs struct {
 	ctx context.Context
 }
 
+// Env returns a map of all environment variables
+func (EnvFuncs) Env() map[string]string {
+	envMap := make(map[string]string)
+	for _, e := range os.Environ() {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			// skip malformed entries or Windows =C: style env vars
+			continue
+		}
+		envMap[parts[0]] = parts[1]
+	}
+	return envMap
+}
+
 // Getenv -
 func (EnvFuncs) Getenv(key any, def ...string) string {
 	return env.Getenv(conv.ToString(key), def...)
@@ -30,4 +46,10 @@ func (EnvFuncs) Getenv(key any, def ...string) string {
 // ExpandEnv -
 func (EnvFuncs) ExpandEnv(s any) string {
 	return env.ExpandEnv(conv.ToString(s))
+}
+
+// HasEnv returns true if the environment variable is set, false otherwise
+func (EnvFuncs) HasEnv(key any) bool {
+	_, ok := os.LookupEnv(conv.ToString(key))
+	return ok
 }

--- a/internal/funcs/env_test.go
+++ b/internal/funcs/env_test.go
@@ -1,7 +1,6 @@
 package funcs
 
 import (
-	"context"
 	"os"
 	"strconv"
 	"testing"
@@ -17,11 +16,13 @@ func TestCreateEnvFuncs(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			fmap := CreateEnvFuncs(ctx)
 			actual := fmap["env"].(func() any)
+			ns := actual().(*EnvFuncs)
 
-			assert.Equal(t, ctx, actual().(*EnvFuncs).ctx)
+			assert.Equal(t, ctx, ns.ctx)
+			assert.NotNil(t, ns.Env())
 		})
 	}
 }
@@ -34,4 +35,55 @@ func TestEnvGetenv(t *testing.T) {
 	assert.Equal(t, expected, ef.Getenv("USER"))
 
 	assert.Equal(t, "foo", ef.Getenv("bogusenvvar", "foo"))
+}
+
+func TestEnvEnv(t *testing.T) {
+	t.Setenv("GOMPLATE_TEST_ENV", "testvalue")
+
+	t.Run("should return a map with expected values", func(t *testing.T) {
+		ef := &EnvFuncs{}
+
+		fn := ef.Env()
+		assert.Equal(t, "testvalue", fn["GOMPLATE_TEST_ENV"])
+		assert.Equal(t, os.Getenv("USER"), fn["USER"])
+	})
+
+	t.Run("should return an empty map for missing keys", func(t *testing.T) {
+		ef := &EnvFuncs{}
+		_, ok := ef.Env()["NONEXISTENT_VAR_12345"]
+		assert.False(t, ok)
+	})
+
+	t.Run("mutation should not affect subsequent calls", func(t *testing.T) {
+		ef := &EnvFuncs{}
+		ef.Env()["GOMPLATE_TEST_MUTATION"] = "modified"
+
+		assert.NotContains(t, ef.Env(), "GOMPLATE_TEST_MUTATION")
+	})
+
+	t.Run("gets updated environment variables", func(t *testing.T) {
+		ef := &EnvFuncs{}
+
+		fn := ef.Env()
+		assert.Equal(t, "testvalue", fn["GOMPLATE_TEST_ENV"])
+		t.Setenv("GOMPLATE_TEST_ENV", "modified")
+		t.Setenv("NEW_ENV_VAR", "newvalue")
+
+		fn = ef.Env()
+		assert.Equal(t, "modified", fn["GOMPLATE_TEST_ENV"])
+		assert.Equal(t, "newvalue", fn["NEW_ENV_VAR"])
+	})
+}
+
+func TestEnvHasEnv(t *testing.T) {
+	t.Setenv("GOMPLATE_TEST_HASENV", "somevalue")
+
+	ef := &EnvFuncs{}
+
+	assert.True(t, ef.HasEnv("GOMPLATE_TEST_HASENV"))
+
+	assert.False(t, ef.HasEnv("NONEXISTENT_VAR_67890"))
+
+	t.Setenv("GOMPLATE_TEST_EMPTY", "")
+	assert.True(t, ef.HasEnv("GOMPLATE_TEST_EMPTY"))
 }

--- a/internal/tests/integration/envvars_test.go
+++ b/internal/tests/integration/envvars_test.go
@@ -9,7 +9,10 @@ import (
 
 func TestEnvVars_NonExistent(t *testing.T) {
 	os.Unsetenv("FOO")
+
 	_, _, err := cmd(t, "-i", `{{ .Env.FOO }}`).run()
+	assert.ErrorContains(t, err, "map has no entry for key")
+	_, _, err = cmd(t, "-i", `{{ env.Env.FOO }}`).run()
 	assert.ErrorContains(t, err, "map has no entry for key")
 
 	inOutTest(t, `{{ getenv "FOO" }}`, "")
@@ -29,10 +32,37 @@ func TestEnvVars_Existent(t *testing.T) {
 		`{{ getenv "FOO" }}`,
 		`{{ env.Getenv "FOO" }}`,
 		`{{env.ExpandEnv "${FOO}"}}`,
+		`{{ env.Env.FOO }}`,
+		`{{ (env.Env).FOO }}`,
 	}
 	for _, in := range data {
 		o, e, err := cmd(t, "-i", in).
 			withEnv("FOO", "foo").run()
 		assertSuccess(t, o, e, err, "foo")
 	}
+}
+
+func TestEnvVars_HasEnv(t *testing.T) {
+	os.Unsetenv("FOO")
+
+	t.Run("non-existent var returns false", func(t *testing.T) {
+		inOutTest(t, `{{ env.HasEnv "FOO" }}`, "false")
+	})
+
+	t.Run("empty var still returns true", func(t *testing.T) {
+		o, e, err := cmd(t, "-i", `{{ env.HasEnv "FOO" }}`).
+			withEnv("FOO", "").run()
+		assertSuccess(t, o, e, err, "true")
+	})
+
+	t.Run("existent var (including empty) returns true", func(t *testing.T) {
+		data := []string{
+			`{{ env.HasEnv "FOO" }}`,
+			`{{ "FOO" | env.HasEnv }}`,
+		}
+		for _, in := range data {
+			o, e, err := cmd(t, "-i", in).withEnv("FOO", "bar").run()
+			assertSuccess(t, o, e, err, "true")
+		}
+	})
 }


### PR DESCRIPTION
Introduces 2 new functions:
- `env.Env` - the same as `.Env`, but doesn't get clobbered by `--context .=...`
- `env.HasEnv` - returns whether a given environment variable is set

Fixes #2459
