### PR TITLE
fix(ci): set LAB_CORE_HOST/LAB_CORE_TOKEN for lab mr create in aports deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,9 @@ jobs:
           git rebase upstream/master
           git push
       - name: upgrade gomplate in aports
+        env:
+          LAB_CORE_HOST: https://gitlab.alpinelinux.org
+          LAB_CORE_TOKEN: ${{ secrets.GITLAB_ACCESS_TOKEN }}
         run: |
           set -ex
           export VERSION=${TAG_NAME#v}


### PR DESCRIPTION
Without these, lab has no config for gitlab.alpinelinux.org and falls back to its interactive first-run wizard, which hits EOF on stdin in CI and exits 1.

This should fix the failure that hit 5.2.0 - https://github.com/hairyhenderson/gomplate/actions/runs/29203224624/job/86678011575