### PR TITLE
feat(net): add net.GenerateMAC function

### DIFF
--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -131,6 +131,37 @@ funcs:
         [
           "v=spf1 -all"
         ]
+  - name: net.GenerateMAC
+    released: v5.3.0
+    description: |
+      Generate a MAC (hardware) address, returned as a string in the usual
+      colon-separated form (e.g. `aa:bb:cc:dd:ee:ff`).
+
+      With no arguments a random locally administered unicast address is
+      generated, so it won't collide with a real vendor-assigned address.
+
+      An optional `prefix` fixes the leading octets of the address (such as an
+      OUI); the rest are filled in randomly. Colons, hyphens, and dots in the
+      prefix are ignored, so `aa:bb`, `aa-bb`, and `aabb` are all equivalent.
+
+      An optional `seed` makes the output deterministic: the same prefix and
+      seed always produce the same address. Use an empty prefix to seed the
+      whole address.
+    pipeline: true
+    arguments:
+      - name: prefix
+        required: false
+        description: The fixed leading octets of the address. Defaults to empty (a fully-generated address).
+      - name: seed
+        required: false
+        description: When provided, the address is derived deterministically from this value instead of being random.
+    examples:
+      - |
+        $ gomplate -i '{{ net.GenerateMAC }}'
+        4e:2d:8f:0b:1a:c7
+      - |
+        $ gomplate -i '{{ net.GenerateMAC "aa:bb:cc" "some-seed" }}'
+        aa:bb:cc:0a:d4:0e
   - name: net.ParseAddr
     released: v4.0.0
     description: |

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -218,6 +218,50 @@ $ gomplate -i '{{net.LookupTXT "example.com" | data.ToJSONPretty "  " }}'
 ]
 ```
 
+## `net.GenerateMAC`
+
+Generate a MAC (hardware) address, returned as a string in the usual
+colon-separated form (e.g. `aa:bb:cc:dd:ee:ff`).
+
+With no arguments a random locally administered unicast address is
+generated, so it won't collide with a real vendor-assigned address.
+
+An optional `prefix` fixes the leading octets of the address (such as an
+OUI); the rest are filled in randomly. Colons, hyphens, and dots in the
+prefix are ignored, so `aa:bb`, `aa-bb`, and `aabb` are all equivalent.
+
+An optional `seed` makes the output deterministic: the same prefix and
+seed always produce the same address. Use an empty prefix to seed the
+whole address.
+
+_<span class="release-check" data-tag="v5.3.0">Added in gomplate v5.3.0</span>_
+### Usage
+
+```
+net.GenerateMAC [prefix] [seed]
+```
+```
+seed | net.GenerateMAC [prefix]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `prefix` | _(optional)_ The fixed leading octets of the address. Defaults to empty (a fully-generated address). |
+| `seed` | _(optional)_ When provided, the address is derived deterministically from this value instead of being random. |
+
+### Examples
+
+```console
+$ gomplate -i '{{ net.GenerateMAC }}'
+4e:2d:8f:0b:1a:c7
+```
+```console
+$ gomplate -i '{{ net.GenerateMAC "aa:bb:cc" "some-seed" }}'
+aa:bb:cc:0a:d4:0e
+```
+
 ## `net.ParseAddr`
 
 Parse the given string as an IP address (a

--- a/internal/funcs/net.go
+++ b/internal/funcs/net.go
@@ -61,6 +61,26 @@ func (f NetFuncs) LookupTXT(name any) ([]string, error) {
 	return stdnet.DefaultResolver.LookupTXT(f.ctx, conv.ToString(name))
 }
 
+// GenerateMAC -
+func (f NetFuncs) GenerateMAC(args ...any) (string, error) {
+	var prefix string
+	var seed []byte
+
+	switch len(args) {
+	case 0:
+	case 1:
+		prefix = conv.ToString(args[0])
+	case 2:
+		prefix = conv.ToString(args[0])
+		//nolint:gosec // G602 false positive: len(args)==2 from switch
+		seed = []byte(conv.ToString(args[1]))
+	default:
+		return "", fmt.Errorf("wrong number of args: want 0, 1, or 2, got %d", len(args))
+	}
+
+	return net.GenerateMAC(prefix, seed)
+}
+
 // ParseAddr -
 func (f NetFuncs) ParseAddr(ip any) (netip.Addr, error) {
 	return netip.ParseAddr(conv.ToString(ip))

--- a/internal/funcs/net_test.go
+++ b/internal/funcs/net_test.go
@@ -4,6 +4,7 @@ import (
 	stdnet "net"
 	"net/netip"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hairyhenderson/gomplate/v5/internal/config"
@@ -33,6 +34,36 @@ func TestNetLookupIP(t *testing.T) {
 
 	n := testNetNS(t)
 	assert.Equal(t, "127.0.0.1", must(n.LookupIP("localhost")))
+}
+
+func TestGenerateMAC(t *testing.T) {
+	t.Parallel()
+
+	n := testNetNS(t)
+
+	// no args: a valid, locally administered address
+	mac, err := n.GenerateMAC()
+	require.NoError(t, err)
+	hw, err := stdnet.ParseMAC(mac)
+	require.NoError(t, err)
+	assert.Len(t, hw, 6)
+	assert.Equal(t, byte(0x02), hw[0]&0x02)
+
+	// one arg fixes the prefix
+	mac, err = n.GenerateMAC("aa:bb:cc")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(mac, "aa:bb:cc:"))
+
+	// prefix plus seed is deterministic
+	a, err := n.GenerateMAC("aa:bb", "some-seed")
+	require.NoError(t, err)
+	b, err := n.GenerateMAC("aa:bb", "some-seed")
+	require.NoError(t, err)
+	assert.Equal(t, a, b)
+
+	// too many args is an error
+	_, err = n.GenerateMAC("a", "b", "c")
+	require.Error(t, err)
 }
 
 func TestParseAddr(t *testing.T) {

--- a/net/net.go
+++ b/net/net.go
@@ -3,9 +3,16 @@ package net
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net"
 	"slices"
+	"strings"
 )
+
+const macLen = 6
 
 // LookupIP -
 func LookupIP(ctx context.Context, name string) (string, error) {
@@ -39,6 +46,65 @@ func LookupIPs(ctx context.Context, name string) ([]string, error) {
 		}
 	}
 	return ips, nil
+}
+
+// GenerateMAC generates a 6-octet MAC (hardware) address, returned as a string
+// in the usual colon-separated form.
+//
+// prefix, when non-empty, fixes the leading octets of the address (for example
+// an OUI like "aa:bb:cc"); the remaining octets are filled in randomly. Colons,
+// hyphens, and dots in prefix are ignored, so "aa:bb", "aa-bb", and "aabb" are
+// all equivalent. When prefix is empty the whole address is generated, and the
+// local bit is set (and the multicast bit cleared) so the result is a locally
+// administered unicast address that won't collide with real vendor-assigned
+// hardware.
+//
+// When seed is non-nil the random octets are derived from it, so the same
+// prefix and seed always produce the same address. When seed is nil the address
+// is cryptographically random.
+func GenerateMAC(prefix string, seed []byte) (string, error) {
+	octets, err := parseMACPrefix(prefix)
+	if err != nil {
+		return "", err
+	}
+
+	mac := make(net.HardwareAddr, macLen)
+	copy(mac, octets)
+	fill := mac[len(octets):]
+
+	if seed == nil {
+		if _, err := rand.Read(fill); err != nil {
+			return "", fmt.Errorf("failed to read random bytes: %w", err)
+		}
+	} else {
+		sum := sha256.Sum256(seed)
+		copy(fill, sum[:])
+	}
+
+	// With no prefix the first octet is generated too, so make the address a
+	// locally administered unicast one to keep it out of real vendor ranges.
+	if len(octets) == 0 {
+		mac[0] = (mac[0] &^ 0x01) | 0x02
+	}
+
+	return mac.String(), nil
+}
+
+func parseMACPrefix(prefix string) ([]byte, error) {
+	cleaned := strings.NewReplacer(":", "", "-", "", ".", "").Replace(prefix)
+	if cleaned == "" {
+		return nil, nil
+	}
+
+	octets, err := hex.DecodeString(cleaned)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MAC prefix %q: %w", prefix, err)
+	}
+	if len(octets) > macLen {
+		return nil, fmt.Errorf("MAC prefix %q is too long: want at most %d octets, got %d", prefix, macLen, len(octets))
+	}
+
+	return octets, nil
 }
 
 // LookupCNAME -

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -1,6 +1,8 @@
 package net
 
 import (
+	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +36,53 @@ func TestLookupTXT(t *testing.T) {
 
 func TestLookupCNAME(t *testing.T) {
 	assert.Equal(t, "hairyhenderson.ca.", must(LookupCNAME("www.hairyhenderson.ca.")))
+}
+
+func TestGenerateMAC(t *testing.T) {
+	// no prefix: a valid, locally administered unicast address
+	first, err := GenerateMAC("", nil)
+	require.NoError(t, err)
+	hw, err := net.ParseMAC(first)
+	require.NoError(t, err)
+	require.Len(t, hw, macLen)
+	assert.Equal(t, byte(0x02), hw[0]&0x02, "local bit should be set")
+	assert.Equal(t, byte(0x00), hw[0]&0x01, "multicast bit should be clear")
+
+	// without a seed each call differs
+	second, err := GenerateMAC("", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second)
+
+	// a prefix is respected, and separators don't matter
+	for _, p := range []string{"aa:bb:cc", "aa-bb-cc", "aabbcc"} {
+		mac, perr := GenerateMAC(p, nil)
+		require.NoError(t, perr)
+		assert.True(t, strings.HasPrefix(mac, "aa:bb:cc:"), "prefix %q gave %q", p, mac)
+	}
+
+	// a seed makes the output deterministic for a given prefix
+	seeded, err := GenerateMAC("aa:bb", []byte("gomplate"))
+	require.NoError(t, err)
+	again, err := GenerateMAC("aa:bb", []byte("gomplate"))
+	require.NoError(t, err)
+	assert.Equal(t, seeded, again)
+
+	other, err := GenerateMAC("aa:bb", []byte("different"))
+	require.NoError(t, err)
+	assert.NotEqual(t, seeded, other)
+
+	// a full 6-octet prefix leaves nothing to randomize
+	full, err := GenerateMAC("01:02:03:04:05:06", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "01:02:03:04:05:06", full)
+
+	// invalid inputs
+	_, err = GenerateMAC("not hex", nil)
+	require.Error(t, err)
+	_, err = GenerateMAC("aa:b", nil) // odd number of hex digits
+	require.Error(t, err)
+	_, err = GenerateMAC("aa:bb:cc:dd:ee:ff:00", nil) // too long
+	require.Error(t, err)
 }
 
 func TestLookupSRV(t *testing.T) {


### PR DESCRIPTION
This adds the `net.GenerateMAC` function from #1699, following the shape you sketched out in that thread.

With no arguments it returns a random, locally administered unicast address (local bit set, multicast bit cleared) so it stays out of real vendor ranges. A single argument fixes the leading octets as a prefix, and a second argument seeds the result so the same prefix and seed always produce the same address. Separators in the prefix are ignored, so `aa:bb`, `aa-bb`, and `aabb` are all treated the same.

Tests and docs are included. I left it out of the experimental gate since the surface is small and matches what was discussed, but happy to put it behind that if you would prefer to iterate on it first.

Fixes #1699