### PR TITLE
feat(crypto): finalize experimental crypto functions

### DIFF
--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -111,7 +111,6 @@ funcs:
         $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Encode }}'
         MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
   - name: crypto.ECDSAGenerateKey
-    experimental: true
     released: v3.11.0
     description: |
       Generate a new Elliptic Curve Private Key and output in
@@ -135,7 +134,6 @@ funcs:
         -----BEGIN EC PRIVATE KEY-----
         ...
   - name: crypto.ECDSADerivePublicKey
-    experimental: true
     released: v3.11.0
     description: |
       Derive a public key from an elliptic curve private key and output in PKIX
@@ -159,7 +157,6 @@ funcs:
         aztsmrD79OXXnhUlURI=
         -----END PUBLIC KEY-----
   - name: crypto.Ed25519GenerateKey
-    experimental: true
     released: v4.0.0
     description: |
       Generate a new Ed25519 Private Key and output in
@@ -170,7 +167,6 @@ funcs:
         -----BEGIN PRIVATE KEY-----
         ...
   - name: crypto.Ed25519GenerateKeyFromSeed
-    experimental: true
     released: v4.0.0
     description: |
       Generate a new Ed25519 Private Key from a random seed and output in
@@ -189,7 +185,6 @@ funcs:
         -----BEGIN PRIVATE KEY-----
         ...
   - name: crypto.Ed25519DerivePublicKey
-    experimental: true
     released: v4.0.0
     description: |
       Derive a public key from an Ed25519 private key and output in PKIX
@@ -237,12 +232,11 @@ funcs:
         $ gomplate -i '{{ crypto.PBKDF2 "foo" "bar" 1024 8 }}'
         32c4907c3c80792b
   - name: crypto.RSADecrypt
-    experimental: true
     released: v3.8.0
     description: |
       Decrypt an RSA-encrypted input and print the output as a string. Note that
       this may result in unreadable text if the decrypted payload is binary. See
-      [`crypto.RSADecryptBytes`](#cryptorsadecryptbytes-_experimental_) for a safer method.
+      [`crypto.RSADecryptBytes`](#cryptorsadecryptbytes) for a safer method.
 
       The private key must be a PEM-encoded RSA private key in PKCS#1, ASN.1 DER
       form, which typically begins with `-----BEGIN RSA PRIVATE KEY-----`.
@@ -271,7 +265,6 @@ funcs:
           -i '{{ base64.DecodeBytes .ciphertext | crypto.RSADecrypt .privKey }}'
         hello
   - name: crypto.RSADecryptBytes
-    experimental: true
     released: v3.8.0
     description: |
       Decrypt an RSA-encrypted input and output the decrypted byte array.
@@ -284,7 +277,7 @@ funcs:
       first decode with the [`base64.DecodeBytes`](../base64/#base64decodebytes)
       function.
 
-      See [`crypto.RSADecrypt`](#cryptorsadecrypt-_experimental_) for a function that outputs
+      See [`crypto.RSADecrypt`](#cryptorsadecrypt) for a function that outputs
       a string.
     pipeline: true
     arguments:
@@ -306,7 +299,6 @@ funcs:
           {{ crypto.RSADecryptBytes .privKey $enc | conv.ToString }}'
         hello
   - name: crypto.RSAEncrypt
-    experimental: true
     released: v3.8.0
     description: |
       Encrypt the input with RSA and the padding scheme from PKCS#1 v1.5.
@@ -346,7 +338,6 @@ funcs:
           Ciphertext in hex: {{ printf "%x" $enc }}'
         71729b87cccabb248b9e0e5173f0b12c01d9d2a0565bad18aef9d332ce984bde06acb8bb69334a01446f7f6430077f269e6fbf2ccacd972fe5856dd4719252ebddf599948d937d96ea41540dad291b868f6c0cf647dffdb5acb22cd33557f9a1ddd0ee6c1ad2bbafc910ba8f817b66ea0569afc06e5c7858fd9dc2638861fe7c97391b2f190e4c682b4aa2c9b0050081efe18b10aa8c2b2b5f5b68a42dcc06c9da35b37fca9b1509fddc940eb99f516a2e0195405bcb3993f0fa31bc038d53d2e7231dff08cc39448105ed2d0ac52d375cb543ca8a399f807cc5d007e2c44c69876d189667eee66361a393c4916826af77479382838cd4e004b8baa05636805a
   - name: crypto.RSAGenerateKey
-    experimental: true
     released: v3.8.0
     description: |
       Generate a new RSA Private Key and output in PEM-encoded PKCS#1 ASN.1 DER
@@ -377,7 +368,6 @@ funcs:
           {{ crypto.RSADecrypt $key $enc }}'
         hello
   - name: crypto.RSADerivePublicKey
-    experimental: true
     released: v3.8.0
     description: |
       Derive a public key from an RSA private key and output in PKIX ASN.1 DER

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -164,10 +164,7 @@ $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Enc
 MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
 ```
 
-## `crypto.ECDSAGenerateKey` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.ECDSAGenerateKey`
 
 Generate a new Elliptic Curve Private Key and output in
 PEM-encoded PKCS#1 ASN.1 DER form.
@@ -204,10 +201,7 @@ $ gomplate -i '{{ crypto.ECDSAGenerateKey }}'
 ...
 ```
 
-## `crypto.ECDSADerivePublicKey` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.ECDSADerivePublicKey`
 
 Derive a public key from an elliptic curve private key and output in PKIX
 ASN.1 DER form.
@@ -245,10 +239,7 @@ aztsmrD79OXXnhUlURI=
 -----END PUBLIC KEY-----
 ```
 
-## `crypto.Ed25519GenerateKey` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.Ed25519GenerateKey`
 
 Generate a new Ed25519 Private Key and output in
 PEM-encoded PKCS#8 ASN.1 DER form.
@@ -269,10 +260,7 @@ $ gomplate -i '{{ crypto.Ed25519GenerateKey }}'
 ...
 ```
 
-## `crypto.Ed25519GenerateKeyFromSeed` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.Ed25519GenerateKeyFromSeed`
 
 Generate a new Ed25519 Private Key from a random seed and output in
 PEM-encoded PKCS#8 ASN.1 DER form.
@@ -302,10 +290,7 @@ $ gomplate -i '{{ crypto.Ed25519GenerateKeyFromSeed "base64" "MDAwMDAwMDAwMDAwMD
 ...
 ```
 
-## `crypto.Ed25519DerivePublicKey` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.Ed25519DerivePublicKey`
 
 Derive a public key from an Ed25519 private key and output in PKIX
 ASN.1 DER form.
@@ -370,14 +355,11 @@ $ gomplate -i '{{ crypto.PBKDF2 "foo" "bar" 1024 8 }}'
 32c4907c3c80792b
 ```
 
-## `crypto.RSADecrypt` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.RSADecrypt`
 
 Decrypt an RSA-encrypted input and print the output as a string. Note that
 this may result in unreadable text if the decrypted payload is binary. See
-[`crypto.RSADecryptBytes`](#cryptorsadecryptbytes-_experimental_) for a safer method.
+[`crypto.RSADecryptBytes`](#cryptorsadecryptbytes) for a safer method.
 
 The private key must be a PEM-encoded RSA private key in PKCS#1, ASN.1 DER
 form, which typically begins with `-----BEGIN RSA PRIVATE KEY-----`.
@@ -419,10 +401,7 @@ $ gomplate -c ciphertext=env:///ENCRYPTED -c privKey=./testPrivKey \
 hello
 ```
 
-## `crypto.RSADecryptBytes` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.RSADecryptBytes`
 
 Decrypt an RSA-encrypted input and output the decrypted byte array.
 
@@ -434,7 +413,7 @@ convertible to a byte array. To decrypt base64-encoded input, you must
 first decode with the [`base64.DecodeBytes`](../base64/#base64decodebytes)
 function.
 
-See [`crypto.RSADecrypt`](#cryptorsadecrypt-_experimental_) for a function that outputs
+See [`crypto.RSADecrypt`](#cryptorsadecrypt) for a function that outputs
 a string.
 
 _Added in gomplate [v3.8.0](https://github.com/hairyhenderson/gomplate/releases/tag/v3.8.0)_
@@ -469,10 +448,7 @@ $ gomplate -c pubKey=./testPubKey -c privKey=./testPrivKey \
 hello
 ```
 
-## `crypto.RSAEncrypt` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.RSAEncrypt`
 
 Encrypt the input with RSA and the padding scheme from PKCS#1 v1.5.
 
@@ -524,10 +500,7 @@ $ gomplate -c pubKey=./testPubKey \
 71729b87cccabb248b9e0e5173f0b12c01d9d2a0565bad18aef9d332ce984bde06acb8bb69334a01446f7f6430077f269e6fbf2ccacd972fe5856dd4719252ebddf599948d937d96ea41540dad291b868f6c0cf647dffdb5acb22cd33557f9a1ddd0ee6c1ad2bbafc910ba8f817b66ea0569afc06e5c7858fd9dc2638861fe7c97391b2f190e4c682b4aa2c9b0050081efe18b10aa8c2b2b5f5b68a42dcc06c9da35b37fca9b1509fddc940eb99f516a2e0195405bcb3993f0fa31bc038d53d2e7231dff08cc39448105ed2d0ac52d375cb543ca8a399f807cc5d007e2c44c69876d189667eee66361a393c4916826af77479382838cd4e004b8baa05636805a
 ```
 
-## `crypto.RSAGenerateKey` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.RSAGenerateKey`
 
 Generate a new RSA Private Key and output in PEM-encoded PKCS#1 ASN.1 DER
 form.
@@ -572,10 +545,7 @@ $ gomplate -i '{{ $key := crypto.RSAGenerateKey 2048 -}}
 hello
 ```
 
-## `crypto.RSADerivePublicKey` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
-
-[experimental]: ../config/#experimental
+## `crypto.RSADerivePublicKey`
 
 Derive a public key from an RSA private key and output in PKIX ASN.1 DER
 form.

--- a/internal/funcs/crypto.go
+++ b/internal/funcs/crypto.go
@@ -198,44 +198,27 @@ func (CryptoFuncs) Bcrypt(args ...any) (string, error) {
 }
 
 // RSAEncrypt -
-// Experimental!
 func (f *CryptoFuncs) RSAEncrypt(key string, in any) ([]byte, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return nil, err
-	}
 	msg := toBytes(in)
 	return crypto.RSAEncrypt(key, msg)
 }
 
 // RSADecrypt -
-// Experimental!
 func (f *CryptoFuncs) RSADecrypt(key string, in []byte) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
 	out, err := crypto.RSADecrypt(key, in)
 	return string(out), err
 }
 
 // RSADecryptBytes -
-// Experimental!
 func (f *CryptoFuncs) RSADecryptBytes(key string, in []byte) ([]byte, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return nil, err
-	}
 	out, err := crypto.RSADecrypt(key, in)
 	return out, err
 }
 
 // RSAGenerateKey -
-// Experimental!
 func (f *CryptoFuncs) RSAGenerateKey(args ...any) (string, error) {
-	err := checkExperimental(f.ctx)
-	if err != nil {
-		return "", err
-	}
-
 	bits := 4096
+	var err error
 	if len(args) == 1 {
 		bits, err = conv.ToInt(args[0])
 		if err != nil {
@@ -250,22 +233,13 @@ func (f *CryptoFuncs) RSAGenerateKey(args ...any) (string, error) {
 }
 
 // RSADerivePublicKey -
-// Experimental!
 func (f *CryptoFuncs) RSADerivePublicKey(privateKey string) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
 	out, err := crypto.RSADerivePublicKey([]byte(privateKey))
 	return string(out), err
 }
 
 // ECDSAGenerateKey -
-// Experimental!
 func (f *CryptoFuncs) ECDSAGenerateKey(args ...any) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
-
 	curve := elliptic.P256()
 	if len(args) == 1 {
 		c := conv.ToString(args[0])
@@ -285,32 +259,19 @@ func (f *CryptoFuncs) ECDSAGenerateKey(args ...any) (string, error) {
 }
 
 // ECDSADerivePublicKey -
-// Experimental!
 func (f *CryptoFuncs) ECDSADerivePublicKey(privateKey string) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
-
 	out, err := crypto.ECDSADerivePublicKey([]byte(privateKey))
 	return string(out), err
 }
 
 // Ed25519GenerateKey -
-// Experimental!
 func (f *CryptoFuncs) Ed25519GenerateKey() (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
 	out, err := crypto.Ed25519GenerateKey()
 	return string(out), err
 }
 
 // Ed25519GenerateKeyFromSeed -
-// Experimental!
 func (f *CryptoFuncs) Ed25519GenerateKeyFromSeed(encoding, seed string) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
 	if !utf8.ValidString(seed) {
 		return "", fmt.Errorf("given seed is not valid UTF-8") // Don't print out seed (private).
 	}
@@ -332,11 +293,7 @@ func (f *CryptoFuncs) Ed25519GenerateKeyFromSeed(encoding, seed string) (string,
 }
 
 // Ed25519DerivePublicKey -
-// Experimental!
 func (f *CryptoFuncs) Ed25519DerivePublicKey(privateKey string) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
 	out, err := crypto.Ed25519DerivePublicKey([]byte(privateKey))
 	return string(out), err
 }

--- a/internal/tests/integration/crypto_test.go
+++ b/internal/tests/integration/crypto_test.go
@@ -43,14 +43,12 @@ func setupCryptoTest(t *testing.T) *fs.Dir {
 func TestCrypto_RSACrypt(t *testing.T) {
 	tmpDir := setupCryptoTest(t)
 	o, e, err := cmd(t,
-		"--experimental",
 		"-i", `{{ crypto.RSAGenerateKey 2048 -}}`,
 		"-o", `key.pem`).
 		withDir(tmpDir.Path()).run()
 	assertSuccess(t, o, e, err, "")
 
 	o, e, err = cmd(t,
-		"--experimental",
 		"-c", "privKey=./key.pem?type=text/plain",
 		"-i", `{{ $pub := crypto.RSADerivePublicKey .privKey -}}
 {{ $enc := "hello" | crypto.RSAEncrypt $pub -}}


### PR DESCRIPTION
Remove experimental flag from all `crypto.*` functions that were previously gated behind --experimental mode.

Most of these functions have been stable and in use since v3.8.0-v4.0.0 and are ready for general availability.

The one exception is the AES functions (`DecryptAES*`/`EncryptAES`) which will be renamed in a separate PR.

Closes #1416