### PR TITLE
fix(parsers): replace hairyhenderson/toml fork with BurntSushi/toml v1.6.0

### DIFF
--- a/docs-src/content/functions/data.yml
+++ b/docs-src/content/functions/data.yml
@@ -253,7 +253,7 @@ funcs:
       Converts a [TOML](https://github.com/toml-lang/toml) document into an object.
       This can be used to access properties of TOML documents.
 
-      Compatible with [TOML v0.4.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md).
+      Compatible with [TOML v1.1.0](https://toml.io/en/v1.1.0).
     pipeline: true
     arguments:
       - name: input

--- a/docs/content/functions/data.md
+++ b/docs/content/functions/data.md
@@ -364,7 +364,7 @@ Hello world
 Converts a [TOML](https://github.com/toml-lang/toml) document into an object.
 This can be used to access properties of TOML documents.
 
-Compatible with [TOML v0.4.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md).
+Compatible with [TOML v1.1.0](https://toml.io/en/v1.1.0).
 
 _<span class="release-check" data-tag="v2.0.0">Added in gomplate v2.0.0</span>_
 ### Usage

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.27.0
 
 require (
 	cuelang.org/go v0.17.1
+	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/goutils v1.1.1
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/Shopify/ejson v1.5.5
@@ -20,7 +21,6 @@ require (
 	github.com/gosimple/slug v1.15.0
 	github.com/hack-pad/hackpadfs v0.2.4
 	github.com/hairyhenderson/go-fsimpl v0.4.6
-	github.com/hairyhenderson/toml v0.4.2-0.20210923231440-40456b8e66cf
 	github.com/hairyhenderson/xignore v0.3.3-0.20230403012150-95fe86932830 // iofs-port branch
 	github.com/hashicorp/go-sockaddr v1.0.7
 	github.com/hashicorp/vault/api v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
@@ -483,8 +485,6 @@ github.com/hairyhenderson/go-fsimpl v0.4.5 h1:kZteoZkSMPqCxvrvolyEr5QLeVsvDXyzDE
 github.com/hairyhenderson/go-fsimpl v0.4.5/go.mod h1:xoOE4B2Kf7GUqNuV7sJhK5V6ozhU56RC4vtTW4bMyKQ=
 github.com/hairyhenderson/go-fsimpl v0.4.6 h1:KReezFCAf6a0dl5gLGEjGklKbaI7EmbloqLKd3SXDFc=
 github.com/hairyhenderson/go-fsimpl v0.4.6/go.mod h1:bT3MxCYFMkQraH3fwV5K22y3FP1IJUJSaDuT6gTB+Tw=
-github.com/hairyhenderson/toml v0.4.2-0.20210923231440-40456b8e66cf h1:I1sbT4ZbIt9i+hB1zfKw2mE8C12TuGxPiW7YmtLbPa4=
-github.com/hairyhenderson/toml v0.4.2-0.20210923231440-40456b8e66cf/go.mod h1:jDHmWDKZY6MIIYltYYfW4Rs7hQ50oS4qf/6spSiZAxY=
 github.com/hairyhenderson/xignore v0.3.3-0.20230403012150-95fe86932830 h1:f+VnmDFJqYgkq1PRraUsYEzJ7bFr36CmzOb/xfV5Q9s=
 github.com/hairyhenderson/xignore v0.3.3-0.20230403012150-95fe86932830/go.mod h1:UqUZ8CHnVcV2/rb26Ydn+PQO7bAI8kFONU/vaK1Q/WU=
 github.com/hairyhenderson/yaml v0.0.0-20220618171115-2d35fca545ce h1:cVkYhlWAxwuS2/Yp6qPtcl0fGpcWxuZNonywHZ6/I+s=

--- a/internal/parsers/parsefuncs.go
+++ b/internal/parsers/parsefuncs.go
@@ -13,16 +13,13 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/format"
+	"github.com/BurntSushi/toml"
 	"github.com/Shopify/ejson"
 	ejsonJson "github.com/Shopify/ejson/json"
 	"github.com/hairyhenderson/gomplate/v5/conv"
-	"github.com/joho/godotenv"
-
-	// XXX: replace once https://github.com/BurntSushi/toml/pull/179 is merged
-	"github.com/hairyhenderson/toml"
-	"github.com/ugorji/go/codec"
-
 	"github.com/hairyhenderson/yaml"
+	"github.com/joho/godotenv"
+	"github.com/ugorji/go/codec"
 )
 
 func unmarshalObj(obj map[string]any, in string, f func([]byte, any) error) (map[string]any, error) {
@@ -460,6 +457,13 @@ func ToYAML(in any) (string, error) {
 
 // ToTOML - Stringify a struct as TOML
 func ToTOML(in any) (string, error) {
+	// BurntSushi/toml can't encode maps with non-string key types (e.g. the
+	// map[any]any values produced by YAML unmarshaling), so coerce those to
+	// map[string]any first.
+	if v, changed := stringifyMapKeys(in); changed {
+		in = v
+	}
+
 	buf := new(bytes.Buffer)
 	err := toml.NewEncoder(buf).Encode(in)
 	if err != nil {


### PR DESCRIPTION
Fixes #2684.

Swaps the stale `hairyhenderson/toml` fork for upstream `BurntSushi/toml` v1.6.0, which parses TOML 1.1 (including newlines in inline tables).

The fork only existed to encode `map[any]any` values, so `ToTOML` now coerces those to `map[string]any` first using the `stringifyMapKeys` helper that's already in the file. Parsed values and encoder output are unchanged; no test changes were needed.