### PR TITLE
fix(test): Update test to stop failing randomly

### DIFF
--- a/docs-src/content/functions/random.yml
+++ b/docs-src/content/functions/random.yml
@@ -5,7 +5,7 @@ preamble: |
 
   ### About randomness
 
-  `gomplate` uses Go's [`math/rand`](https://pkg.go.dev/math/rand/) package
+  `gomplate` uses Go's [`math/rand/v2`](https://pkg.go.dev/math/rand/v2/) package
   to generate pseudo-random numbers. Note that these functions are not suitable
   for use in security-sensitive applications, such as cryptography. However,
   these functions will not deplete system entropy.

--- a/docs/content/functions/random.md
+++ b/docs/content/functions/random.md
@@ -9,7 +9,7 @@ Functions for generating random values.
 
 ### About randomness
 
-`gomplate` uses Go's [`math/rand`](https://pkg.go.dev/math/rand/) package
+`gomplate` uses Go's [`math/rand/v2`](https://pkg.go.dev/math/rand/v2/) package
 to generate pseudo-random numbers. Note that these functions are not suitable
 for use in security-sensitive applications, such as cryptography. However,
 these functions will not deplete system entropy.

--- a/internal/funcs/random_test.go
+++ b/internal/funcs/random_test.go
@@ -167,14 +167,14 @@ func TestItem(t *testing.T) {
 	assert.Equal(t, "foo", i)
 
 	in := []string{"foo", "bar"}
-	got := ""
-	for range 10 {
+	seen := map[string]bool{}
+	for range 30 {
 		i, err = f.Item(in)
 		require.NoError(t, err)
-		got += i.(string)
+		seen[i.(string)] = true
 	}
-	assert.NotEqual(t, "foofoofoofoofoofoofoofoofoofoo", got)
-	assert.NotEqual(t, "barbarbarbarbarbarbarbarbarbar", got)
+	assert.True(t, seen["foo"], "expected \"foo\" to appear in 30 random picks")
+	assert.True(t, seen["bar"], "expected \"bar\" to appear in 30 random picks")
 }
 
 func TestNumber(t *testing.T) {


### PR DESCRIPTION
there's a chance (~1/512) that the test will fail, and CI's failed a few times due to this. changing the approach to be much less likely to fail, while still ensuring the output is ~random