### PR TITLE
fix(conv): Print actual argument type in InterfaceSlice error

### DIFF
--- a/internal/conv/conv.go
+++ b/internal/conv/conv.go
@@ -23,6 +23,6 @@ func InterfaceSlice(slice any) ([]any, error) {
 		}
 		return ret, nil
 	default:
-		return nil, fmt.Errorf("expected an array or slice, but got a %T", s)
+		return nil, fmt.Errorf("expected an array or slice, but got a %s", kind.String())
 	}
 }

--- a/internal/conv/conv_test.go
+++ b/internal/conv/conv_test.go
@@ -26,7 +26,7 @@ func TestInterfaceSlice(t *testing.T) {
 	}
 
 	_, err := InterfaceSlice(42)
-	assert.ErrorContains(t, err, "")
+	assert.ErrorContains(t, err, "int")
 }
 
 func BenchmarkInterfaceSlice(b *testing.B) {


### PR DESCRIPTION
This fixes an issue where `conv.Slice` would produce a misleading error message if the argument could not be parsed as a slice. Previously the error message would indicate that the type provided was `reflect.Value` which was not necessarily the case.