### PR TITLE
feat(crypto): Rename AES functions for consistent naming

### DIFF
--- a/docs-src/content/functions/crypto.yml
+++ b/docs-src/content/functions/crypto.yml
@@ -28,16 +28,16 @@ funcs:
       - |
         $ gomplate -i '{{ crypto.Bcrypt 4 "foo" }}
         $2a$04$zjba3N38sjyYsw0Y7IRCme1H4gD0MJxH8Ixai0/sgsrf7s1MFUK1C
-  - name: crypto.DecryptAES
-    experimental: true
+  - name: crypto.AESDecrypt
     released: v3.11.0
+    alias: crypto.DecryptAES (deprecated)
     description: |
       Decrypts the given input using the given key. By default,
       uses AES-256-CBC, but supports 128- and 192-bit keys as well.
 
       This function prints the output as a string. Note that this may result in
       unreadable text if the decrypted payload is binary. See
-      [`crypto.DecryptAESBytes`](#cryptodecryptaesbytes-_experimental_) for another method.
+      [`crypto.AESDecryptBytes`](#cryptoaesdecryptbytes) for another method.
 
       This function is suitable for decrypting data that was encrypted by
       Helm's `encryptAES` function, when the input is base64-decoded, and when
@@ -55,11 +55,11 @@ funcs:
         description: the input to decrypt
     examples:
       - |
-        $ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.DecryptAES "swordfish" 128 }}'
+        $ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.AESDecrypt "swordfish" 128 }}'
         hello world
-  - name: crypto.DecryptAESBytes
-    experimental: true
+  - name: crypto.AESDecryptBytes
     released: v3.11.0
+    alias: crypto.DecryptAESBytes (deprecated)
     description: |
       Decrypts the given input using the given key. By default,
       uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -83,11 +83,11 @@ funcs:
         description: the input to decrypt
     examples:
       - |
-        $ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.DecryptAES "swordfish" 128 }}'
+        $ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.AESDecryptBytes "swordfish" 128 }}'
         hello world
-  - name: crypto.EncryptAES
-    experimental: true
+  - name: crypto.AESEncrypt
     released: v3.11.0
+    alias: crypto.EncryptAES (deprecated)
     description: |
       Encrypts the given input using the given key. By default,
       uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -108,7 +108,7 @@ funcs:
         description: the input to encrypt
     examples:
       - |
-        $ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Encode }}'
+        $ gomplate -i '{{ "hello world" | crypto.AESEncrypt "swordfish" 128 | base64.Encode }}'
         MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
   - name: crypto.DerivePublicKey
     released: v5.1.0

--- a/docs/content/functions/crypto.md
+++ b/docs/content/functions/crypto.md
@@ -46,17 +46,16 @@ $ gomplate -i '{{ crypto.Bcrypt 4 "foo" }}
 $2a$04$zjba3N38sjyYsw0Y7IRCme1H4gD0MJxH8Ixai0/sgsrf7s1MFUK1C
 ```
 
-## `crypto.DecryptAES` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+## `crypto.AESDecrypt`
 
-[experimental]: ../config/#experimental
+**Alias:** `crypto.DecryptAES (deprecated)`
 
 Decrypts the given input using the given key. By default,
 uses AES-256-CBC, but supports 128- and 192-bit keys as well.
 
 This function prints the output as a string. Note that this may result in
 unreadable text if the decrypted payload is binary. See
-[`crypto.DecryptAESBytes`](#cryptodecryptaesbytes-_experimental_) for another method.
+[`crypto.AESDecryptBytes`](#cryptoaesdecryptbytes) for another method.
 
 This function is suitable for decrypting data that was encrypted by
 Helm's `encryptAES` function, when the input is base64-decoded, and when
@@ -66,10 +65,10 @@ _Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases
 ### Usage
 
 ```
-crypto.DecryptAES key [keyBits] input
+crypto.AESDecrypt key [keyBits] input
 ```
 ```
-input | crypto.DecryptAES key [keyBits]
+input | crypto.AESDecrypt key [keyBits]
 ```
 
 ### Arguments
@@ -83,14 +82,13 @@ input | crypto.DecryptAES key [keyBits]
 ### Examples
 
 ```console
-$ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.DecryptAES "swordfish" 128 }}'
+$ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.AESDecrypt "swordfish" 128 }}'
 hello world
 ```
 
-## `crypto.DecryptAESBytes` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+## `crypto.AESDecryptBytes`
 
-[experimental]: ../config/#experimental
+**Alias:** `crypto.DecryptAESBytes (deprecated)`
 
 Decrypts the given input using the given key. By default,
 uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -106,10 +104,10 @@ _Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases
 ### Usage
 
 ```
-crypto.DecryptAESBytes key [keyBits] input
+crypto.AESDecryptBytes key [keyBits] input
 ```
 ```
-input | crypto.DecryptAESBytes key [keyBits]
+input | crypto.AESDecryptBytes key [keyBits]
 ```
 
 ### Arguments
@@ -123,14 +121,13 @@ input | crypto.DecryptAESBytes key [keyBits]
 ### Examples
 
 ```console
-$ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.DecryptAES "swordfish" 128 }}'
+$ gomplate -i '{{ base64.Decode "Gp2WG/fKOUsVlhcpr3oqgR+fRUNBcO1eZJ9CW+gDI18=" | crypto.AESDecryptBytes "swordfish" 128 }}'
 hello world
 ```
 
-## `crypto.EncryptAES` _(experimental)_
-**Experimental:** This function is [_experimental_][experimental] and may be enabled with the [`--experimental`][experimental] flag.
+## `crypto.AESEncrypt`
 
-[experimental]: ../config/#experimental
+**Alias:** `crypto.EncryptAES (deprecated)`
 
 Encrypts the given input using the given key. By default,
 uses AES-256-CBC, but supports 128- and 192-bit keys as well.
@@ -143,10 +140,10 @@ _Added in gomplate [v3.11.0](https://github.com/hairyhenderson/gomplate/releases
 ### Usage
 
 ```
-crypto.EncryptAES key [keyBits] input
+crypto.AESEncrypt key [keyBits] input
 ```
 ```
-input | crypto.EncryptAES key [keyBits]
+input | crypto.AESEncrypt key [keyBits]
 ```
 
 ### Arguments
@@ -160,7 +157,7 @@ input | crypto.EncryptAES key [keyBits]
 ### Examples
 
 ```console
-$ gomplate -i '{{ "hello world" | crypto.EncryptAES "swordfish" 128 | base64.Encode }}'
+$ gomplate -i '{{ "hello world" | crypto.AESEncrypt "swordfish" 128 | base64.Encode }}'
 MnRutHovsh/9JN3YrJtBVjZtI6xXZh33bCQS2iZ4SDI=
 ```
 

--- a/internal/funcs/crypto.go
+++ b/internal/funcs/crypto.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hairyhenderson/gomplate/v5/conv"
 	"github.com/hairyhenderson/gomplate/v5/crypto"
+	"github.com/hairyhenderson/gomplate/v5/internal/deprecated"
 )
 
 // CreateCryptoFuncs -
@@ -305,13 +306,8 @@ func (f *CryptoFuncs) DerivePublicKey(privateKey string) (string, error) {
 	return string(out), err
 }
 
-// EncryptAES -
-// Experimental!
-func (f *CryptoFuncs) EncryptAES(key string, args ...any) ([]byte, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return nil, err
-	}
-
+// AESEncrypt encrypts content using AES-CBC with 128, 192, or 256 bit keys.
+func (f *CryptoFuncs) AESEncrypt(key string, args ...any) ([]byte, error) {
 	k, msg, err := parseAESArgs(key, args...)
 	if err != nil {
 		return nil, err
@@ -320,30 +316,44 @@ func (f *CryptoFuncs) EncryptAES(key string, args ...any) ([]byte, error) {
 	return crypto.EncryptAESCBC(k, msg)
 }
 
-// DecryptAES -
-// Experimental!
-func (f *CryptoFuncs) DecryptAES(key string, args ...any) (string, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return "", err
-	}
-
-	out, err := f.DecryptAESBytes(key, args...)
+// AESDecrypt decrypts AES-CBC encrypted content, returning a string.
+func (f *CryptoFuncs) AESDecrypt(key string, args ...any) (string, error) {
+	out, err := f.AESDecryptBytes(key, args...)
 	return conv.ToString(out), err
 }
 
-// DecryptAESBytes -
-// Experimental!
-func (f *CryptoFuncs) DecryptAESBytes(key string, args ...any) ([]byte, error) {
-	if err := checkExperimental(f.ctx); err != nil {
-		return nil, err
-	}
-
+// AESDecryptBytes decrypts AES-CBC encrypted content, returning raw bytes.
+func (f *CryptoFuncs) AESDecryptBytes(key string, args ...any) ([]byte, error) {
 	k, msg, err := parseAESArgs(key, args...)
 	if err != nil {
 		return nil, err
 	}
 
 	return crypto.DecryptAESCBC(k, msg)
+}
+
+// EncryptAES encrypts content using AES-CBC.
+//
+// Deprecated: Use AESEncrypt instead.
+func (f *CryptoFuncs) EncryptAES(key string, args ...any) ([]byte, error) {
+	deprecated.WarnDeprecated(f.ctx, "crypto.EncryptAES is deprecated - use crypto.AESEncrypt instead")
+	return f.AESEncrypt(key, args...)
+}
+
+// DecryptAES decrypts AES-CBC encrypted content.
+//
+// Deprecated: Use AESDecrypt instead.
+func (f *CryptoFuncs) DecryptAES(key string, args ...any) (string, error) {
+	deprecated.WarnDeprecated(f.ctx, "crypto.DecryptAES is deprecated - use crypto.AESDecrypt instead")
+	return f.AESDecrypt(key, args...)
+}
+
+// DecryptAESBytes decrypts AES-CBC encrypted content, returning raw bytes.
+//
+// Deprecated: Use AESDecryptBytes instead.
+func (f *CryptoFuncs) DecryptAESBytes(key string, args ...any) ([]byte, error) {
+	deprecated.WarnDeprecated(f.ctx, "crypto.DecryptAESBytes is deprecated - use crypto.AESDecryptBytes instead")
+	return f.AESDecryptBytes(key, args...)
 }
 
 func parseAESArgs(key string, args ...any) ([]byte, []byte, error) {

--- a/internal/funcs/crypto_test.go
+++ b/internal/funcs/crypto_test.go
@@ -296,31 +296,38 @@ func TestAESCrypt(t *testing.T) {
 	key := "0123456789012345"
 	in := "hello world"
 
-	_, err := c.EncryptAES(key, 1, 2, 3, 4)
+	_, err := c.AESEncrypt(key, 1, 2, 3, 4)
 	require.Error(t, err)
 
-	_, err = c.DecryptAES(key, 1, 2, 3, 4)
+	_, err = c.AESDecrypt(key, 1, 2, 3, 4)
 	require.Error(t, err)
 
-	enc, err := c.EncryptAES(key, in)
+	enc, err := c.AESEncrypt(key, in)
 	require.NoError(t, err)
 
-	dec, err := c.DecryptAES(key, enc)
+	dec, err := c.AESDecrypt(key, enc)
 	require.NoError(t, err)
 	assert.Equal(t, in, dec)
 
-	b, err := c.DecryptAESBytes(key, enc)
+	b, err := c.AESDecryptBytes(key, enc)
 	require.NoError(t, err)
 	assert.Equal(t, dec, string(b))
 
-	enc, err = c.EncryptAES(key, 128, in)
+	enc, err = c.AESEncrypt(key, 128, in)
 	require.NoError(t, err)
 
-	dec, err = c.DecryptAES(key, 128, enc)
+	dec, err = c.AESDecrypt(key, 128, enc)
 	require.NoError(t, err)
 	assert.Equal(t, in, dec)
 
-	b, err = c.DecryptAESBytes(key, 128, enc)
+	b, err = c.AESDecryptBytes(key, 128, enc)
 	require.NoError(t, err)
 	assert.Equal(t, dec, string(b))
+
+	// Test deprecated aliases still work
+	enc2, err := c.EncryptAES(key, in)
+	require.NoError(t, err)
+	dec2, err := c.DecryptAES(key, enc2)
+	require.NoError(t, err)
+	assert.Equal(t, in, dec2)
 }

--- a/internal/tests/integration/crypto_test.go
+++ b/internal/tests/integration/crypto_test.go
@@ -59,6 +59,13 @@ func TestCrypto_RSACrypt(t *testing.T) {
 	assertSuccess(t, o, e, err, "hello\nhello\n")
 }
 
+func TestCrypto_AESCrypt(t *testing.T) {
+	o, e, err := cmd(t,
+		"-i", `{{ $enc := "hello" | crypto.AESEncrypt "swordfish" 128 -}}
+{{ crypto.AESDecrypt "swordfish" 128 $enc }}`).run()
+	assertSuccess(t, o, e, err, "hello")
+}
+
 func TestCrypto_DerivePublicKey(t *testing.T) {
 	// Test unified DerivePublicKey with RSA
 	o, e, err := cmd(t,


### PR DESCRIPTION
Rename EncryptAES/DecryptAES/DecryptAESBytes to
AESEncrypt/AESDecrypt/AESDecryptBytes to match the AlgorithmAction naming pattern used by RSA, ECDSA, and Ed25519 functions.

The old function names are kept as deprecated aliases that emit a runtime warning via deprecated.WarnDeprecated.