### PR TITLE
feat: add file.Glob function

### DIFF
--- a/docs-src/content/functions/file.yml
+++ b/docs-src/content/functions/file.yml
@@ -25,6 +25,25 @@ funcs:
         $ gomplate -f input.tmpl
         yes
         ```
+  - name: file.Glob
+    description: |
+      Returns a list of files and directories that match the given shell file name pattern, sorted in lexical order.
+
+      The pattern syntax is that of Go's [`path.Match`](https://pkg.go.dev/path#Match) function. A pattern with no matches returns an empty list and no error.
+
+      Similar to Go's [`fs.Glob`](https://pkg.go.dev/io/fs#Glob) function.
+    pipeline: true
+    arguments:
+      - name: pattern
+        required: true
+        description: The pattern to match
+    examples:
+      - |
+        $ mkdir -p /tmp/foo
+        $ touch /tmp/foo/one.yaml /tmp/foo/two.yaml /tmp/foo/three.json
+        $ gomplate -i '{{ range file.Glob "/tmp/foo/*.yaml" }}{{.}}{{"\n"}}{{end}}'
+        /tmp/foo/one.yaml
+        /tmp/foo/two.yaml
   - name: file.IsDir
     released: v2.4.0
     description: |

--- a/docs/content/functions/file.md
+++ b/docs/content/functions/file.md
@@ -42,6 +42,40 @@ $ gomplate -f input.tmpl
 yes
 ```
 
+## `file.Glob`_(unreleased)_
+**Unreleased:** _This function is in development, and not yet available in released builds of gomplate._
+
+Returns a list of files and directories that match the given shell file name pattern, sorted in lexical order.
+
+The pattern syntax is that of Go's [`path.Match`](https://pkg.go.dev/path#Match) function. A pattern with no matches returns an empty list and no error.
+
+Similar to Go's [`fs.Glob`](https://pkg.go.dev/io/fs#Glob) function.
+
+### Usage
+
+```
+file.Glob pattern
+```
+```
+pattern | file.Glob
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `pattern` | _(required)_ The pattern to match |
+
+### Examples
+
+```console
+$ mkdir -p /tmp/foo
+$ touch /tmp/foo/one.yaml /tmp/foo/two.yaml /tmp/foo/three.json
+$ gomplate -i '{{ range file.Glob "/tmp/foo/*.yaml" }}{{.}}{{"\n"}}{{end}}'
+/tmp/foo/one.yaml
+/tmp/foo/two.yaml
+```
+
 ## `file.IsDir`
 
 Reports whether a given path is a directory.

--- a/internal/funcs/file.go
+++ b/internal/funcs/file.go
@@ -72,6 +72,23 @@ func (f *FileFuncs) ReadDir(path any) ([]string, error) {
 	return names, nil
 }
 
+// Glob -
+func (f *FileFuncs) Glob(pattern any) ([]string, error) {
+	matches, err := fs.Glob(f.fs, conv.ToString(pattern))
+	if err != nil {
+		return nil, err
+	}
+
+	// fs.Glob always uses slash-separated paths, even on Windows. We need to
+	// convert them to the OS-specific separator to match the behaviour of the
+	// other file functions.
+	for i, match := range matches {
+		matches[i] = filepath.FromSlash(match)
+	}
+
+	return matches, nil
+}
+
 // Walk -
 func (f *FileFuncs) Walk(path any) ([]string, error) {
 	files := make([]string, 0)

--- a/internal/funcs/file_test.go
+++ b/internal/funcs/file_test.go
@@ -86,6 +86,26 @@ func TestFileWalk(t *testing.T) {
 	assert.Equal(t, expectedPaths, actualPaths)
 }
 
+func TestFileGlob(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"tmp":          &fstest.MapFile{Mode: fs.ModeDir | 0o777},
+		"tmp/foo.yaml": &fstest.MapFile{Data: []byte("foo")},
+		"tmp/bar.yaml": &fstest.MapFile{Data: []byte("bar")},
+		"tmp/baz.json": &fstest.MapFile{Data: []byte("baz")},
+	}
+
+	ff := &FileFuncs{fs: datafs.WrapWdFS(fsys)}
+
+	sep := string(filepath.Separator)
+	expected := []string{sep + filepath.Join("tmp", "bar.yaml"), sep + filepath.Join("tmp", "foo.yaml")}
+
+	actual, err := ff.Glob("/tmp/*.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
 func TestReadDir(t *testing.T) {
 	fsys := fs.FS(fstest.MapFS{
 		"tmp":          &fstest.MapFile{Mode: fs.ModeDir | 0o777},


### PR DESCRIPTION
## Description

Adds a `file.Glob` template function that returns the list of files and directories matching a shell file name pattern, sorted in lexical order. This mirrors the existing `file.Walk` function and wraps Go's [`fs.Glob`](https://pkg.go.dev/io/fs#Glob), including the slash-to-OS-separator conversion used by the other `file` functions.

Example:

```console
$ gomplate -i '{{ range file.Glob "/tmp/foo/*.yaml" }}{{.}}{{"\n"}}{{end}}'
/tmp/foo/one.yaml
/tmp/foo/two.yaml
```

## Changes

- `internal/funcs/file.go`: add `FileFuncs.Glob`
- `internal/funcs/file_test.go`: add `TestFileGlob`
- `docs-src/content/functions/file.yml` and generated `docs/content/functions/file.md`: document `file.Glob`

Fixes hairyhenderson/gomplate#2305