### PR TITLE
ci(docker): Stop pushing to DockerHub on main builds (too much rate-limiting)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,8 +43,6 @@ jobs:
         VERSION=${{ needs.version.outputs.version }}
       meta-images: |
         ghcr.io/hairyhenderson/gomplate
-        gomplate/gomplate
-        hairyhenderson/gomplate
       meta-tags: type=raw,value=latest
     secrets:
       registry-auths: |
@@ -73,8 +71,6 @@ jobs:
         VERSION=${{ needs.version.outputs.version }}
       meta-images: |
         ghcr.io/hairyhenderson/gomplate
-        gomplate/gomplate
-        hairyhenderson/gomplate
       meta-tags: type=raw,value=alpine
     secrets:
       registry-auths: |


### PR DESCRIPTION
the rate-limiting's killing me... hopefully this helps; there's no real need to push to dockerhub on every commit to main!