### PR TITLE
feat(net): add net.GenerateMAC for generating MAC addresses

### DIFF
--- a/docs-src/content/functions/net.yml
+++ b/docs-src/content/functions/net.yml
@@ -282,3 +282,29 @@ funcs:
       - |
         $ gomplate -i '{{ net.CIDRSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'
         [10.1.0.0/20 10.1.16.0/20 10.1.32.0/24 10.1.48.0/20]
+  - name: net.GenerateMAC
+    released: v5.3.0
+    description: |
+      Generate a MAC (hardware) address.
+
+      With no arguments a fully random address is returned, marked as a locally
+      administered unicast address. Providing a `prefix` (a partial MAC such as
+      `"AA:BB:CC"`) fixes the leading octets and randomises the rest. Providing a
+      `seed` as well derives the trailing octets from it, so the same prefix and
+      seed always produce the same address.
+
+      Octets in the prefix may be separated with either `:` or `-`.
+    pipeline: true
+    arguments:
+      - name: prefix
+        required: false
+        description: A partial MAC address used as the leading octets of the result.
+      - name: seed
+        required: false
+        description: When set, the trailing octets are derived from this value so the result is stable.
+    examples:
+      - |
+        $ gomplate -i '{{ net.GenerateMAC }}'
+        9a:2f:6b:4c:7d:e1
+        $ gomplate -i '{{ net.GenerateMAC "aa:bb:cc" "gomplate" }}'
+        aa:bb:cc:96:41:27

--- a/docs/content/functions/net.md
+++ b/docs/content/functions/net.md
@@ -468,3 +468,41 @@ prefix | net.CIDRSubnetSizes newbits...
 $ gomplate -i '{{ net.CIDRSubnetSizes 4 4 8 4 "10.1.0.0/16" -}}'
 [10.1.0.0/20 10.1.16.0/20 10.1.32.0/24 10.1.48.0/20]
 ```
+
+## `net.GenerateMAC`
+
+Generate a MAC (hardware) address.
+
+With no arguments a fully random address is returned, marked as a locally
+administered unicast address. Providing a `prefix` (a partial MAC such as
+`"AA:BB:CC"`) fixes the leading octets and randomises the rest. Providing a
+`seed` as well derives the trailing octets from it, so the same prefix and
+seed always produce the same address.
+
+Octets in the prefix may be separated with either `:` or `-`.
+
+_<span class="release-check" data-tag="v5.3.0">Added in gomplate v5.3.0</span>_
+### Usage
+
+```
+net.GenerateMAC [prefix] [seed]
+```
+```
+seed | net.GenerateMAC [prefix]
+```
+
+### Arguments
+
+| name | description |
+|------|-------------|
+| `prefix` | _(optional)_ A partial MAC address used as the leading octets of the result. |
+| `seed` | _(optional)_ When set, the trailing octets are derived from this value so the result is stable. |
+
+### Examples
+
+```console
+$ gomplate -i '{{ net.GenerateMAC }}'
+9a:2f:6b:4c:7d:e1
+$ gomplate -i '{{ net.GenerateMAC "aa:bb:cc" "gomplate" }}'
+aa:bb:cc:96:41:27
+```

--- a/internal/funcs/net.go
+++ b/internal/funcs/net.go
@@ -2,10 +2,14 @@ package funcs
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"math/big"
+	"math/rand/v2"
 	stdnet "net"
 	"net/netip"
+	"strconv"
+	"strings"
 
 	"github.com/hairyhenderson/gomplate/v5/conv"
 	"github.com/hairyhenderson/gomplate/v5/internal/cidr"
@@ -74,6 +78,71 @@ func (f NetFuncs) ParsePrefix(ipprefix any) (netip.Prefix, error) {
 // ParseRange -
 func (f NetFuncs) ParseRange(iprange any) (netipx.IPRange, error) {
 	return netipx.ParseIPRange(conv.ToString(iprange))
+}
+
+// GenerateMAC generates a MAC (hardware) address. It accepts up to two optional
+// arguments: a prefix and a seed.
+//
+// With no arguments a fully random address is returned, marked as a locally
+// administered unicast address. A prefix (a partial MAC such as "AA:BB:CC")
+// fixes the leading octets and randomises the rest. When a seed is also given
+// the trailing octets are derived from it, so the same prefix and seed always
+// produce the same address.
+func (f NetFuncs) GenerateMAC(args ...any) (string, error) {
+	if len(args) > 2 {
+		return "", fmt.Errorf("wrong number of args: want 0, 1, or 2, got %d", len(args))
+	}
+
+	var prefix, seed string
+	for i, arg := range args {
+		switch i {
+		case 0:
+			prefix = conv.ToString(arg)
+		case 1:
+			seed = conv.ToString(arg)
+		}
+	}
+
+	mac := make(stdnet.HardwareAddr, 6)
+
+	// copy any fixed leading octets from the prefix
+	fixed := 0
+	if prefix != "" {
+		octets := strings.FieldsFunc(prefix, func(r rune) bool {
+			return r == ':' || r == '-'
+		})
+		if len(octets) >= len(mac) {
+			return "", fmt.Errorf("prefix %q must be shorter than a full MAC address", prefix)
+		}
+		for i, o := range octets {
+			b, err := strconv.ParseUint(o, 16, 8)
+			if err != nil {
+				return "", fmt.Errorf("invalid prefix octet %q: %w", o, err)
+			}
+			mac[i] = byte(b)
+		}
+		fixed = len(octets)
+	}
+
+	rest := mac[fixed:]
+	if seed != "" {
+		// derive the remaining octets from the seed so the result is stable
+		sum := sha256.Sum256([]byte(seed))
+		copy(rest, sum[:])
+	} else {
+		for i := range rest {
+			//nolint:gosec
+			rest[i] = byte(rand.IntN(256))
+		}
+	}
+
+	// when no prefix is given we own the first octet, so flag the address as
+	// locally administered (U/L bit set) and unicast (I/G bit clear)
+	if fixed == 0 {
+		mac[0] = mac[0]&0xfe | 0x02
+	}
+
+	return mac.String(), nil
 }
 
 func (f *NetFuncs) parseNetipPrefix(prefix any) (netip.Prefix, error) {

--- a/internal/funcs/net_test.go
+++ b/internal/funcs/net_test.go
@@ -4,6 +4,7 @@ import (
 	stdnet "net"
 	"net/netip"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hairyhenderson/gomplate/v5/internal/config"
@@ -201,4 +202,58 @@ func TestCIDRSubnetSizes(t *testing.T) {
 	assert.Equal(t, "2016:1234:5678:9abc:c400::/70", subnets[5].String())
 	assert.Equal(t, "2016:1234:5678:9abc:c800::/72", subnets[6].String())
 	assert.Equal(t, "2016:1234:5678:9abc:c900::/74", subnets[7].String())
+}
+
+func TestGenerateMAC(t *testing.T) {
+	t.Parallel()
+
+	n := testNetNS(t)
+
+	// no args: a random, locally administered unicast address
+	got, err := n.GenerateMAC()
+	require.NoError(t, err)
+	hw, err := stdnet.ParseMAC(got)
+	require.NoError(t, err)
+	assert.Len(t, hw, 6)
+	assert.Equal(t, byte(0x02), hw[0]&0x02, "should be locally administered")
+	assert.Equal(t, byte(0x00), hw[0]&0x01, "should be unicast")
+
+	// a prefix fixes the leading octets
+	got, err = n.GenerateMAC("aa:bb:cc")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, "aa:bb:cc:"), "got %q", got)
+	_, err = stdnet.ParseMAC(got)
+	require.NoError(t, err)
+
+	// a seed makes the result stable
+	first, err := n.GenerateMAC("aa:bb:cc", "some-seed")
+	require.NoError(t, err)
+	second, err := n.GenerateMAC("aa:bb:cc", "some-seed")
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+
+	// a different seed gives a different address
+	other, err := n.GenerateMAC("aa:bb:cc", "another-seed")
+	require.NoError(t, err)
+	assert.NotEqual(t, first, other)
+
+	// hyphen-separated prefixes are accepted too
+	got, err = n.GenerateMAC("aa-bb")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, "aa:bb:"), "got %q", got)
+}
+
+func TestGenerateMACErrors(t *testing.T) {
+	t.Parallel()
+
+	n := testNetNS(t)
+
+	_, err := n.GenerateMAC("aa:bb", "seed", "extra")
+	require.Error(t, err)
+
+	_, err = n.GenerateMAC("nothex")
+	require.Error(t, err)
+
+	_, err = n.GenerateMAC("aa:bb:cc:dd:ee:ff")
+	require.Error(t, err)
 }


### PR DESCRIPTION
This adds net.GenerateMAC, following the shape you sketched out in #1699. With no arguments you get a random, locally administered unicast address, a single argument fixes a prefix, and a second argument acts as a seed so the same prefix and seed always produce the same address.

Docs and tests are included. The prefix accepts `:` or `-` separators.