### PR TITLE
feat(crypto): add unified crypto.DerivePublicKey function

### DIFF
--- a/crypto/pubkey.go
+++ b/crypto/pubkey.go
@@ -1,0 +1,48 @@
+package crypto
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// DerivePublicKey derives a public key from any supported private key type
+// (RSA, ECDSA, or Ed25519). The key type is auto-detected from the PEM block type.
+func DerivePublicKey(privateKey []byte) ([]byte, error) {
+	block, _ := pem.Decode(privateKey)
+	if block == nil {
+		return nil, fmt.Errorf("failed to read key: no PEM data found")
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return RSADerivePublicKey(privateKey)
+	case "EC PRIVATE KEY":
+		return ECDSADerivePublicKey(privateKey)
+	case "PRIVATE KEY":
+		// PKCS#8 format - need to parse to determine the key type
+		priv, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse PKCS#8 private key: %w", err)
+		}
+
+		// Extract the public key using crypto.Signer interface
+		signer, ok := priv.(crypto.Signer)
+		if !ok {
+			return nil, fmt.Errorf("private key does not implement crypto.Signer")
+		}
+
+		b, err := x509.MarshalPKIXPublicKey(signer.Public())
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal public key: %w", err)
+		}
+
+		return pem.EncodeToMemory(&pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: b,
+		}), nil
+	default:
+		return nil, fmt.Errorf("unsupported key type: %s", block.Type)
+	}
+}

--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -110,6 +110,34 @@ funcs:
       - |
         $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Encode }}'
         MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
+  - name: crypto.DerivePublicKey
+    released: v5.1.0
+    description: |
+      Derive a public key from any supported private key type (RSA, ECDSA, or
+      Ed25519) and output in PKIX ASN.1 DER form. The key type is auto-detected
+      from the PEM block type.
+
+      This is a unified function that can replace the algorithm-specific
+      `crypto.RSADerivePublicKey`, `crypto.ECDSADerivePublicKey`, and
+      `crypto.Ed25519DerivePublicKey` functions.
+    pipeline: true
+    arguments:
+      - name: key
+        required: true
+        description: the private key to derive a public key from
+    examples:
+      - |
+        $ gomplate -i '{{ crypto.RSAGenerateKey | crypto.DerivePublicKey }}'
+        -----BEGIN PUBLIC KEY-----
+        ...
+      - |
+        $ gomplate -i '{{ crypto.ECDSAGenerateKey | crypto.DerivePublicKey }}'
+        -----BEGIN PUBLIC KEY-----
+        ...
+      - |
+        $ gomplate -i '{{ crypto.Ed25519GenerateKey | crypto.DerivePublicKey }}'
+        -----BEGIN PUBLIC KEY-----
+        ...
   - name: crypto.ECDSAGenerateKey
     released: v3.11.0
     description: |

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -164,6 +164,50 @@ $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Enc
 MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
 ```
 
+## `crypto.DerivePublicKey`
+
+Derive a public key from any supported private key type (RSA, ECDSA, or
+Ed25519) and output in PKIX ASN.1 DER form. The key type is auto-detected
+from the PEM block type.
+
+This is a unified function that can replace the algorithm-specific
+`crypto.RSADerivePublicKey`, `crypto.ECDSADerivePublicKey`, and
+`crypto.Ed25519DerivePublicKey` functions.
+
+_Added in gomplate [v5.1.0](https://github.com/hairyhenderson/gomplate/releases/tag/v5.1.0)_
+### Usage
+
+```
+crypto.DerivePublicKey key
+```
+```
+key | crypto.DerivePublicKey
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `key` | _(required)_ the private key to derive a public key from |
+
+### Examples
+
+```console
+$ gomplate -i '{{ crypto.RSAGenerateKey | crypto.DerivePublicKey }}'
+-----BEGIN PUBLIC KEY-----
+...
+```
+```console
+$ gomplate -i '{{ crypto.ECDSAGenerateKey | crypto.DerivePublicKey }}'
+-----BEGIN PUBLIC KEY-----
+...
+```
+```console
+$ gomplate -i '{{ crypto.Ed25519GenerateKey | crypto.DerivePublicKey }}'
+-----BEGIN PUBLIC KEY-----
+...
+```
+
 ## `crypto.ECDSAGenerateKey`
 
 Generate a new Elliptic Curve Private Key and output in

--- a/internal/funcs/crypto.go
+++ b/internal/funcs/crypto.go
@@ -298,6 +298,13 @@ func (f *CryptoFuncs) Ed25519DerivePublicKey(privateKey string) (string, error) 
 	return string(out), err
 }
 
+// DerivePublicKey derives a public key from any supported private key type
+// (RSA, ECDSA, or Ed25519). The key type is auto-detected from the PEM header.
+func (f *CryptoFuncs) DerivePublicKey(privateKey string) (string, error) {
+	out, err := crypto.DerivePublicKey([]byte(privateKey))
+	return string(out), err
+}
+
 // EncryptAES -
 // Experimental!
 func (f *CryptoFuncs) EncryptAES(key string, args ...any) ([]byte, error) {

--- a/internal/funcs/crypto_test.go
+++ b/internal/funcs/crypto_test.go
@@ -243,6 +243,54 @@ func TestRSACrypt(t *testing.T) {
 	assert.Equal(t, dec, string(b))
 }
 
+func TestDerivePublicKey(t *testing.T) {
+	t.Parallel()
+
+	c := testCryptoNS()
+
+	t.Run("RSA key", func(t *testing.T) {
+		t.Parallel()
+		key, err := c.RSAGenerateKey(2048)
+		require.NoError(t, err)
+
+		pub, err := c.DerivePublicKey(key)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(pub, "-----BEGIN PUBLIC KEY-----"))
+	})
+
+	t.Run("ECDSA key", func(t *testing.T) {
+		t.Parallel()
+		key, err := c.ECDSAGenerateKey("P-256")
+		require.NoError(t, err)
+
+		pub, err := c.DerivePublicKey(key)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(pub, "-----BEGIN PUBLIC KEY-----"))
+	})
+
+	t.Run("Ed25519 key", func(t *testing.T) {
+		t.Parallel()
+		key, err := c.Ed25519GenerateKey()
+		require.NoError(t, err)
+
+		pub, err := c.DerivePublicKey(key)
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(pub, "-----BEGIN PUBLIC KEY-----"))
+	})
+
+	t.Run("invalid key", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.DerivePublicKey("not a valid key")
+		require.Error(t, err)
+	})
+
+	t.Run("unknown key type", func(t *testing.T) {
+		t.Parallel()
+		_, err := c.DerivePublicKey("-----BEGIN UNKNOWN KEY-----\nYWJj\n-----END UNKNOWN KEY-----\n")
+		require.Error(t, err)
+	})
+}
+
 func TestAESCrypt(t *testing.T) {
 	c := testCryptoNS()
 	key := "0123456789012345"

--- a/internal/tests/integration/crypto_test.go
+++ b/internal/tests/integration/crypto_test.go
@@ -58,3 +58,26 @@ func TestCrypto_RSACrypt(t *testing.T) {
 		withDir(tmpDir.Path()).run()
 	assertSuccess(t, o, e, err, "hello\nhello\n")
 }
+
+func TestCrypto_DerivePublicKey(t *testing.T) {
+	// Test unified DerivePublicKey with RSA
+	o, e, err := cmd(t,
+		"-i", `{{ $key := crypto.RSAGenerateKey 2048 -}}
+{{ $pub := crypto.DerivePublicKey $key -}}
+{{ $pub | strings.HasPrefix "-----BEGIN PUBLIC KEY-----" }}`).run()
+	assertSuccess(t, o, e, err, "true")
+
+	// Test unified DerivePublicKey with ECDSA
+	o, e, err = cmd(t,
+		"-i", `{{ $key := crypto.ECDSAGenerateKey -}}
+{{ $pub := crypto.DerivePublicKey $key -}}
+{{ $pub | strings.HasPrefix "-----BEGIN PUBLIC KEY-----" }}`).run()
+	assertSuccess(t, o, e, err, "true")
+
+	// Test unified DerivePublicKey with Ed25519
+	o, e, err = cmd(t,
+		"-i", `{{ $key := crypto.Ed25519GenerateKey -}}
+{{ $pub := crypto.DerivePublicKey $key -}}
+{{ $pub | strings.HasPrefix "-----BEGIN PUBLIC KEY-----" }}`).run()
+	assertSuccess(t, o, e, err, "true")
+}


### PR DESCRIPTION
Add a new crypto.DerivePublicKey function that auto-detects the private key type (RSA, ECDSA, or Ed25519) from the PEM block header and derives the corresponding public key. This provides a single entry point instead of requiring users to call algorithm-specific functions.